### PR TITLE
Feat/#284 revise job info

### DIFF
--- a/backend/oas/provider/openapi.yaml
+++ b/backend/oas/provider/openapi.yaml
@@ -400,6 +400,28 @@ components:
       type: string
       format: string
       example: 7af020f6-2e38-4d70-8cf0-4349650ea08c
+    jobs.JobProgram:
+      type: array
+      description: A list of OPENQASM3 program. For non-multiprogramming jobs, this field is assumed to contain exactly one program. Otherwise, those programs are combined according to the multiprogramming machinery.
+      items:
+        type: string
+      example: '[ "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;" ]'
+    jobs.OperatorItem:
+      type: object
+      properties:
+        pauli:
+          type: string
+          description: The Pauli string.
+          example: X 0 X 1
+        coeff:
+          description: Complex coefficient number in the Pauli string representation.
+          type: array
+          items:
+            type: number
+          minItems: 1
+          maxItems: 2
+      required:
+        - pauli
     jobs.JobInfoEstimation:
       type: object
       description: The descriptor of estimation jobs
@@ -408,15 +430,15 @@ components:
           type: string
           enum:
             - estimation
-        code:
-          type: string
-          example: OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;
+        program:
+          $ref: '#/components/schemas/jobs.JobProgram'
         operator:
-          type: string
-          example: X 0 Y 1 Z 5 I 2
+          type: array
+          items:
+            $ref: '#/components/schemas/jobs.OperatorItem'
       required:
         - job_type
-        - code
+        - program
         - operator
     jobs.JobInfoSampling:
       type: object
@@ -426,36 +448,91 @@ components:
           type: string
           enum:
             - sampling
-        code:
-          type: string
-          example: OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;
+        program:
+          $ref: '#/components/schemas/jobs.JobProgram'
       required:
         - job_type
-        - code
+        - program
     jobs.JobInfoDesc:
       type: object
       oneOf:
         - $ref: '#/components/schemas/jobs.JobInfoEstimation'
         - $ref: '#/components/schemas/jobs.JobInfoSampling'
+    jobs.JobResultEstimation:
+      type: object
+      properties:
+        job_type:
+          type: string
+          enum:
+            - estimation
+        exp_value:
+          type: array
+          items:
+            type: number
+          minItems: 1
+          maxItems: 2
+        stds:
+          description: The standard deviation value
+          type: number
+      required:
+        - job_type
+        - exp_value
+        - stds
+    jobs.JobResultSampling:
+      type: object
+      properties:
+        job_type:
+          type: string
+          enum:
+            - sampling
+        counts:
+          type: string
+          example: |-
+            {
+              "10": 84,
+              "11": 387,
+              "10": 454,
+              "01": 75
+            }
+      required:
+        - job_type
+        - counts
+    jobs.JobResultDesc:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/jobs.JobResultEstimation'
+        - $ref: '#/components/schemas/jobs.JobResultSampling'
+    jobs.JobResult:
+      type: object
+      properties:
+        desc:
+          $ref: '#/components/schemas/jobs.JobResultDesc'
+        divided_result:
+          type: object
+          description: Assumed to be used for multiprogramming, but currently not supported yet.
+          properties: {}
+        properties:
+          type: string
+        transpile_result:
+          type: object
+          properties:
+            virtual_physical_mapping:
+              type: string
+      required:
+        - desc
     jobs.JobInfo:
       type: object
       properties:
         desc:
           $ref: '#/components/schemas/jobs.JobInfoDesc'
-        transpiled_code:
+        transpiled_program:
           type: string
           example: OPENQASM 3; include "stdgates.inc"; qubit[2] _all_qubits; let q = _all_qubits[0:1]; h q[0]; cx q[0], q[1];
         result:
+          $ref: '#/components/schemas/jobs.JobResult'
+        message:
           type: string
-          description: The result of quantum computation, set only if the computation is successful.
-          example: |-
-            {
-              "11": 4980,
-              "00": 5020
-            }
-        reason:
-          type: string
-          description: The reason indicating why there is no result
+          description: Describing the reason why there is no result
       required:
         - desc
     jobs.GetJobsResponse:
@@ -693,11 +770,17 @@ components:
     jobs.UpdateJobInfoRequest:
       type: object
       properties:
-        transpiled_code:
+        overwrite_status:
+          description: Overwrite the job status. Use with caution to avoid putting the job into an inconsistent state. If this field is not specified, the status will be updated automatically.
+          $ref: '#/components/schemas/jobs.JobStatus'
+        execution_time:
+          type: number
+          description: Execution time for quantum computation. Specify the time in seconds, including up to milliseconds.
+        transpiled_program:
           type: string
         result:
-          type: string
-        reason:
+          $ref: '#/components/schemas/jobs.JobResult'
+        message:
           type: string
     jobs.UpdateJobInfoResponse:
       type: object

--- a/backend/oas/provider/schemas/jobs.yaml
+++ b/backend/oas/provider/schemas/jobs.yaml
@@ -14,51 +14,66 @@ jobs.JobStatus:
     - cancelled
   example: submitted
 
+jobs.JobProgram:
+  type: array
+  description: >-
+    A list of OPENQASM3 program.
+    For non-multiprogramming jobs, this field is assumed to contain exactly one program.
+    Otherwise, those programs are combined according to the multiprogramming machinery.
+  items:
+    type: string
+  example: >-
+      [ "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;" ]
+
 jobs.JobInfoSampling:
   type: object
-  description: The descriptor of sampling jobs
+  description: "The descriptor of sampling jobs"
   properties:
     job_type:
       type: string
       enum:
         - sampling
-    code:
-      type: string
-      example: >-
-        OPENQASM 3;
-        qubit[2] q;
-        bit[2] c;
-        h q[0];
-        cnot q[0], q[1];
-        c = measure q;
+    program:
+      $ref: "#/jobs.JobProgram"
   required:
     - job_type
-    - code
+    - program
 
 jobs.JobInfoEstimation:
   type: object
-  description: The descriptor of estimation jobs
+  description: "The descriptor of estimation jobs"
   properties:
     job_type:
       type: string
       enum:
         - estimation
