### PR TITLE
docs: fix readthedocs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ By using it in conjunction with various OSS provided by [@oqtopus-team](https://
 
 ## Documentation
 
-- [Documentation Home](https://readthedocs.org/projects/oqtopus-cloud/)
+- [Documentation Home](https://oqtopus-cloud.readthedocs.io/)
 
 ## CITATION
 


### PR DESCRIPTION
# 📃 Ticket
<!--- Paste related ticket -->

## ✍ Description
<!--- Describe your changes in detail -->
The readthedocs URL in README.md is incorrect.
The correct address is https://oqtopus-cloud.readthedocs.io/

## 📸 Test Result
<!--- Paste `make test result` -->

## 🔗 Related PRs
<!--- Paste related PRs -->
