### PR TITLE
feat: Make  API Authorizer pluggable

### DIFF
--- a/docs/terraform_modules/api-server/README.md
+++ b/docs/terraform_modules/api-server/README.md
@@ -92,6 +92,8 @@ module "user_api" {
 | <a name="input_power_tools_service_name"></a> [power\_tools\_service\_name](#input\_power\_tools\_service\_name) | The service name for the PowerTools metrics | `string` | n/a | yes |
 | <a name="input_product"></a> [product](#input\_product) | product name | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | region of the deployment | `string` | n/a | yes |
+| <a name="input_require_api_key"></a> [require\_api\_key](#input\_require\_api\_key) | Set `true` if API key is required | `bool` | `false` | no |
+| <a name="input_use_cognito_authorizer"></a> [use\_cognito\_authorizer](#input\_use\_cognito\_authorizer) | Set `true` if API is authorized with cognito userpool. | `bool` | `true` | no |
 
 ## Outputs
 

--- a/terraform/service/modules/api-server/README.md
+++ b/terraform/service/modules/api-server/README.md
@@ -92,6 +92,8 @@ module "user_api" {
 | <a name="input_power_tools_service_name"></a> [power\_tools\_service\_name](#input\_power\_tools\_service\_name) | The service name for the PowerTools metrics | `string` | n/a | yes |
 | <a name="input_product"></a> [product](#input\_product) | product name | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | region of the deployment | `string` | n/a | yes |
+| <a name="input_require_api_key"></a> [require\_api\_key](#input\_require\_api\_key) | Set `true` if API key is required | `bool` | `false` | no |
+| <a name="input_use_cognito_authorizer"></a> [use\_cognito\_authorizer](#input\_use\_cognito\_authorizer) | Set `true` if API is authorized with cognito userpool. | `bool` | `true` | no |
 
 ## Outputs
 

--- a/terraform/service/modules/api-server/main.tf
+++ b/terraform/service/modules/api-server/main.tf
@@ -271,13 +271,12 @@ resource "aws_api_gateway_resource" "this" {
 
 
 resource "aws_api_gateway_method" "this" {
-  rest_api_id = aws_api_gateway_rest_api.this.id
-  resource_id = aws_api_gateway_resource.this.id
-  http_method = "ANY"
-  # authorization = "NONE"
-  authorization = "COGNITO_USER_POOLS"
-  authorizer_id = aws_api_gateway_authorizer.this.id
-  # api_key_required = true
+  rest_api_id      = aws_api_gateway_rest_api.this.id
+  resource_id      = aws_api_gateway_resource.this.id
+  http_method      = "ANY"
+  authorization    = var.use_cognito_authorizer ? "COGNITO_USER_POOLS" : "NONE"
+  authorizer_id    = var.use_cognito_authorizer ? aws_api_gateway_authorizer.this.id : null
+  api_key_required = var.require_api_key
 
   request_parameters = {
     "method.request.path.proxy" = true
@@ -315,7 +314,9 @@ resource "aws_lambda_permission" "api_lambda_permission" {
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*/*"
 }
+
 resource "aws_api_gateway_authorizer" "this" {
+  count        = var.use_cognito_authorizer ? 1 : 0
   name          = "${var.product}-${var.org}-${var.env}-${var.identifier}"
   rest_api_id   = aws_api_gateway_rest_api.this.id
   type          = "COGNITO_USER_POOLS"

--- a/terraform/service/modules/api-server/main.tf
+++ b/terraform/service/modules/api-server/main.tf
@@ -275,7 +275,7 @@ resource "aws_api_gateway_method" "this" {
   resource_id      = aws_api_gateway_resource.this.id
   http_method      = "ANY"
   authorization    = var.use_cognito_authorizer ? "COGNITO_USER_POOLS" : "NONE"
-  authorizer_id    = var.use_cognito_authorizer ? aws_api_gateway_authorizer.this.id : null
+  authorizer_id    = var.use_cognito_authorizer ? aws_api_gateway_authorizer.this[0].id : null
   api_key_required = var.require_api_key
 
   request_parameters = {
@@ -316,7 +316,7 @@ resource "aws_lambda_permission" "api_lambda_permission" {
 }
 
 resource "aws_api_gateway_authorizer" "this" {
-  count        = var.use_cognito_authorizer ? 1 : 0
+  count         = var.use_cognito_authorizer ? 1 : 0
   name          = "${var.product}-${var.org}-${var.env}-${var.identifier}"
   rest_api_id   = aws_api_gateway_rest_api.this.id
   type          = "COGNITO_USER_POOLS"

--- a/terraform/service/modules/api-server/variables.tf
+++ b/terraform/service/modules/api-server/variables.tf
@@ -40,6 +40,17 @@ variable "lambda_handler" {
   type        = string
 }
 
+variable "use_cognito_authorizer" {
+  description = "Set `true` if API is authorized with cognito userpool."
+  type        = bool
+  default     = true
+}
+
+variable "require_api_key" {
+  description = "Set `true` if API key is required"
+  type        = bool
+  default     = false
+}
 variable "cognito_user_pool_arns" {
   description = "The ARNs of the Cognito user pools"
   type        = list(string)

--- a/terraform/service/oqtopus-dev/main.tf
+++ b/terraform/service/oqtopus-dev/main.tf
@@ -44,7 +44,9 @@ module "provider_api" {
   lambda_handler                = "oqtopus_cloud.provider.lambda_function.handler"
   lambda_security_group_ids     = data.terraform_remote_state.infrastructure.outputs.security_group.lambda_security_group_ids
   lambda_subnet_ids             = data.terraform_remote_state.infrastructure.outputs.network.private_subnet_ids
-  cognito_user_pool_arns        = [data.terraform_remote_state.infrastructure.outputs.provider_cognito.user_pool_arn]
+  use_cognito_authorizer        = false
+  require_api_key               = true
+  cognito_user_pool_arns        = []
   power_tools_metrics_namespace = "provider-api"
   power_tools_service_name      = "provider-api"
   allow_origins                 = "*"


### PR DESCRIPTION
# 📃 Ticket
<!--- Paste related ticket -->
https://github.com/FujitsuResearch/QuantumCloudPlatform/issues/279

## ✍ Description
This PR updates terraform configuration of the API service, enabling Cognito authorizer pluggable.
This PR does not bring any breaking change, existing cloud stack would work without any modification.

## 📸 Test Result
<!--- Paste `make test result` -->

## 🔗 Related PRs
<!--- Paste related PRs -->
