### PR TITLE
feat: Add endpoint for updating job info.

### DIFF
--- a/backend/oas/provider/openapi.yaml
+++ b/backend/oas/provider/openapi.yaml
@@ -228,6 +228,54 @@ paths:
                 $ref: '#/components/schemas/error.ConflictError'
               example:
                 detail: The specified job is not in a status thatt allows transition to the requested status.
+  /jobs/{job_id}/job_info:
+    patch:
+      summary: Update selected quantum job's job_info by placing job results
+      description: |
+        Used by device to set results or error details in job_info、accompanied by appropriate status updating.
+        Note that job info descriptor (sampling, estimation, etc) cannot be modified.
+      operationId: patchJobInfo
+      security: []
+      tags:
+        - jobs
+      parameters:
+        - in: path
+          name: job_id
+          required: true
+          description: Job identifier
+          schema:
+            type: string
+      requestBody:
+        description: Modification to Job info (excluding jobinfo descriptor.)
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/jobs.UpdateJobInfoRequest'
+      responses:
+        '200':
+          description: job info updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/jobs.UpdateJobInfoResponse'
+              example:
+                message: Job info updated.
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error.BadRequest'
+              example:
+                detail: Bad request malformed input data
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error.NotFoundError'
+              example:
+                detail: Job not found
 components:
   schemas:
     devices.DeviceStatusUpdate:
@@ -261,7 +309,7 @@ components:
           type: string
           example: DeviceCalibrationUpdate
         device_info:
