### PR TITLE
refactor: delete of internal

### DIFF
--- a/backend/oas/provider/openapi.yaml
+++ b/backend/oas/provider/openapi.yaml
@@ -13,7 +13,7 @@ servers:
   - url: http://localhost:8888
     description: Local server url
 paths:
-  /internal/devices/{deviceId}:
+  /devices/{deviceId}:
     patch:
       tags:
         - devices
@@ -121,7 +121,7 @@ paths:
                 $ref: '#/components/schemas/error.InternalServerError'
               example:
                 detail: Internal server error
-  /internal/tasks:
+  /tasks:
     get:
       tags:
         - tasks
@@ -179,7 +179,7 @@ paths:
                 $ref: '#/components/schemas/error.InternalServerError'
               example:
                 detail: Internal server error
-  /internal/tasks/{taskId}:
+  /tasks/{taskId}:
     get:
       summary: Get a task by ID
       description: Get a task by ID
@@ -262,7 +262,7 @@ paths:
                 $ref: '#/components/schemas/error.NotFoundError'
               example:
                 detail: task not found
-  /internal/tasks/unfetched:
+  /tasks/unfetched:
     get:
       summary: Fetch tasks for device
       description: 'Fetches tasks for execution/cancel<br/><br/>Operation is valid only for task with status: QUEUED or CANCELLING. After the operation task status is changed to appropriate FETCHED state (QUEUED_FETCHED or CANCELLING_FETCHED)'
@@ -305,7 +305,7 @@ paths:
                 $ref: '#/components/schemas/error.BadRequest'
               example:
                 detail: Bad request malformed input data
-  /internal/results:
+  /results:
     post:
       summary: Submit a quantum task result
       tags:

--- a/backend/oas/provider/root.yaml
+++ b/backend/oas/provider/root.yaml
@@ -13,13 +13,13 @@ servers:
   - url: http://localhost:8888
     description: Local server url
 paths:
-  /internal/devices/{deviceId}:
+  /devices/{deviceId}:
     $ref: ./paths/devices.yaml#/devices.deviceId
-  /internal/tasks:
+  /tasks:
     $ref: ./paths/tasks.yaml#/tasks
-  /internal/tasks/{taskId}:
+  /tasks/{taskId}:
     $ref: ./paths/tasks.yaml#/tasks.taskId
-  /internal/tasks/unfetched:
+  /tasks/unfetched:
     $ref: ./paths/tasks.yaml#/tasks.unfetched
-  /internal/results:
+  /results:
     $ref: ./paths/results.yaml#/results

