### PR TITLE
docs: Fix sequence_diagram.md to match en and jp documents

### DIFF
--- a/docs/en/architecture/sequence_diagram.md
+++ b/docs/en/architecture/sequence_diagram.md
@@ -64,10 +64,10 @@ The numbers below correspond to the circled numbers in the sequence diagram.
 - (2)
   - tasks table: [success-case-tasks-02.csv](../../sample/architecture/success-case-tasks-02.csv)
   - results table: no data
-- (10)
+- (8)
   - tasks table: [success-case-tasks-10.csv](../../sample/architecture/success-case-tasks-10.csv)
   - results table: no data
-- (14)
+- (12)
   - tasks table: [success-case-tasks-14.csv](../../sample/architecture/success-case-tasks-14.csv)
   - results table: [success-case-results-14.csv](../../sample/architecture/success-case-results-14.csv)
 
@@ -124,9 +124,9 @@ The followings show sample data in the DB at each point in the sequence diagram,
 where there is one task submission to the endpoint `/tasks/estimation`.
 The numbers below correspond to the circled numbers in the sequence diagram.
 
-- (2), (6), (10)
+- (2), (6), (8)
   - Omitted, as they are the same as in the successful case.
-- (14)
+- (12)
   - tasks table: [failure-case-tasks-14.csv](../../sample/architecture/failure-case-tasks-14.csv)
   - results table: [failure-case-tasks-14.csv](../../sample/architecture/failure-case-results-14.csv)
 
@@ -179,10 +179,10 @@ The numbers below correspond to the circled numbers in the sequence diagram.
 - (2)
   - tasks table: [cancel-case-tasks-02.csv](../../sample/architecture/cancel-case-tasks-02.csv)
   - results table: no data
-- (8)
+- (6)
   - tasks table: [cancel-case-tasks-08.csv](../../sample/architecture/cancel-case-tasks-08.csv)
   - results table: [cancel-case-results-08.csv](../../sample/architecture/cancel-case-results-08.csv)
 
 > [!NOTE]
 > If the task is in QUEUED status at (1), Cloud immediately changes the task status to CANCELLED.
-> It means the task state transitions from (1) to (8) directly.
+> It means the task state transitions from (1) to (6) directly.

--- a/docs/ja/architecture/sequence_diagram.md
+++ b/docs/ja/architecture/sequence_diagram.md
@@ -11,7 +11,7 @@
 ## タスク実行のシーケンス (成功ケース)
 
 タスクの実行が成功した場合のシーケンスを以下に示します。
-User によるタスクの送信、Provider によるタスクのフェッチと実行、User による結果の取得の一連の流れを示しています。
+User によるタスクの送信、Provider によるタスクの実行、User による結果の取得の一連の流れを示しています。
 
 ```mermaid
 sequenceDiagram
@@ -52,7 +52,7 @@ sequenceDiagram
     Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "SUCCESS", "result": ... }
 ```
 
-Provider は定期的に、タスクのフェッチ・タスクの実行・実行結果の送信、の流れを繰り返します。
+Provider は定期的に、タスクの実行・実行結果の送信、の流れを繰り返します。
 上図では 1 回分の流れを記載しています。
 
 ### 各時点における DB 内のデータ
@@ -123,7 +123,7 @@ sequenceDiagram
 `/tasks/estimation` エンドポイントに対してタスクを送信した場合の例となっています。  
 以下の数字は、シーケンス図中の丸数字と対応しています。
 
-- (2), (4), (6)
+- (2), (6), (8)
   - 成功ケースの場合と同様であるため省略。
 - (12)
   - tasks テーブル: [failure-case-tasks-14.csv](../../sample/architecture/failure-case-tasks-14.csv)
@@ -163,7 +163,7 @@ sequenceDiagram
     Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "CANCELLED", "reason": ... }
 ```
 
-Provider は定期的に、キャンセルリクエスト (status が CANCELLING のタスク) のフェッチ・タスク実行のキャンセル・キャンセル結果の送信、の流れを繰り返します。
+Provider は定期的に、タスク実行のキャンセル・キャンセル結果の送信、の流れを繰り返します。
 上図では 1 回分の流れを記載しています。
 
 ### 各時点における DB 内のデータ
@@ -178,10 +178,10 @@ Provider は定期的に、キャンセルリクエスト (status が CANCELLING
 - (2)
   - tasks テーブル: [cancel-case-tasks-02.csv](../../sample/architecture/cancel-case-tasks-02.csv)
   - results テーブル: データ無し
-- (8)
+- (6)
   - tasks テーブル: [cancel-case-tasks-08.csv](../../sample/architecture/cancel-case-tasks-08.csv)
   - results テーブル: [cancel-case-results-08.csv](../../sample/architecture/cancel-case-results-08.csv)
 
 > [!NOTE]
 > (1) の時点でタスクが QUEUED 状態の場合、Cloud は即座にタスクを CANCELLED 状態に変更します。
-> 上記のシーケンス図だと、(1) から (8) の状態に即座に遷移することになります。
+> 上記のシーケンス図だと、(1) から (6) の状態に即座に遷移することになります。


### PR DESCRIPTION
Following the deletion of GET /tasks/unfetched, the en and jp documents in sequence_diagram.md were revised, but there were some inconsistencies, so I correct them myself.