-          description: Calibration_data and n_nodes etc. Make sure that the value is valid JSON format.
+          description: Calibration_data and n_nodes etc. Make sure that the value is a valid JSON data.
           type: string
           example: |-
             {
@@ -528,3 +576,19 @@ components:
           type: string
       required:
         - detail
+    jobs.UpdateJobInfoRequest:
+      type: object
+      properties:
+        transpiled_code:
+          type: string
+        result:
+          type: string
+        reason:
+          type: string
+    jobs.UpdateJobInfoResponse:
+      type: object
+      properties:
+        message:
+          type: string
+      required:
+        - message

--- a/backend/oas/provider/openapi.yaml
+++ b/backend/oas/provider/openapi.yaml
@@ -246,7 +246,7 @@ paths:
           schema:
             type: string
       requestBody:
-        description: Modification to Job info (excluding jobinfo descriptor.)
+        description: Modifications applied to Job info
         content:
           application/json:
             schema:

--- a/backend/oas/provider/paths/jobs.yaml
+++ b/backend/oas/provider/paths/jobs.yaml
@@ -7,24 +7,24 @@ jobs:
     operationId: getjobs
     security: []
     parameters:
-        - in: query
-          name: device_id
-          required: true
-          description: "Device identifier"
-          schema: {type: string, example: "Kawasaki"}
-        - in: query
-          name: status
-          description: "Additional search parameter:<br/> Search jobs with specified status only"
-          schema:
-            $ref: "../schemas/jobs.yaml#/jobs.JobStatus"
-        - in: query
-          name: max_results
-          description: "Additional search parameter:<br/> Set max number of quantum jobs to return in single request"
-          schema: {type: integer, example: 1}
-        - in: query
-          name: timestamp
-          description: "Additional search parameter:<br/> Jobs created after the specified timetsamp"
-          schema: {type: string, example: '2022-12-15 15:54:46'}
+      - in: query
+        name: device_id
+        required: true
+        description: "Device identifier"
+        schema: { type: string, example: "Kawasaki" }
+      - in: query
+        name: status
+        description: "Additional search parameter:<br/> Search jobs with specified status only"
+        schema:
+          $ref: "../schemas/jobs.yaml#/jobs.JobStatus"
+      - in: query
+        name: max_results
+        description: "Additional search parameter:<br/> Set max number of quantum jobs to return in single request"
+        schema: { type: integer, example: 1 }
+      - in: query
+        name: timestamp
+        description: "Additional search parameter:<br/> Jobs created after the specified timetsamp"
+        schema: { type: string, example: "2022-12-15 15:54:46" }
     responses:
       "200":
         description: "List of jobs for a device"
@@ -34,20 +34,20 @@ jobs:
               type: array
               items:
                 $ref: "../schemas/jobs.yaml#/jobs.JobDef"
-      '400':
+      "400":
         description: Bad Request
         content:
           application/json:
             schema:
-              $ref: '../schemas/error.yaml#/error.BadRequest'
+              $ref: "../schemas/error.yaml#/error.BadRequest"
             example:
               detail: Bad request malformed input data
-      '500':
+      "500":
         description: Internal Server Error
         content:
           application/json:
             schema:
-              $ref: '../schemas/error.yaml#/error.InternalServerError'
+              $ref: "../schemas/error.yaml#/error.InternalServerError"
             example:
               detail: Internal server error
 
@@ -58,13 +58,13 @@ jobs.jobId:
     operationId: getJob
     security: []
     tags:
-    - jobs
+      - jobs
     parameters:
-        - in: path
-          name: job_id
-          required: true
-          description: "Job identifier"
-          schema: {type: string}
+      - in: path
+        name: job_id
+        required: true
+        description: "Job identifier"
+        schema: { type: string }
     responses:
       "200":
         description: "Return quantum job"
@@ -72,35 +72,35 @@ jobs.jobId:
           application/json:
             schema:
               $ref: "../schemas/jobs.yaml#/jobs.JobDef"
-      '400':
+      "400":
         description: Bad Request
         content:
           application/json:
             schema:
-              $ref: '../schemas/error.yaml#/error.BadRequest'
+              $ref: "../schemas/error.yaml#/error.BadRequest"
             example:
               detail: Bad request malformed input data
-      '404':
+      "404":
         description: Not Found
         content:
           application/json:
             schema:
-              $ref: '../schemas/error.yaml#/error.NotFoundError'
+              $ref: "../schemas/error.yaml#/error.NotFoundError"
             example:
               detail: job not found
   patch:
     summary: "Modify selected quantum job (update status)."
-    description: "Used by device to set job status to \"RUNNING\".<br/>Other statuses are set by CloudAPI automatically when result is created"
+    description: 'Used by device to set job status to "RUNNING".<br/>Other statuses are set by CloudAPI automatically when result is created'
     operationId: patchJob
     security: []
     tags:
       - jobs
     parameters:
-        - in: path
-          name: job_id
-          required: true
-          description: "Job identifier"
-          schema: {type: string}
+      - in: path
+        name: job_id
+        required: true
+        description: "Job identifier"
+        schema: { type: string }
     requestBody:
       description: "New job status. "
       content:
@@ -108,12 +108,12 @@ jobs.jobId:
           schema:
             $ref: "../schemas/jobs.yaml#/jobs.JobStatusUpdate"
     responses:
-      '200':
+      "200":
         description: job data updated
         content:
           application/json:
             schema:
-              $ref: '../schemas/jobs.yaml#/jobs.JobStatusUpdateResponse'
+              $ref: "../schemas/jobs.yaml#/jobs.JobStatusUpdateResponse"
             example:
               message: job data updated
       "404":
@@ -121,7 +121,7 @@ jobs.jobId:
         content:
           application/json:
             schema:
-              $ref: '../schemas/error.yaml#/error.NotFoundError'
+              $ref: "../schemas/error.yaml#/error.NotFoundError"
             example:
               detail: Job not found
       "409":
@@ -129,6 +129,53 @@ jobs.jobId:
         content:
           application/json:
             schema:
-              $ref: '../schemas/error.yaml#/error.ConflictError'
+              $ref: "../schemas/error.yaml#/error.ConflictError"
             example:
               detail: The specified job is not in a status thatt allows transition to the requested status.
+jobs.jobInfo:
+  patch:
+    summary: "Update selected quantum job's job_info by placing job results"
+    description: |
+      Used by device to set results or error details in job_info、accompanied by appropriate status updating.
+      Note that job info descriptor (sampling, estimation, etc) cannot be modified.
+    operationId: patchJobInfo
+    security: []
+    tags:
+      - jobs
+    parameters:
+      - in: path
+        name: job_id
+        required: true
+        description: "Job identifier"
+        schema: { type: string }
+    requestBody:
+      description: "Modifications applied to Job info"
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/jobs.yaml#/jobs.UpdateJobInfoRequest"
+    responses:
+      "200":
+        description: job info updated
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/jobs.yaml#/jobs.UpdateJobInfoResponse"
+            example:
+              message: Job info updated.
+      "400":
+        description: Bad Request
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/error.yaml#/error.BadRequest"
+            example:
+              detail: Bad request malformed input data
+      "404":
+        description: Not Found
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/error.yaml#/error.NotFoundError"
+            example:
+              detail: Job not found

--- a/backend/oas/provider/root.yaml
+++ b/backend/oas/provider/root.yaml
@@ -19,3 +19,5 @@ paths:
     $ref: ./paths/jobs.yaml#/jobs
   /jobs/{job_id}:
     $ref: ./paths/jobs.yaml#/jobs.jobId
+  /jobs/{job_id}/job_info:
+    $ref: ./paths/jobs.yaml#/jobs.jobInfo

--- a/backend/oas/provider/schemas/jobs.yaml
+++ b/backend/oas/provider/schemas/jobs.yaml
@@ -233,3 +233,20 @@ jobs.JobStatusUpdateResponse:
   required:
     - message
 
+jobs.UpdateJobInfoRequest:
+  type: object
+  properties:
+    transpiled_code:
+      type: string
+    result:
+      type: string
+    reason:
+      type: string
+
+jobs.UpdateJobInfoResponse:
+  type: object
+  properties:
+    message:
+      type: string
+  required:
+    - message

--- a/backend/oqtopus_cloud/provider/routers/jobs.py
+++ b/backend/oqtopus_cloud/provider/routers/jobs.py
@@ -163,6 +163,11 @@ def update_job_info(
 
         return (None, job_info)
 
+    if request.reason is not None and request.result is not None:
+        return BadRequestResponse(
+            detail="You cannot specify both a result and a reason."
+        )
+
     try:
         stmt = select(Job).where(Job.id == job_id)
         model = db.execute(stmt).scalar_one_or_none()

--- a/backend/oqtopus_cloud/provider/routers/jobs.py
+++ b/backend/oqtopus_cloud/provider/routers/jobs.py
@@ -7,6 +7,7 @@ from oqtopus_cloud.common.models.job import Job
 from oqtopus_cloud.common.session import get_db
 from oqtopus_cloud.provider.conf import logger, tracer
 from oqtopus_cloud.provider.schemas.errors import (
+    BadRequestResponse,
     ConflictErrorResponse,
     Detail,
     ErrorResponse,
@@ -19,6 +20,8 @@ from oqtopus_cloud.provider.schemas.jobs import (
     JobStatus,
     JobStatusUpdate,
     JobStatusUpdateResponse,
+    UpdateJobInfoRequest,
+    UpdateJobInfoResponse,
 )
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -121,6 +124,58 @@ def update_job(
         model.status = request.status
         db.commit()
         return JobStatusUpdateResponse(message="Job status updated")
+    except Exception as e:
+        return InternalServerErrorResponse(f"Error: {str(e)}")
+
+
+@router.patch(
+    "/jobs/{job_id}/job_info",
+    response_model=UpdateJobInfoResponse,
+    responses={
+        400: {"model": Detail},
+        404: {"model": Detail},
+        500: {"model": Detail},
+    },
+)
+@tracer.capture_method
+def update_job_info(
+    job_id: str,
+    request: UpdateJobInfoRequest,
+    db: Session = Depends(get_db),
+) -> UpdateJobInfoResponse | ErrorResponse:
+    logger.info("invoked: update_job_info")
+    logger.info(
+        f"with parameters: job_id={job_id}, request={request.model_dump_json()}"
+    )
+
+    def patch_job_info(job_info: JobInfo) -> tuple[Optional[JobStatus], JobInfo]:
+        job_info.transpiled_code = request.transpiled_code
+
+        if request.result is not None:
+            job_info.result = request.result
+            job_info.reason = None
+            return (JobStatus.success, job_info)
+
+        elif request.reason is not None:
+            job_info.reason = request.reason
+            job_info.result = None
+            return (JobStatus.failed, job_info)
+
+        return (None, job_info)
+
+    try:
+        stmt = select(Job).where(Job.id == job_id)
+        model = db.execute(stmt).scalar_one_or_none()
+        if model is None:
+            return NotFoundErrorResponse("Job not found")
+        (status, job_info) = patch_job_info(
+            JobInfo.model_validate(json.loads(model.job_info))
+        )
+        model.job_info = JobInfo.model_dump_json(job_info)
+        if status is not None:
+            model.status = status
+        db.commit()
+        return UpdateJobInfoResponse(message="Job info updated")
     except Exception as e:
         return InternalServerErrorResponse(f"Error: {str(e)}")
 

--- a/backend/oqtopus_cloud/provider/schemas/devices.py
+++ b/backend/oqtopus_cloud/provider/schemas/devices.py
@@ -49,7 +49,7 @@ class DeviceCalibrationUpdate(BaseModel):
         ),
     ] = None
     """
-    Calibration_data and n_nodes etc. Make sure that the value is valid JSON format.
+    Calibration_data and n_nodes etc. Make sure that the value is a valid JSON data.
     """
     calibrated_at: Annotated[
         datetime | None, Field(examples=["2023-09-10T14:00:00"])

--- a/backend/oqtopus_cloud/provider/schemas/jobs.py
+++ b/backend/oqtopus_cloud/provider/schemas/jobs.py
@@ -116,3 +116,13 @@ class JobStatusUpdate(BaseModel):
 
 class JobStatusUpdateResponse(BaseModel):
     message: str
+
+
+class UpdateJobInfoRequest(BaseModel):
+    transpiled_code: str | None = None
+    result: str | None = None
+    reason: str | None = None
+
+
+class UpdateJobInfoResponse(BaseModel):
+    message: str

--- a/backend/tests/oqtopus_cloud/provider/routers/test_jobs.py
+++ b/backend/tests/oqtopus_cloud/provider/routers/test_jobs.py
@@ -2,12 +2,14 @@ import json
 import uuid
 from datetime import datetime
 
+from fastapi.testclient import TestClient
 from oqtopus_cloud.common.models.device import (
     Device,
 )
 from oqtopus_cloud.common.models.job import (
     Job,
 )
+from oqtopus_cloud.provider.lambda_function import app
 from oqtopus_cloud.provider.routers.jobs import (
     get_job,
     get_jobs,
@@ -15,8 +17,11 @@ from oqtopus_cloud.provider.routers.jobs import (
 )
 from oqtopus_cloud.provider.schemas.jobs import (
     JobDef,
+    JobInfo,
+    JobStatus,
     JobStatusUpdate,
     JobStatusUpdateResponse,
+    UpdateJobInfoRequest,
 )
 from sqlalchemy.orm.session import Session
 from zoneinfo import ZoneInfo
@@ -26,6 +31,7 @@ from zoneinfo import ZoneInfo
 utc = ZoneInfo("UTC")
 jst = ZoneInfo("Asia/Tokyo")
 
+client = TestClient(app)
 
 # def _get_calibration_dict() -> Dict:
 #     calib_dict = {
@@ -122,6 +128,77 @@ def test_update_job(test_db: Session):
     # Assert
 
     assert actual == expected
+
+
+def test_update_job_info_400(test_db: Session):
+    job_model = _get_job_model()
+    test_db.add(_get_device_model())
+    test_db.add(job_model)
+    test_db.commit()
+
+    # Submitting
+    result = json.dumps({"field1": "value", "field2": "value2"})
+    reason = "Oops! Job failed!"
+    body = UpdateJobInfoRequest(
+        result=result,
+        reason=reason,
+    )
+    submit_resp = client.patch(
+        f"/jobs/{job_model.id}/job_info", content=body.model_dump_json()
+    )
+    assert submit_resp.status_code == 400
+
+
+def test_update_job_info_result(test_db: Session):
+    job_model = _get_job_model()
+    bef_job_info = JobInfo.model_validate(json.loads(job_model.job_info))
+    test_db.add(_get_device_model())
+    test_db.add(job_model)
+    test_db.commit()
+
+    # Submitting
+    result = json.dumps({"field1": "value", "field2": "value2"})
+    transpiled_code = "transpiled_code"
+    body = UpdateJobInfoRequest(
+        result=result,
+        transpiled_code=transpiled_code,
+    )
+    submit_resp = client.patch(
+        f"/jobs/{job_model.id}/job_info", content=body.model_dump_json()
+    )
+    assert submit_resp.status_code == 200
+    get_resp = client.get(f"/jobs/{job_model.id}")
+    aft_job = JobDef.model_validate(get_resp.json())
+    aft_job_info = aft_job.job_info
+    assert bef_job_info.desc == aft_job_info.desc
+    assert aft_job_info.result == result
+    assert aft_job_info.reason is None
+    assert aft_job.status == JobStatus.success
+
+
+def test_update_job_info_reason(test_db: Session):
+    job_model = _get_job_model()
+    bef_job_info = JobInfo.model_validate(json.loads(job_model.job_info))
+    test_db.add(_get_device_model())
+    test_db.add(job_model)
+    test_db.commit()
+
+    # Submitting
+    reason = "Oops, job failed!"
+    body = UpdateJobInfoRequest(
+        reason=reason,
+    )
+    submit_resp = client.patch(
+        f"/jobs/{job_model.id}/job_info", content=body.model_dump_json()
+    )
+    assert submit_resp.status_code == 200
+    get_resp = client.get(f"/jobs/{job_model.id}")
+    aft_job = JobDef.model_validate(get_resp.json())
+    aft_job_info = aft_job.job_info
+    assert bef_job_info.desc == aft_job_info.desc
+    assert aft_job_info.reason == reason
+    assert aft_job_info.result is None
+    assert aft_job.status == JobStatus.failed
 
 
 # TODO: add invalid test cases

--- a/docs/oas/provider/openapi.yaml
+++ b/docs/oas/provider/openapi.yaml
@@ -228,6 +228,54 @@ paths:
                 $ref: '#/components/schemas/error.ConflictError'
               example:
                 detail: The specified job is not in a status thatt allows transition to the requested status.
+  /jobs/{job_id}/job_info:
+    patch:
+      summary: Update selected quantum job's job_info by placing job results
+      description: |
+        Used by device to set results or error details in job_info、accompanied by appropriate status updating.
+        Note that job info descriptor (sampling, estimation, etc) cannot be modified.
+      operationId: patchJobInfo
+      security: []
+      tags:
+        - jobs
+      parameters:
+        - in: path
+          name: job_id
+          required: true
+          description: Job identifier
+          schema:
+            type: string
+      requestBody:
+        description: Modifications applied to Job info
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/jobs.UpdateJobInfoRequest'
+      responses:
+        '200':
+          description: job info updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/jobs.UpdateJobInfoResponse'
+              example:
+                message: Job info updated.
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error.BadRequest'
+              example:
+                detail: Bad request malformed input data
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error.NotFoundError'
+              example:
+                detail: Job not found
 components:
   schemas:
     devices.DeviceStatusUpdate:
@@ -242,7 +290,7 @@ components:
             - available
             - unavailable
         available_at:
-          description: Parameter mandatory and valid for status 'unavailable'
+          description: Parameter mandatory and valid for status `unavailable`
           type: string
           format: date-time
           example: '2023-09-10T14:00:00'
@@ -261,9 +309,24 @@ components:
           type: string
           example: DeviceCalibrationUpdate
         device_info:
-          description: json format calibration_data and n_nodes etc
+          description: Calibration_data and n_nodes etc. Make sure that the value is a valid JSON data.
           type: string
-          example: '{''n_nodes'': 512, ''calibration_data'': {''qubit_connectivity'': [''(1,4)'', ''(4,5)'', ''(5,8)''], ''t1'': {''0'': 55.51, ''1'': 37.03, ''2'': 57.13}}'
+          example: |-
+            {
+              "n_nodes": 512,
+              "calibration_data": {
+                "qubit_connectivity": [
+                  "(1,4)",
+                  "(4,5)",
+                  "(5,8)"
+                ],
+                "t1": {
+                  "0": 55.51,
+                  "1": 37.03,
+                  "2": 57.13
+                }
+              }
+            }
         calibrated_at:
           description: Parameter mandatory and valid if calibrationData not null
           type: string
@@ -430,10 +493,8 @@ components:
             }
         mitigation_info:
           type: string
-          example: |-
-            {
-              "ro_error_mitigation": "pseudo_inverse"
-            }
+          example: |
+            { "ro_error_mitigation": "pseudo_inverse" }
         status:
           $ref: '#/components/schemas/jobs.JobStatus'
         created_at:
@@ -463,9 +524,29 @@ components:
           transpiled_code: null
           result: null
           reason: null
-        transpiler_info: '{ "qubit_allocation": { "0": 12, "1": 16 }, "skip_transpilation": false, "seed_transpilation": 873 }'
-        simulator_info: '{ "n_qubits": 5, "n_nodes": 12, "n_per_node": 2, "seed_simulation": 39058567, "simulation_opt": { "optimization_method": "light", "optimization_block_size": 1, "optimization_swap_level": 1 } }'
-        mitigation_info: '{ "ro_error_mitigation": "pseudo_inverse" }'
+        transpiler_info: |-
+          {
+            "qubit_allocation": {
+              "0": 12,
+              "1": 16
+            },
+            "skip_transpilation": false,
+            "seed_transpilation": 873
+          }
+        simulator_info: |-
+          {
+            "n_qubits": 5,
+            "n_nodes": 12,
+            "n_per_node": 2,
+            "seed_simulation": 39058567,
+            "simulation_opt": {
+              "optimization_method": "light",
+              "optimization_block_size": 1,
+              "optimization_swap_level": 1
+            }
+          }
+        mitigation_info: |
+          { "ro_error_mitigation": "pseudo_inverse" }
         job_type: sampling
         shots: 1000
         status: submitted
@@ -495,3 +576,19 @@ components:
           type: string
       required:
         - detail
+    jobs.UpdateJobInfoRequest:
+      type: object
+      properties:
+        transpiled_code:
+          type: string
+        result:
+          type: string
+        reason:
+          type: string
+    jobs.UpdateJobInfoResponse:
+      type: object
+      properties:
+        message:
+          type: string
+      required:
+        - message

--- a/docs/oas/user/openapi.yaml
+++ b/docs/oas/user/openapi.yaml
@@ -609,7 +609,8 @@ components:
         result:
           type: string
           description: The result of quantum computation, set only if the computation is successful.
-          example: '{ "11": 4980, "00": 5020 }'
+          example: |
+            { "11": 4980, "00": 5020 }
         reason:
           type: string
           description: The reason indicating why there is no result


### PR DESCRIPTION
# 📃 Ticket
<!--- Paste related ticket -->
#273 (internal)

## ✍ Description
<!--- Describe your changes in detail -->
This PR introduces new Provider API endpoint for updating quantum job info.
With this feature, quantum devices can update the result or reason of failure of their jobs.

## 📸 Test Result
<!--- Paste `make test result` -->
>tests/oqtopus_cloud/provider/routers/test_devices.py::test_update_device_pending_jobs PASSED [ 11%]
tests/oqtopus_cloud/provider/routers/test_devices.py::test_update_device_status_available PASSED [ 22%]
tests/oqtopus_cloud/provider/routers/test_devices.py::test_update_device_status_not_available PASSED [ 33%]
tests/oqtopus_cloud/provider/routers/test_jobs.py::test_get_jobs PASSED  [ 44%]
tests/oqtopus_cloud/provider/routers/test_jobs.py::test_get_job PASSED   [ 55%]
tests/oqtopus_cloud/provider/routers/test_jobs.py::test_update_job PASSED [ 66%]
tests/oqtopus_cloud/provider/routers/test_jobs.py::test_update_job_info_400 PASSED [ 77%]
tests/oqtopus_cloud/provider/routers/test_jobs.py::test_update_job_info_result PASSED [ 88%]
/home/runner/work/oqtopus-cloud/oqtopus-cloud/.venv/lib/python3.12/site-packages/coverage/inorout.py:505: CoverageWarning: Module backend/api was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
tests/oqtopus_cloud/provider/routers/test_jobs.py::test_update_job_info_reason PASSED [100%]

## 🔗 Related PRs
<!--- Paste related PRs -->