--- a/backend/oqtopus_cloud/provider/routers/devices.py
+++ b/backend/oqtopus_cloud/provider/routers/devices.py
@@ -130,7 +130,7 @@ def update_device_calibration(
 
 
 @router.patch(
-    "/internal/devices/{deviceId}",
+    "/devices/{deviceId}",
     response_model=DeviceDataUpdateResponse,
     responses={
         400: {"model": Detail},

--- a/backend/oqtopus_cloud/provider/routers/results.py
+++ b/backend/oqtopus_cloud/provider/routers/results.py
@@ -22,7 +22,7 @@ router: APIRouter = APIRouter(route_class=LoggerRouteHandler)
 
 
 @router.post(
-    "/internal/results",
+    "/results",
     response_model=CreateResultResponse,
     responses={
         404: {"model": Detail},

--- a/backend/oqtopus_cloud/provider/routers/tasks.py
+++ b/backend/oqtopus_cloud/provider/routers/tasks.py
@@ -59,7 +59,7 @@ def create_task_info(task: Task, status=None) -> TaskInfo:
 
 
 @router.get(
-    "/internal/tasks",
+    "/tasks",
     response_model=list[TaskInfo],
 )
 @tracer.capture_method
@@ -85,7 +85,7 @@ def get_tasks(
 
 
 @router.get(
-    "/internal/tasks/unfetched",
+    "/tasks/unfetched",
     response_model=UnfetchedTasksResponse,
     responses={400: {"model": Detail}, 500: {"model": Detail}},
 )
@@ -130,7 +130,7 @@ def get_unfetched_tasks(
 
 
 @router.get(
-    "/internal/tasks/{taskId}",
+    "/tasks/{taskId}",
     response_model=TaskInfo,
     responses={404: {"model": Detail}, 400: {"model": Detail}, 500: {"model": Detail}},
 )
@@ -154,7 +154,7 @@ def get_task(
 
 
 @router.patch(
-    "/internal/tasks/{taskId}",
+    "/tasks/{taskId}",
     response_model=TaskStatusUpdateResponse,
     responses={404: {"model": Detail}, 400: {"model": Detail}, 500: {"model": Detail}},
 )

--- a/docs/en/architecture/sequence_diagram.md
+++ b/docs/en/architecture/sequence_diagram.md
@@ -28,23 +28,23 @@ sequenceDiagram
     User->>Cloud: GET /tasks/<task ID-1>/status
     Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "QUEUED" }
 
-    Provider->>Cloud: GET /internal/tasks/unfetched?deviceId=SC&status=QUEUED
+    Provider->>Cloud: GET /tasks/unfetched?deviceId=SC&status=QUEUED
     Note over Cloud: The statuses of fetched tasks are updated to QUEUED_FETCHED.
     Cloud-->>Provider: HTTP 200 OK {[ {"taskId": <task ID-1>, ... }, { "taskId: <task ID-2>, ... }, ... ]}
 
     Note over Provider: Provider starts execution of the fetched tasks<br>and sends requests to update their statuses to RUNNING.
-    Provider->>Cloud: PATCH /internal/tasks/<task ID-1> { "status": "RUNNING" }
+    Provider->>Cloud: PATCH /tasks/<task ID-1> { "status": "RUNNING" }
     Note over Cloud: The task status is updated to RUNNING.
     Cloud-->>Provider: HTTP 200 OK
 
-    Provider->>Cloud: PATCH /internal/tasks/<task ID-N> { "status": "RUNNING" }
+    Provider->>Cloud: PATCH /tasks/<task ID-N> { "status": "RUNNING" }
     Note over Cloud: The task status is updated to RUNNING.
     Cloud-->>Provider: HTTP 200 OK
 
     User->>Cloud: GET /tasks/<task ID-1>/status
     Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "RUNNING" }
     Note over Provider: The execution of the task <task ID-1> is successfully completed.
-    Provider->>Cloud: POST /internal/results { "taskId": <task ID-1>, "status": "SUCCESS", result: ... }
+    Provider->>Cloud: POST /results { "taskId": <task ID-1>, "status": "SUCCESS", result: ... }
 
     Note over Cloud: The received result of the task is inserted to the DB,<br> then the task status is changed to COMPLETED (via a DB trigger).
     Cloud-->>Provider: HTTP 200 OK
@@ -104,16 +104,16 @@ sequenceDiagram
     User->>Cloud: GET /tasks/<task ID-1>/status
     Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "QUEUED" }
 
-    Provider->>Cloud: GET /internal/tasks/unfetched?deviceId=SVSim&status=QUEUED
+    Provider->>Cloud: GET /tasks/unfetched?deviceId=SVSim&status=QUEUED
     Note over Cloud: The statuses of fetched tasks are updated to QUEUED_FETCHED.
     Cloud-->>Provider: HTTP 200 OK {[ {"taskId": <task ID-1>, ... }, { "taskId: <task ID-2>, ... }, ... ]}
 
     Note over Provider: Provider starts execution of the fetched tasks<br>and sends requests to update their statuses to RUNNING.
-    Provider->>Cloud: PATCH /internal/tasks/<task ID-1> { "status": "RUNNING" }
+    Provider->>Cloud: PATCH /tasks/<task ID-1> { "status": "RUNNING" }
     Note over Cloud: The task status is updated to RUNNING.
     Cloud-->>Provider: HTTP 200 OK
 
-    Provider->>Cloud: PATCH /internal/tasks/<task ID-N> { "status": "RUNNING" }
+    Provider->>Cloud: PATCH /tasks/<task ID-N> { "status": "RUNNING" }
     Note over Cloud: The task status is updated to RUNNING.
     Cloud-->>Provider: HTTP 200 OK
 
@@ -122,7 +122,7 @@ sequenceDiagram
 
     rect rgb(255, 240, 240)
         Note over Provider: The execution of the task <task ID-1> is failed.
-        Provider->>Cloud: POST /internal/results { "taskId": <task ID-1>, "status": "FAILURE", "reason": ... }
+        Provider->>Cloud: POST /results { "taskId": <task ID-1>, "status": "FAILURE", "reason": ... }
         Note over Cloud: The received result of the task is inserted to the DB,<br> then the task status is changed to FAILED (via a DB trigger).
         Cloud-->>Provider: HTTP 200 OK
   
@@ -166,13 +166,13 @@ sequenceDiagram
     User->>Cloud: GET /tasks/<task ID-1>/status
     Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "CANCELLING" }
 
-    Provider->>Cloud: GET /internal/tasks/unfetched?deviceId=SVSim&status=CANCELLING
+    Provider->>Cloud: GET /tasks/unfetched?deviceId=SVSim&status=CANCELLING
     Note over Cloud: The statuses of fetched tasks are updated to CANCELLING_FETCHED.
     Cloud-->>Provider: HTTP 200 OK {[ {"taskId": <task ID-1>, ... }, { "taskId: <task ID-2>, ... }, ... ]}
 
     Note over Provider: Provider tries to cancel the executions of the fetched tasks.
     Note over Provider: The execution of the task <task ID-1> is successfully cancelled.
-    Provider->>Cloud: POST /internal/results { "taskId": <task ID-1>, "status": "CANCELLED", "reason": ... }
+    Provider->>Cloud: POST /results { "taskId": <task ID-1>, "status": "CANCELLED", "reason": ... }
 
     Note over Cloud: The received result of the task is inserted to the DB,<br> then the task status is changed to CANCELLED (via a DB trigger).
     Cloud-->>Provider: HTTP 200 OK

--- a/docs/ja/architecture/sequence_diagram.md
+++ b/docs/ja/architecture/sequence_diagram.md
@@ -28,23 +28,23 @@ sequenceDiagram
     User->>Cloud: GET /tasks/<task ID-1>/status
     Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "QUEUED" }
 
-    Provider->>Cloud: GET /internal/tasks/unfetched?deviceId=SC&status=QUEUED
+    Provider->>Cloud: GET /tasks/unfetched?deviceId=SC&status=QUEUED
     Note over Cloud: The statuses of fetched tasks are updated to QUEUED_FETCHED.
     Cloud-->>Provider: HTTP 200 OK {[ {"taskId": <task ID-1>, ... }, { "taskId: <task ID-2>, ... }, ... ]}
 
     Note over Provider: Provider starts execution of the fetched tasks<br>and sends requests to update their statuses to RUNNING.
-    Provider->>Cloud: PATCH /internal/tasks/<task ID-1> { "status": "RUNNING" }
+    Provider->>Cloud: PATCH /tasks/<task ID-1> { "status": "RUNNING" }
     Note over Cloud: The task status is updated to RUNNING.
     Cloud-->>Provider: HTTP 200 OK
 
-    Provider->>Cloud: PATCH /internal/tasks/<task ID-N> { "status": "RUNNING" }
+    Provider->>Cloud: PATCH /tasks/<task ID-N> { "status": "RUNNING" }
     Note over Cloud: The task status is updated to RUNNING.
     Cloud-->>Provider: HTTP 200 OK
 
     User->>Cloud: GET /tasks/<task ID-1>/status
     Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "RUNNING" }
     Note over Provider: The execution of the task <task ID-1> is successfully completed.
-    Provider->>Cloud: POST /internal/results { "taskId": <task ID-1>, "status": "SUCCESS", result: ... }
+    Provider->>Cloud: POST /results { "taskId": <task ID-1>, "status": "SUCCESS", result: ... }
 
     Note over Cloud: The received result of the task is inserted to the DB,<br> then the task status is changed to COMPLETED (via a DB trigger).
     Cloud-->>Provider: HTTP 200 OK
@@ -102,16 +102,16 @@ sequenceDiagram
     User->>Cloud: GET /tasks/<task ID-1>/status
     Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "QUEUED" }
 
-    Provider->>Cloud: GET /internal/tasks/unfetched?deviceId=SVSim&status=QUEUED
+    Provider->>Cloud: GET /tasks/unfetched?deviceId=SVSim&status=QUEUED
     Note over Cloud: The statuses of fetched tasks are updated to QUEUED_FETCHED.
     Cloud-->>Provider: HTTP 200 OK {[ {"taskId": <task ID-1>, ... }, { "taskId: <task ID-2>, ... }, ... ]}
 
     Note over Provider: Provider starts execution of the fetched tasks<br>and sends requests to update their statuses to RUNNING.
-    Provider->>Cloud: PATCH /internal/tasks/<task ID-1> { "status": "RUNNING" }
+    Provider->>Cloud: PATCH /tasks/<task ID-1> { "status": "RUNNING" }
     Note over Cloud: The task status is updated to RUNNING.
     Cloud-->>Provider: HTTP 200 OK
 
-    Provider->>Cloud: PATCH /internal/tasks/<task ID-N> { "status": "RUNNING" }
+    Provider->>Cloud: PATCH /tasks/<task ID-N> { "status": "RUNNING" }
     Note over Cloud: The task status is updated to RUNNING.
     Cloud-->>Provider: HTTP 200 OK
 
@@ -120,7 +120,7 @@ sequenceDiagram
 
     rect rgb(255, 240, 240)
         Note over Provider: The execution of the task <task ID-1> is failed.
-        Provider->>Cloud: POST /internal/results { "taskId": <task ID-1>, "status": "FAILURE", "reason": ... }
+        Provider->>Cloud: POST /results { "taskId": <task ID-1>, "status": "FAILURE", "reason": ... }
         Note over Cloud: The received result of the task is inserted to the DB,<br> then the task status is changed to FAILED (via a DB trigger).
         Cloud-->>Provider: HTTP 200 OK
   
@@ -164,13 +164,13 @@ sequenceDiagram
     User->>Cloud: GET /tasks/<task ID-1>/status
     Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "CANCELLING" }
 
-    Provider->>Cloud: GET /internal/tasks/unfetched?deviceId=SVSim&status=CANCELLING
+    Provider->>Cloud: GET /tasks/unfetched?deviceId=SVSim&status=CANCELLING
     Note over Cloud: The statuses of fetched tasks are updated to CANCELLING_FETCHED.
     Cloud-->>Provider: HTTP 200 OK {[ {"taskId": <task ID-1>, ... }, { "taskId: <task ID-2>, ... }, ... ]}
 
     Note over Provider: Provider tries to cancel the executions of the fetched tasks.
     Note over Provider: The execution of the task <task ID-1> is successfully cancelled.
-    Provider->>Cloud: POST /internal/results { "taskId": <task ID-1>, "status": "CANCELLED", "reason": ... }
+    Provider->>Cloud: POST /results { "taskId": <task ID-1>, "status": "CANCELLED", "reason": ... }
 
     Note over Cloud: The received result of the task is inserted to the DB,<br> then the task status is changed to CANCELLED (via a DB trigger).
     Cloud-->>Provider: HTTP 200 OK

--- a/docs/oas/provider/openapi.yaml
+++ b/docs/oas/provider/openapi.yaml
@@ -13,7 +13,7 @@ servers:
   - url: http://localhost:8888
     description: Local server url
 paths:
-  /internal/devices/{deviceId}:
+  /devices/{deviceId}:
     patch:
       tags:
         - devices
@@ -121,7 +121,7 @@ paths:
                 $ref: '#/components/schemas/error.InternalServerError'
               example:
                 detail: Internal server error
-  /internal/tasks:
+  /tasks:
     get:
       tags:
         - tasks
@@ -179,7 +179,7 @@ paths:
                 $ref: '#/components/schemas/error.InternalServerError'
               example:
                 detail: Internal server error
-  /internal/tasks/{taskId}:
+  /tasks/{taskId}:
     get:
       summary: Get a task by ID
       description: Get a task by ID
@@ -262,7 +262,7 @@ paths:
                 $ref: '#/components/schemas/error.NotFoundError'
               example:
                 detail: task not found
-  /internal/tasks/unfetched:
+  /tasks/unfetched:
     get:
       summary: Fetch tasks for device
       description: 'Fetches tasks for execution/cancel<br/><br/>Operation is valid only for task with status: QUEUED or CANCELLING. After the operation task status is changed to appropriate FETCHED state (QUEUED_FETCHED or CANCELLING_FETCHED)'
@@ -305,7 +305,7 @@ paths:
                 $ref: '#/components/schemas/error.BadRequest'
               example:
                 detail: Bad request malformed input data
-  /internal/results:
+  /results:
     post:
       summary: Submit a quantum task result
       tags:

--- a/runnbooks/provider/tasks/get-task.yaml
+++ b/runnbooks/provider/tasks/get-task.yaml
@@ -1,4 +1,4 @@
-desc: get internal task test
+desc: get task test
 runners:
   req: ${API_URL}
   openapi3: docs/provider/openapi.yaml
@@ -6,7 +6,7 @@ steps:
   -
     desc: get task
     req:
-      /v1/internal/tasks/7af020f6-2e38-4d70-8cf0-4349650ea08c:
+      /v1/tasks/7af020f6-2e38-4d70-8cf0-4349650ea08c:
         get:
           headers:
             Authorization: Bearer ${IdToken}

--- a/runnbooks/provider/tasks/get-tasks.yaml
+++ b/runnbooks/provider/tasks/get-tasks.yaml
@@ -1,4 +1,4 @@
-desc: get internal tasks test
+desc: get tasks test
 runners:
   req: ${API_URL}
   openapi3: docs/provider/openapi.yaml
@@ -6,7 +6,7 @@ steps:
   -
     desc: get tasks
     req:
-      /v1/internal/tasks?deviceId=Kawasaki:
+      /v1/tasks?deviceId=Kawasaki:
         get:
           headers:
             Authorization: Bearer ${IdToken}


### PR DESCRIPTION
Since the API Gateways on the user side and provider side have been separated, there is no longer any duplication. Also, from a RESTful perspective, this is the hierarchy where resources should be, so the "internal" hierarchy feels strange. Therefore, the "internal" hierarchy is deleted from the provider side OAS.