-    code:
-      type: string
-      example: >-
-        OPENQASM 3;
-        qubit[2] q;
-        bit[2] c;
-        h q[0];
-        cnot q[0], q[1];
-        c = measure q;
+    program:
+      $ref: "#/jobs.JobProgram"
     operator:
-      type: string
-      example: X 0 Y 1 Z 5 I 2
+      type: array
+      items:
+        $ref: "#/jobs.OperatorItem"
   required:
     - job_type
-    - code
+    - program
     - operator
+
+jobs.OperatorItem:
+  type: object
+  properties:
+    pauli:
+      type: string
+      description: The Pauli string.
+      example: "X 0 X 1"
+    coeff:
+      description: "Complex coefficient number in the Pauli string representation."
+      type: array
+      items:
+        type: number
+      minItems: 1
+      maxItems: 2
+  required:
+    - pauli
 
 jobs.JobInfoDesc:
   type: object
@@ -66,12 +81,78 @@ jobs.JobInfoDesc:
     - $ref: "#/jobs.JobInfoEstimation"
     - $ref: "#/jobs.JobInfoSampling"
 
+jobs.JobResultSampling:
+  type: object
+  properties:
+    job_type:
+      type: string
+      enum:
+        - "sampling"
+    counts:
+      type: string
+      example: >-
+        {
+          "10": 84,
+          "11": 387,
+          "10": 454,
+          "01": 75
+        }
+  required:
+    - job_type
+    - counts
+
+jobs.JobResultEstimation:
+  type: object
+  properties:
+    job_type:
+      type: string
+      enum:
+        - "estimation"
+    exp_value:
+      type: array
+      items:
+        type: number
+      minItems: 1
+      maxItems: 2
+    stds:
+      description: "The standard deviation value"
+      type: number
+  required:
+    - job_type
+    - exp_value
+    - stds
+
+jobs.JobResultDesc:
+  type: object
+  oneOf:
+    - $ref: "#/jobs.JobResultEstimation"
+    - $ref: "#/jobs.JobResultSampling"
+
+jobs.JobResult:
+  type: object
+  properties:
+    desc:
+      $ref: "#/jobs.JobResultDesc"
+    divided_result:
+      type: object
+      description: "Assumed to be used for multiprogramming, but currently not supported yet."
+      properties: {}
+    properties:
+      type: string
+    transpile_result:
+      type: object
+      properties:
+        virtual_physical_mapping:
+          type: string
+  required:
+    - desc
+
 jobs.JobInfo:
   type: object
   properties:
     desc:
       $ref: "#/jobs.JobInfoDesc"
-    transpiled_code:
+    transpiled_program:
       type: string
       example: >-
         OPENQASM 3;
@@ -81,16 +162,10 @@ jobs.JobInfo:
         h q[0];
         cx q[0], q[1];
     result:
+      $ref: "#/jobs.JobResult"
+    message:
       type: string
-      description: The result of quantum computation, set only if the computation is successful.
-      example: >-
-        {
-          "11": 4980,
-          "00": 5020
-        }
-    reason:
-      type: string
-      description: The reason indicating why there is no result
+      description: Describing the reason why there is no result
   required:
     - desc
 
@@ -344,11 +419,22 @@ jobs.JobStatusUpdateResponse:
 jobs.UpdateJobInfoRequest:
   type: object
   properties:
-    transpiled_code:
+    overwrite_status:
+      description: >-
+        Overwrite the job status. Use with caution to avoid putting
+        the job into an inconsistent state. If this field is not
+        specified, the status will be updated automatically.
+      $ref: "#/jobs.JobStatus"
+    execution_time:
+      type: number
+      description: >-
+        Execution time for quantum computation. Specify the time in seconds,
+        including up to milliseconds.
+    transpiled_program:
       type: string
     result:
-      type: string
-    reason:
+      $ref: "#/jobs.JobResult"
+    message:
       type: string
 
 jobs.UpdateJobInfoResponse:

--- a/backend/oas/user/openapi.yaml
+++ b/backend/oas/user/openapi.yaml
@@ -203,7 +203,8 @@ paths:
                   device_id: Kawasaki
                   job_info:
                     job_type: sampling
-                    code: OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;
+                    program:
+                      - OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;
                   transpiler_info: '{}'
                   simulator_info: '{ "n_qubits": 5, "n_nodes": 12, "n_per_node": 2, "seed_simulation": 39058567, "simulation_opt": {"optimization_method": "light", "optimization_block_size": 1, "optimization_swap_level": 1}}'
                   mitigation_info: '{}'
@@ -214,13 +215,22 @@ paths:
               qpu:
                 description: QPU example
                 value:
-                  name: Bell State Sampling
-                  description: Bell State Sampling Example
+                  name: Bell State Estimation
+                  description: Bell State Estimation Example
                   device_id: Kawasaki
                   job_info:
                     job_type: estimation
-                    code: OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;
-                    operator: X 0 Y 1 Z 5 I 2
+                    program:
+                      - OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;
+                    operator:
+                      - pauli: X 0 X 1
+                        coeff:
+                          - 1.5
+                          - 2.8
+                      - pauli: Y 0 Z 1
+                        coeff:
+                          - 1.2
+                          - -2.e-8
                   transpiler_info: '{"qubit_allocation": {"0": 12, "1": 16}, "skip_transpilation": false, "seed_transpilation": 873}'
                   simulator_info: '{}'
                   mitigation_info: '{"ro_error_mitigation": "pseudo_inverse"}'
@@ -634,6 +644,22 @@ components:
         - failed
         - cancelled
       example: submitted
+    jobs.OperatorItem:
+      type: object
+      properties:
+        pauli:
+          type: string
+          description: The Pauli string.
+          example: X 0 X 1
+        coeff:
+          description: Complex coefficient number in the Pauli string representation.
+          type: array
+          items:
+            type: number
+          minItems: 1
+          maxItems: 2
+      required:
+        - pauli
     jobs.JobInfoEstimation:
       type: object
       description: The descriptor of estimation jobs
