### PR TITLE
docs: fix the link for language switching on the top page of the docu…

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -120,4 +120,10 @@ extra_css:
 extra:
   toc:
     include: 2
-
+  alternate:
+    - name: "English"
+      link: ""
+      lang: en
+    - name: "日本語"
+      link: "ja/"
+      lang: ja


### PR DESCRIPTION
…mentation site

# 📃 Ticket
<!--- Paste related ticket -->

## ✍ Description
<!--- Describe your changes in detail -->

Changed the language-switching link on the top page of the documentation site from absolute paths to relative paths, so that it works correctly in readthedocs.
Reference https://squidfunk.github.io/mkdocs-material/setup/changing-the-language/#site-language-selector

## 📸 Test Result
<!--- Paste `make test result` -->

## 🔗 Related PRs
<!--- Paste related PRs -->
