### PR TITLE
docs: fix readthedocs link

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -5,8 +5,8 @@
 <table>
   <thead>
     <tr>
-      <th style="text-align:center"><a href="../">🇺🇸English</a></th>
-      <th style="text-align:center"><a href="../ja/">🇯🇵日本語</a></th>
+      <th style="text-align:center"><a href="./">🇺🇸English</a></th>
+      <th style="text-align:center"><a href="./ja/">🇯🇵日本語</a></th>
     </tr>
   </thead>
 </table>

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -6,7 +6,7 @@
   <thead>
     <tr>
       <th style="text-align:center"><a href="../">🇺🇸English</a></th>
-      <th style="text-align:center"><a href="../jp/">🇯🇵日本語</a></th>
+      <th style="text-align:center"><a href="./">🇯🇵日本語</a></th>
     </tr>
   </thead>
 </table>


### PR DESCRIPTION
# 📃 Ticket
<!--- Paste related ticket -->

## ✍ Description
<!--- Describe your changes in detail -->

- The link from https://oqtopus-cloud.readthedocs.io/latest/ to the Japanese page is https://oqtopus-cloud.readthedocs.io/ja/. The correct link is https://oqtopus-cloud.readthedocs.io/latest/ja/ 
- The link from https://oqtopus-cloud.readthedocs.io/latest/ja/ to the Japanese page is https://oqtopus-cloud.readthedocs.io/latest/jp/. The correct link is https://oqtopus-cloud.readthedocs.io/latest/ja/

## 📸 Test Result
<!--- Paste `make test result` -->

## 🔗 Related PRs
<!--- Paste related PRs -->