@@ -642,15 +668,19 @@ components:
           type: string
           enum:
             - estimation
-        code:
-          type: string
-          example: OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;
+        program:
+          type: array
+          description: A list of OPENQASM3 program. For non-multiprogramming jobs, this field is assumed to contain exactly one program. Otherwise, those programs are combined according to the multiprogramming machinery.
+          items:
+            type: string
+          example: '[ "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;" ]'
         operator:
-          type: string
-          example: X 0 Y 1 Z 5 I 2
+          type: array
+          items:
+            $ref: '#/components/schemas/jobs.OperatorItem'
       required:
         - job_type
-        - code
+        - program
         - operator
     jobs.JobInfoSampling:
       type: object
@@ -660,33 +690,95 @@ components:
           type: string
           enum:
             - sampling
-        code:
-          type: string
-          example: OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;
+        program:
+          type: array
+          description: A list of OPENQASM3 program. For non-multiprogramming jobs, this field is assumed to contain exactly one program. Otherwise, those programs are combined according to the multiprogramming machinery.
+          items:
+            type: string
+          example: '[ "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;" ]'
       required:
         - job_type
-        - code
+        - program
     jobs.JobInfoDesc:
       type: object
       oneOf:
         - $ref: '#/components/schemas/jobs.JobInfoEstimation'
         - $ref: '#/components/schemas/jobs.JobInfoSampling'
+    jobs.JobResultEstimation:
+      type: object
+      properties:
+        job_type:
+          type: string
+          enum:
+            - estimation
+        exp_value:
+          type: array
+          items:
+            type: number
+          minItems: 1
+          maxItems: 2
+        stds:
+          description: The standard deviation value
+          type: number
+      required:
+        - job_type
+        - exp_value
+        - stds
+    jobs.JobResultSampling:
+      type: object
+      properties:
+        job_type:
+          type: string
+          enum:
+            - sampling
+        counts:
+          type: string
+          example: |-
+            {
+              "10": 84,
+              "11": 387,
+              "10": 454,
+              "01": 75
+            }
+      required:
+        - job_type
+        - counts
+    jobs.JobResultDesc:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/jobs.JobResultEstimation'
+        - $ref: '#/components/schemas/jobs.JobResultSampling'
+    jobs.JobResult:
+      type: object
+      properties:
+        desc:
+          $ref: '#/components/schemas/jobs.JobResultDesc'
+        divided_result:
+          type: object
+          description: Assumed to be used for multiprogramming, but currently not supported yet.
+          properties: {}
+        properties:
+          type: string
+        transpile_result:
+          type: object
+          properties:
+            virtual_physical_mapping:
+              type: string
+      required:
+        - desc
     jobs.JobInfo:
       type: object
       properties:
         desc:
           $ref: '#/components/schemas/jobs.JobInfoDesc'
-        transpiled_code:
+        transpiled_program:
           type: string
           example: OPENQASM 3; include "stdgates.inc"; qubit[2] _all_qubits; let q = _all_qubits[0:1]; h q[0]; cx q[0], q[1];
         result:
+          $ref: '#/components/schemas/jobs.JobResult'
+        message:
           type: string
-          description: The result of quantum computation, set only if the computation is successful.
-          example: |
-            { "11": 4980, "00": 5020 }
-        reason:
-          type: string
-          description: The reason indicating why there is no result
+          description: Describing the reason why there is no result
       required:
         - desc
     jobs.TranspilerInfo:

--- a/backend/oas/user/paths/jobs.yaml
+++ b/backend/oas/user/paths/jobs.yaml
@@ -125,7 +125,8 @@ jobs:
                   device_id: "Kawasaki",
                   job_info: {
                     job_type: "sampling",
-                    code: "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;"
+                    program:
+                      [ "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;" ]
                   },
                   transpiler_info: '{}',
                   simulator_info: '{ "n_qubits": 5, "n_nodes": 12, "n_per_node": 2, "seed_simulation": 39058567, "simulation_opt": {"optimization_method": "light", "optimization_block_size": 1, "optimization_swap_level": 1}}',
@@ -139,13 +140,24 @@ jobs:
               description: QPU example
               value:
                 {
-                  name: "Bell State Sampling",
-                  description: "Bell State Sampling Example",
+                  name: "Bell State Estimation",
+                  description: "Bell State Estimation Example",
                   device_id: "Kawasaki",
                   job_info: {
                     job_type: "estimation",
-                    code: "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;",
-                    operator: "X 0 Y 1 Z 5 I 2"
+                    program: [
+                      "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;",
+                    ],
+                    operator: [
+                      {
+                        pauli: "X 0 X 1",
+                        coeff: [1.5, 2.8]
+                      },
+                      {
+                        pauli: "Y 0 Z 1",
+                        coeff: [1.2, -2e-8]
+                      }
+                    ]
                   },
                   transpiler_info: '{"qubit_allocation": {"0": 12, "1": 16}, "skip_transpilation": false, "seed_transpilation": 873}',
                   simulator_info: '{}',

--- a/backend/oas/user/schemas/jobs.yaml
+++ b/backend/oas/user/schemas/jobs.yaml
@@ -31,19 +31,19 @@ jobs.JobInfoSampling:
       type: string
       enum:
         - sampling
-    code:
-      type: string
+    program:
+      type: array
+      description: >-
+        A list of OPENQASM3 program.
+        For non-multiprogramming jobs, this field is assumed to contain exactly one program.
+        Otherwise, those programs are combined according to the multiprogramming machinery.
+      items:
+        type: string
       example: >-
-        OPENQASM 3;
-        qubit[2] q;
-        bit[2] c;
-        h q[0];
-        cnot q[0], q[1];
-        c = measure q;
+          [ "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;" ]
   required:
     - job_type
-    - code
-
+    - program
 
 jobs.JobInfoEstimation:
   type: object
@@ -53,22 +53,41 @@ jobs.JobInfoEstimation:
       type: string
       enum:
         - estimation
-    code:
-      type: string
+    program:
+      type: array
+      description: >-
+        A list of OPENQASM3 program.
+        For non-multiprogramming jobs, this field is assumed to contain exactly one program.
+        Otherwise, those programs are combined according to the multiprogramming machinery.
+      items:
+        type: string
       example: >-
-        OPENQASM 3;
-        qubit[2] q;
-        bit[2] c;
-        h q[0];
-        cnot q[0], q[1];
-        c = measure q;
+          [ "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;" ]
     operator:
-      type: string
-      example: X 0 Y 1 Z 5 I 2
+      type: array
+      items:
+        $ref: "#/jobs.OperatorItem"
   required:
     - job_type
-    - code
+    - program
     - operator
+
+jobs.OperatorItem:
+  type: object
+  properties:
+    pauli:
+      type: string
+      description: The Pauli string.
+      example: "X 0 X 1"
+    coeff:
+      description: "Complex coefficient number in the Pauli string representation."
+      type: array
+      items:
+        type: number
+      minItems: 1
+      maxItems: 2
+  required:
+    - pauli
 
 jobs.JobInfoDesc:
   type: object
@@ -76,12 +95,78 @@ jobs.JobInfoDesc:
     - $ref: "#/jobs.JobInfoEstimation"
     - $ref: "#/jobs.JobInfoSampling"
 
+jobs.JobResultSampling:
+  type: object
+  properties:
+    job_type:
+      type: string
+      enum:
+        - "sampling"
+    counts:
+      type: string
+      example: >-
+        {
+          "10": 84,
+          "11": 387,
+          "10": 454,
+          "01": 75
+        }
+  required:
+    - job_type
+    - counts
+
+jobs.JobResultEstimation:
+  type: object
+  properties:
+    job_type:
+      type: string
+      enum:
+        - "estimation"
+    exp_value:
+      type: array
+      items:
+        type: number
+      minItems: 1
+      maxItems: 2
+    stds:
+      description: "The standard deviation value"
+      type: number
+  required:
+    - job_type
+    - exp_value
+    - stds
+
+jobs.JobResultDesc:
+  type: object
+  oneOf:
+    - $ref: "#/jobs.JobResultEstimation"
+    - $ref: "#/jobs.JobResultSampling"
+
+jobs.JobResult:
+  type: object
+  properties:
+    desc:
+      $ref: "#/jobs.JobResultDesc"
+    divided_result:
+      type: object
+      description: "Assumed to be used for multiprogramming, but currently not supported yet."
+      properties: {}
+    properties:
+      type: string
+    transpile_result:
+      type: object
+      properties:
+        virtual_physical_mapping:
+          type: string
+  required:
+    - desc
+
 jobs.JobInfo:
   type: object
   properties:
     desc:
       $ref: "#/jobs.JobInfoDesc"
-    transpiled_code:
+    transpiled_program:
       type: string
       example: >-
         OPENQASM 3;
@@ -91,13 +176,10 @@ jobs.JobInfo:
         h q[0];
         cx q[0], q[1];
     result:
+      $ref: "#/jobs.JobResult"
+    message:
       type: string
-      description: "The result of quantum computation, set only if the computation is successful."
-      example: |
-        { "11": 4980, "00": 5020 }
-    reason:
-      type: string
-      description: The reason indicating why there is no result
+      description: Describing the reason why there is no result
   required:
     - desc
 

--- a/backend/oqtopus_cloud/provider/routers/jobs.py
+++ b/backend/oqtopus_cloud/provider/routers/jobs.py
@@ -197,23 +197,24 @@ def update_job_info(
     )
 
     def patch_job_info(job_info: JobInfo) -> tuple[Optional[JobStatus], JobInfo]:
-        job_info.transpiled_code = request.transpiled_code
+        job_info.transpiled_program = request.transpiled_program
 
+        status = request.overwrite_status
         if request.result is not None:
             job_info.result = request.result
-            job_info.reason = None
-            return (JobStatus.succeeded, job_info)
+            job_info.message = None
+            return (status or JobStatus.succeeded, job_info)
 
-        elif request.reason is not None:
-            job_info.reason = request.reason
+        elif request.message is not None:
+            job_info.message = request.message
             job_info.result = None
-            return (JobStatus.failed, job_info)
+            return (status or JobStatus.failed, job_info)
 
-        return (None, job_info)
+        return (status, job_info)
 
-    if request.reason is not None and request.result is not None:
+    if request.message is not None and request.result is not None:
         return BadRequestResponse(
-            detail="You cannot specify both a result and a reason."
+            detail="You cannot specify both a result and a message."
         )
 
     try:
@@ -221,9 +222,20 @@ def update_job_info(
         model = db.execute(stmt).scalar_one_or_none()
         if model is None:
             return NotFoundErrorResponse("Job not found")
-        (status, job_info) = patch_job_info(
-            JobInfo.model_validate(json.loads(model.job_info))
-        )
+        job_info = JobInfo.model_validate(json.loads(model.job_info))
+
+        # The job result must be compatible with the job info.
+        if (
+            request.result is not None
+            and job_info.desc.job_type != request.result.desc.job_type
+        ):
+            return BadRequestResponse(
+                detail="The job result type is not compatible with job info."
+            )
+
+        # Calculate upodated job_info.
+        (status, job_info) = patch_job_info(job_info)
+
         model.job_info = JobInfo.model_dump_json(job_info)
         if status is not None:
             model.status = status

--- a/backend/oqtopus_cloud/provider/schemas/jobs.py
+++ b/backend/oqtopus_cloud/provider/schemas/jobs.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, RootModel
 
@@ -20,21 +20,35 @@ class JobStatus(str, Enum):
     cancelled = "cancelled"
 
 
+class OperatorItem(BaseModel):
+    pauli: Annotated[str, Field(examples=["X 0 X 1"])]
+    """
+    The Pauli string.
+    """
+    coeff: Annotated[list[float] | None, Field(max_length=2, min_length=1)] = None
+    """
+    Complex coefficient number in the Pauli string representation.
+    """
+
+
 class JobInfoEstimation(BaseModel):
     """
     The descriptor of estimation jobs
     """
 
     job_type: Literal["estimation"]
-    code: Annotated[
-        str,
+    program: Annotated[
+        list[str],
         Field(
             examples=[
-                "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;"
+                '[ "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;" ]'
             ]
         ),
     ]
-    operator: Annotated[str, Field(examples=["X 0 Y 1 Z 5 I 2"])]
+    """
+    A list of OPENQASM3 program. For non-multiprogramming jobs, this field is assumed to contain exactly one program. Otherwise, those programs are combined according to the multiprogramming machinery.
+    """
+    operator: list[OperatorItem]
 
 
 class JobInfoSampling(BaseModel):
@@ -43,19 +57,53 @@ class JobInfoSampling(BaseModel):
     """
 
     job_type: Literal["sampling"]
-    code: Annotated[
-        str,
+    program: Annotated[
+        list[str],
         Field(
             examples=[
-                "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;"
+                '[ "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;" ]'
             ]
         ),
     ]
+    """
+    A list of OPENQASM3 program. For non-multiprogramming jobs, this field is assumed to contain exactly one program. Otherwise, those programs are combined according to the multiprogramming machinery.
+    """
+
+
+class JobResultEstimation(BaseModel):
+    job_type: Literal["estimation"]
+    exp_value: Annotated[list[float], Field(max_length=2, min_length=1)]
+    stds: float
+    """
+    The standard deviation value
+    """
+
+
+class JobResultSampling(BaseModel):
+    job_type: Literal["sampling"]
+    counts: Annotated[
+        str,
+        Field(examples=['{\n  "10": 84,\n  "11": 387,\n  "10": 454,\n  "01": 75\n}']),
+    ]
+
+
+class TranspileResult(BaseModel):
+    virtual_physical_mapping: str | None = None
+
+
+class JobResult(BaseModel):
+    desc: JobResultEstimation | JobResultSampling
+    divided_result: dict[str, Any] | None = None
+    """
+    Assumed to be used for multiprogramming, but currently not supported yet.
+    """
+    properties: str | None = None
+    transpile_result: TranspileResult | None = None
 
 
 class JobInfo(BaseModel):
     desc: JobInfoEstimation | JobInfoSampling
-    transpiled_code: Annotated[
+    transpiled_program: Annotated[
         str | None,
         Field(
             examples=[
@@ -63,15 +111,10 @@ class JobInfo(BaseModel):
             ]
         ),
     ] = None
-    result: Annotated[
-        str | None, Field(examples=['{\n  "11": 4980,\n  "00": 5020\n}'])
-    ] = None
+    result: JobResult | None = None
+    message: str | None = None
     """
-    The result of quantum computation, set only if the computation is successful.
-    """
-    reason: str | None = None
-    """
-    The reason indicating why there is no result
+    Describing the reason why there is no result
     """
 
 
@@ -158,9 +201,17 @@ class JobStatusUpdateResponse(BaseModel):
 
 
 class UpdateJobInfoRequest(BaseModel):
-    transpiled_code: str | None = None
-    result: str | None = None
-    reason: str | None = None
+    overwrite_status: JobStatus | None = None
+    """
+    Overwrite the job status. Use with caution to avoid putting the job into an inconsistent state. If this field is not specified, the status will be updated automatically.
+    """
+    execution_time: float | None = None
+    """
+    Execution time for quantum computation. Specify the time in seconds, including up to milliseconds.
+    """
+    transpiled_program: str | None = None
+    result: JobResult | None = None
+    message: str | None = None
 
 
 class UpdateJobInfoResponse(BaseModel):

--- a/backend/oqtopus_cloud/user/schemas/jobs.py
+++ b/backend/oqtopus_cloud/user/schemas/jobs.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, RootModel
 
@@ -25,21 +25,35 @@ class JobStatus(str, Enum):
     cancelled = "cancelled"
 
 
+class OperatorItem(BaseModel):
+    pauli: Annotated[str, Field(examples=["X 0 X 1"])]
+    """
+    The Pauli string.
+    """
+    coeff: Annotated[list[float] | None, Field(max_length=2, min_length=1)] = None
+    """
+    Complex coefficient number in the Pauli string representation.
+    """
+
+
 class JobInfoEstimation(BaseModel):
     """
     The descriptor of estimation jobs
     """
 
     job_type: Literal["estimation"]
-    code: Annotated[
-        str,
+    program: Annotated[
+        list[str],
         Field(
             examples=[
-                "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;"
+                '[ "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;" ]'
             ]
         ),
     ]
-    operator: Annotated[str, Field(examples=["X 0 Y 1 Z 5 I 2"])]
+    """
+    A list of OPENQASM3 program. For non-multiprogramming jobs, this field is assumed to contain exactly one program. Otherwise, those programs are combined according to the multiprogramming machinery.
+    """
+    operator: list[OperatorItem]
 
 
 class JobInfoSampling(BaseModel):
@@ -48,19 +62,53 @@ class JobInfoSampling(BaseModel):
     """
 
     job_type: Literal["sampling"]
-    code: Annotated[
-        str,
+    program: Annotated[
+        list[str],
         Field(
             examples=[
-                "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;"
+                '[ "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;" ]'
             ]
         ),
     ]
+    """
+    A list of OPENQASM3 program. For non-multiprogramming jobs, this field is assumed to contain exactly one program. Otherwise, those programs are combined according to the multiprogramming machinery.
+    """
+
+
+class JobResultEstimation(BaseModel):
+    job_type: Literal["estimation"]
+    exp_value: Annotated[list[float], Field(max_length=2, min_length=1)]
+    stds: float
+    """
+    The standard deviation value
+    """
+
+
+class JobResultSampling(BaseModel):
+    job_type: Literal["sampling"]
+    counts: Annotated[
+        str,
+        Field(examples=['{\n  "10": 84,\n  "11": 387,\n  "10": 454,\n  "01": 75\n}']),
+    ]
+
+
+class TranspileResult(BaseModel):
+    virtual_physical_mapping: str | None = None
+
+
+class JobResult(BaseModel):
+    desc: JobResultEstimation | JobResultSampling
+    divided_result: dict[str, Any] | None = None
+    """
+    Assumed to be used for multiprogramming, but currently not supported yet.
+    """
+    properties: str | None = None
+    transpile_result: TranspileResult | None = None
 
 
 class JobInfo(BaseModel):
     desc: JobInfoEstimation | JobInfoSampling
-    transpiled_code: Annotated[
+    transpiled_program: Annotated[
         str | None,
         Field(
             examples=[
@@ -68,15 +116,10 @@ class JobInfo(BaseModel):
             ]
         ),
     ] = None
-    result: Annotated[str | None, Field(examples=['{ "11": 4980, "00": 5020 }\n'])] = (
-        None
-    )
+    result: JobResult | None = None
+    message: str | None = None
     """
-    The result of quantum computation, set only if the computation is successful.
-    """
-    reason: str | None = None
-    """
-    The reason indicating why there is no result
+    Describing the reason why there is no result
     """
 
 

--- a/backend/tests/oqtopus_cloud/provider/routers/test_jobs.py
+++ b/backend/tests/oqtopus_cloud/provider/routers/test_jobs.py
@@ -20,6 +20,9 @@ from oqtopus_cloud.provider.schemas.jobs import (
     JobDef,
     JobInfo,
     JobInfoSampling,
+    JobResult,
+    JobResultEstimation,
+    JobResultSampling,
     JobStatus,
     JobStatusUpdate,
     JobStatusUpdateResponse,
@@ -80,7 +83,7 @@ def _get_job_model(n: int) -> Job:
             {
                 "desc": {
                     "job_type": "sampling",
-                    "code": "code",
+                    "program": ["code"],
                 }
             }
         ),
@@ -108,7 +111,7 @@ def _get_job_model_2() -> Job:
             {
                 "desc": {
                     "job_type": "sampling",
-                    "code": "code",
+                    "program": ["code"],
                 }
             }
         ),
@@ -138,6 +141,7 @@ def test_get_jobs(test_db: Session):
         assert job.status == "submitted"
 
     jobs = get_jobs(device_id=device_id, db=test_db)
+    assert isinstance(jobs, list)
     assert jobs[0].device_id == device_id
     assert jobs[0].status == "ready"
 
@@ -162,14 +166,14 @@ def test_get_jobs_filtering(test_db: Session):
             job_id="testjob1id",
             description="test job 1",
             job_info=JobInfo(
-                desc=JobInfoSampling(job_type="sampling", code="code"),
+                desc=JobInfoSampling(job_type="sampling", program=["code"]),
             ),
         ),
         GetJobsResponse(
             job_id="testjob2id",
             description="test job 2",
             job_info=JobInfo(
-                desc=JobInfoSampling(job_type="sampling", code="code"),
+                desc=JobInfoSampling(job_type="sampling", program=["code"]),
             ),
         ),
     ]
@@ -268,12 +272,30 @@ def test_update_job_info_400(test_db: Session):
     test_db.commit()
 
     # Submitting
-    result = json.dumps({"field1": "value", "field2": "value2"})
-    reason = "Oops! Job failed!"
-    body = UpdateJobInfoRequest(
-        result=result,
-        reason=reason,
+    result = JobResult(
+        desc=JobResultSampling(
+            job_type="sampling", counts=json.dumps({"00": 1, "01": 2, "11": 3, "10": 4})
+        ),
     )
+    message = "Oops! Job failed!"
+    body = UpdateJobInfoRequest(result=result, message=message)
+    submit_resp = client.patch(
+        f"/jobs/{job_model.id}/job_info", content=body.model_dump_json()
+    )
+    assert submit_resp.status_code == 400
+
+
+def test_update_job_info_result_compat(test_db: Session):
+    job_model = _get_job_model(1)
+    test_db.add(_get_device_model())
+    test_db.add(job_model)
+    test_db.commit()
+
+    # Submitting
+    result = JobResult(
+        desc=JobResultEstimation(job_type="estimation", exp_value=[1.0, 0.0], stds=0.0),
+    )
+    body = UpdateJobInfoRequest(result=result)
     submit_resp = client.patch(
         f"/jobs/{job_model.id}/job_info", content=body.model_dump_json()
     )
@@ -288,11 +310,15 @@ def test_update_job_info_result(test_db: Session):
     test_db.commit()
 
     # Submitting
-    result = json.dumps({"field1": "value", "field2": "value2"})
+    result = JobResult(
+        desc=JobResultSampling(
+            job_type="sampling", counts=json.dumps({"00": 1, "01": 2, "11": 3, "10": 4})
+        ),
+    )
     transpiled_code = "transpiled_code"
     body = UpdateJobInfoRequest(
         result=result,
-        transpiled_code=transpiled_code,
+        transpiled_program=transpiled_code,
     )
     submit_resp = client.patch(
         f"/jobs/{job_model.id}/job_info", content=body.model_dump_json()
@@ -303,7 +329,7 @@ def test_update_job_info_result(test_db: Session):
     aft_job_info = aft_job.job_info
     assert bef_job_info.desc == aft_job_info.desc
     assert aft_job_info.result == result
-    assert aft_job_info.reason is None
+    assert aft_job_info.message is None
     assert aft_job.status == JobStatus.succeeded
 
 
@@ -315,9 +341,9 @@ def test_update_job_info_reason(test_db: Session):
     test_db.commit()
 
     # Submitting
-    reason = "Oops, job failed!"
+    message = "Oops, job failed!"
     body = UpdateJobInfoRequest(
-        reason=reason,
+        message=message,
     )
     submit_resp = client.patch(
         f"/jobs/{job_model.id}/job_info", content=body.model_dump_json()
@@ -327,7 +353,7 @@ def test_update_job_info_reason(test_db: Session):
     aft_job = JobDef.model_validate(get_resp.json())
     aft_job_info = aft_job.job_info
     assert bef_job_info.desc == aft_job_info.desc
-    assert aft_job_info.reason == reason
+    assert aft_job_info.message == message
     assert aft_job_info.result is None
     assert aft_job.status == JobStatus.failed
 

--- a/backend/tests/oqtopus_cloud/user/routers/test_jobs.py
+++ b/backend/tests/oqtopus_cloud/user/routers/test_jobs.py
@@ -43,7 +43,7 @@ def _get_model(n: int) -> Job:
             {
                 "desc": {
                     "job_type": "sampling",
-                    "code": "code",
+                    "program": ["code"],
                 }
             }
         ),
@@ -97,7 +97,7 @@ def test_get_jobs_simple(
             device_id="Kawasaki",
             job_type=JobType.sampling,
             job_info=JobInfo(
-                desc=JobInfoSampling(job_type="sampling", code="code"),
+                desc=JobInfoSampling(job_type="sampling", program=["code"]),
             ),
             transpiler_info=json.dumps({"this_is": "transpiler_info"}),
             simulator_info=json.dumps({"this_is": "simulator_info"}),
@@ -116,7 +116,7 @@ def test_get_jobs_simple(
             device_id="Kawasaki",
             job_type=JobType.sampling,
             job_info=JobInfo(
-                desc=JobInfoSampling(job_type="sampling", code="code"),
+                desc=JobInfoSampling(job_type="sampling", program=["code"]),
             ),
             transpiler_info=json.dumps({"this_is": "transpiler_info"}),
             simulator_info=json.dumps({"this_is": "simulator_info"}),
@@ -213,7 +213,7 @@ def test_get_jobs_filtering_startTime(
             device_id="Kawasaki",
             job_type=JobType.sampling,
             job_info=JobInfo(
-                desc=JobInfoSampling(job_type="sampling", code="code"),
+                desc=JobInfoSampling(job_type="sampling", program=["code"]),
             ),
             transpiler_info=json.dumps({"this_is": "transpiler_info"}),
             simulator_info=json.dumps({"this_is": "simulator_info"}),
@@ -254,7 +254,7 @@ def test_get_jobs_filtering_endTime(
             device_id="Kawasaki",
             job_type=JobType.sampling,
             job_info=JobInfo(
-                desc=JobInfoSampling(job_type="sampling", code="code"),
+                desc=JobInfoSampling(job_type="sampling", program=["code"]),
             ),
             transpiler_info=json.dumps({"this_is": "transpiler_info"}),
             simulator_info=json.dumps({"this_is": "simulator_info"}),
@@ -295,7 +295,7 @@ def test_get_jobs_filtering_search_string(
             device_id="Kawasaki",
             job_type=JobType.sampling,
             job_info=JobInfo(
-                desc=JobInfoSampling(job_type="sampling", code="code"),
+                desc=JobInfoSampling(job_type="sampling", program=["code"]),
             ),
             transpiler_info=json.dumps({"this_is": "transpiler_info"}),
             simulator_info=json.dumps({"this_is": "simulator_info"}),
@@ -336,7 +336,7 @@ def test_get_jobs_desc_order(
             device_id="Kawasaki",
             job_type=JobType.sampling,
             job_info=JobInfo(
-                desc=JobInfoSampling(job_type="sampling", code="code"),
+                desc=JobInfoSampling(job_type="sampling", program=["code"]),
             ),
             transpiler_info=json.dumps({"this_is": "transpiler_info"}),
             simulator_info=json.dumps({"this_is": "simulator_info"}),
@@ -355,7 +355,7 @@ def test_get_jobs_desc_order(
             device_id="Kawasaki",
             job_type=JobType.sampling,
             job_info=JobInfo(
-                desc=JobInfoSampling(job_type="sampling", code="code"),
+                desc=JobInfoSampling(job_type="sampling", program=["code"]),
             ),
             transpiler_info=json.dumps({"this_is": "transpiler_info"}),
             simulator_info=json.dumps({"this_is": "simulator_info"}),
@@ -426,14 +426,14 @@ def test_get_jobs_all_parameters(
             job_id="testjob3id",
             description="test job 3",
             job_info=JobInfo(
-                desc=JobInfoSampling(job_type="sampling", code="code"),
+                desc=JobInfoSampling(job_type="sampling", program=["code"]),
             ),
         ),
         GetJobsResponse(
             job_id="testjob2id",
             description="test job 2",
             job_info=JobInfo(
-                desc=JobInfoSampling(job_type="sampling", code="code"),
+                desc=JobInfoSampling(job_type="sampling", program=["code"]),
             ),
         ),
     ]
@@ -448,7 +448,7 @@ def test_job_sortedness(test_db):
             name=f"test-job-{n}",
             device_id="Kawasaki",
             status=JobStatus.submitted,
-            job_info=JobInfoSampling(job_type="sampling", code="code"),
+            job_info=JobInfoSampling(job_type="sampling", program=["code"]),
             simulator_info="{}",
             transpiler_info="{}",
             mitigation_info="{}",
@@ -495,7 +495,7 @@ def test_get_jobs_handler(
         device_id="Kawasaki",
         job_type=JobType.sampling,
         job_info=JobInfo(
-            desc=JobInfoSampling(job_type="sampling", code="code"),
+            desc=JobInfoSampling(job_type="sampling", program=["code"]),
         ),
         transpiler_info=json.dumps({"this_is": "transpiler_info"}),
         simulator_info=json.dumps({"this_is": "simulator_info"}),
@@ -559,7 +559,7 @@ def test_submit_get(
         name="submit-job-test",
         description="Submit job test",
         device_id="Kawasaki",
-        job_info=JobInfoSampling(job_type="sampling", code="codecodecode"),
+        job_info=JobInfoSampling(job_type="sampling", program=["codecodecode"]),
         mitigation_info=json.dumps(
             {
                 "field1": "value1",
@@ -604,7 +604,7 @@ def test_submit_delete(test_db):
         name="submit-job-test",
         description="Submit job test",
         device_id="Kawasaki",
-        job_info=JobInfoSampling(job_type="sampling", code="codecodecode"),
+        job_info=JobInfoSampling(job_type="sampling", program=["codecodecode"]),
         mitigation_info=json.dumps(
             {
                 "field1": "value1",

--- a/docs/oas/user/openapi.yaml
+++ b/docs/oas/user/openapi.yaml
@@ -203,7 +203,8 @@ paths:
                   device_id: Kawasaki
                   job_info:
                     job_type: sampling
-                    code: OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;
+                    program:
+                      - OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;
                   transpiler_info: '{}'
                   simulator_info: '{ "n_qubits": 5, "n_nodes": 12, "n_per_node": 2, "seed_simulation": 39058567, "simulation_opt": {"optimization_method": "light", "optimization_block_size": 1, "optimization_swap_level": 1}}'
                   mitigation_info: '{}'
@@ -214,13 +215,22 @@ paths:
               qpu:
                 description: QPU example
                 value:
-                  name: Bell State Sampling
-                  description: Bell State Sampling Example
+                  name: Bell State Estimation
+                  description: Bell State Estimation Example
                   device_id: Kawasaki
                   job_info:
                     job_type: estimation
-                    code: OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;
-                    operator: X 0 Y 1 Z 5 I 2
+                    program:
+                      - OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;
+                    operator:
+                      - pauli: X 0 X 1
+                        coeff:
+                          - 1.5
+                          - 2.8
+                      - pauli: Y 0 Z 1
+                        coeff:
+                          - 1.2
+                          - -2.e-8
                   transpiler_info: '{"qubit_allocation": {"0": 12, "1": 16}, "skip_transpilation": false, "seed_transpilation": 873}'
                   simulator_info: '{}'
                   mitigation_info: '{"ro_error_mitigation": "pseudo_inverse"}'
@@ -634,6 +644,22 @@ components:
         - failed
         - cancelled
       example: submitted
+    jobs.OperatorItem:
+      type: object
+      properties:
+        pauli:
+          type: string
+          description: The Pauli string.
+          example: X 0 X 1
+        coeff:
+          description: Complex coefficient number in the Pauli string representation.
+          type: array
+          items:
+            type: number
+          minItems: 1
+          maxItems: 2
+      required:
+        - pauli
     jobs.JobInfoEstimation:
       type: object
       description: The descriptor of estimation jobs
@@ -642,15 +668,19 @@ components:
           type: string
           enum:
             - estimation
-        code:
-          type: string
-          example: OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;
+        program:
+          type: array
+          description: A list of OPENQASM3 program. For non-multiprogramming jobs, this field is assumed to contain exactly one program. Otherwise, those programs are combined according to the multiprogramming machinery.
+          items:
+            type: string
+          example: '[ "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;" ]'
         operator:
-          type: string
-          example: X 0 Y 1 Z 5 I 2
+          type: array
+          items:
+            $ref: '#/components/schemas/jobs.OperatorItem'
       required:
         - job_type
-        - code
+        - program
         - operator
     jobs.JobInfoSampling:
       type: object
@@ -660,33 +690,95 @@ components:
           type: string
           enum:
             - sampling
-        code:
-          type: string
-          example: OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;
+        program:
+          type: array
+          description: A list of OPENQASM3 program. For non-multiprogramming jobs, this field is assumed to contain exactly one program. Otherwise, those programs are combined according to the multiprogramming machinery.
+          items:
+            type: string
+          example: '[ "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;" ]'
       required:
         - job_type
-        - code
+        - program
     jobs.JobInfoDesc:
       type: object
       oneOf:
         - $ref: '#/components/schemas/jobs.JobInfoEstimation'
         - $ref: '#/components/schemas/jobs.JobInfoSampling'
+    jobs.JobResultEstimation:
+      type: object
+      properties:
+        job_type:
+          type: string
+          enum:
+            - estimation
+        exp_value:
+          type: array
+          items:
+            type: number
+          minItems: 1
+          maxItems: 2
+        stds:
+          description: The standard deviation value
+          type: number
+      required:
+        - job_type
+        - exp_value
+        - stds
+    jobs.JobResultSampling:
+      type: object
+      properties:
+        job_type:
+          type: string
+          enum:
+            - sampling
+        counts:
+          type: string
+          example: |-
+            {
+              "10": 84,
+              "11": 387,
+              "10": 454,
+              "01": 75
+            }
+      required:
+        - job_type
+        - counts
+    jobs.JobResultDesc:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/jobs.JobResultEstimation'
+        - $ref: '#/components/schemas/jobs.JobResultSampling'
+    jobs.JobResult:
+      type: object
+      properties:
+        desc:
+          $ref: '#/components/schemas/jobs.JobResultDesc'
+        divided_result:
+          type: object
+          description: Assumed to be used for multiprogramming, but currently not supported yet.
+          properties: {}
+        properties:
+          type: string
+        transpile_result:
+          type: object
+          properties:
+            virtual_physical_mapping:
+              type: string
+      required:
+        - desc
     jobs.JobInfo:
       type: object
       properties:
         desc:
           $ref: '#/components/schemas/jobs.JobInfoDesc'
-        transpiled_code:
+        transpiled_program:
           type: string
           example: OPENQASM 3; include "stdgates.inc"; qubit[2] _all_qubits; let q = _all_qubits[0:1]; h q[0]; cx q[0], q[1];
         result:
+          $ref: '#/components/schemas/jobs.JobResult'
+        message:
           type: string
-          description: The result of quantum computation, set only if the computation is successful.
-          example: |
-            { "11": 4980, "00": 5020 }
-        reason:
-          type: string
-          description: The reason indicating why there is no result
+          description: Describing the reason why there is no result
       required:
         - desc
     jobs.TranspilerInfo:


### PR DESCRIPTION
# 📃 Ticket
 - https://github.com/FujitsuResearch/QuantumCloudPlatform/issues/284
 - https://github.com/FujitsuResearch/QuantumCloudPlatform/issues/285
<!--- Paste related ticket -->

## ✍ Description

This PR brings some breaking changes:
  - The OAS has been updated to explicitly define the shape of job_info, especially for the job result. 
  - According to the changes in the definition of job_info, the request parameter for `PATCH /jobs/{job_id}/job_info`  is also changed. 
  - Currently, job status is automatically updated during patching job_info. In addition to this, one can manually overwrite the job status to arbitrary value within `PATCH /jobs/{job_id}/job_info` request. 

## 📸 Test Result

See the result of GitHub Actions.

## 🔗 Related PRs
<!--- Paste related PRs -->
