### PR TITLE
refactor: unify OpenAPI responses from 'details' or 'message' to 'message'

### DIFF
--- a/backend/oas/provider/openapi.yaml
+++ b/backend/oas/provider/openapi.yaml
@@ -70,7 +70,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.BadRequest'
               example:
-                detail: Bad request malformed input data
+                message: Bad request malformed input data
         '404':
           description: Not Found
           content:
@@ -78,7 +78,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.NotFoundError'
               example:
-                detail: Device not found
+                message: Device not found
         '500':
           description: Internal Server Error
           content:
@@ -86,7 +86,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.InternalServerError'
               example:
-                detail: Internal server error
+                message: Internal server error
   /jobs:
     get:
       tags:
@@ -149,7 +149,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.BadRequest'
               example:
-                detail: Bad request malformed input data
+                message: Bad request malformed input data
         '500':
           description: Internal Server Error
           content:
@@ -157,7 +157,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.InternalServerError'
               example:
-                detail: Internal server error
+                message: Internal server error
   /jobs/{job_id}:
     get:
       summary: Get a job by ID
@@ -187,7 +187,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.BadRequest'
               example:
-                detail: Bad request malformed input data
+                message: Bad request malformed input data
         '404':
           description: Not Found
           content:
@@ -195,7 +195,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.NotFoundError'
               example:
-                detail: job not found
+                message: job not found
     patch:
       summary: Modify selected quantum job (update status).
       description: Used by device to set job status to "running".<br/>Other statuses are set by CloudAPI automatically when result is created
@@ -232,7 +232,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.NotFoundError'
               example:
-                detail: Job not found
+                message: Job not found
         '409':
           description: Returned when the specified job is not in a status thatt allows transition to the requested status.
           content:
@@ -240,7 +240,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.ConflictError'
               example:
-                detail: The specified job is not in a status thatt allows transition to the requested status.
+                message: The specified job is not in a status thatt allows transition to the requested status.
   /jobs/{job_id}/job_info:
     patch:
       summary: Update selected quantum job's job_info by placing job results
@@ -280,7 +280,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.BadRequest'
               example:
-                detail: Bad request malformed input data
+                message: Bad request malformed input data
         '404':
           description: Not Found
           content:
@@ -288,7 +288,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.NotFoundError'
               example:
-                detail: Job not found
+                message: Job not found
 components:
   schemas:
     devices.DeviceStatusUpdate:
@@ -368,24 +368,24 @@ components:
     error.BadRequest:
       type: object
       properties:
-        detail:
+        message:
           type: string
       required:
-        - detail
+        - message
     error.NotFoundError:
       type: object
       properties:
-        detail:
+        message:
           type: string
       required:
-        - detail
+        - message
     error.InternalServerError:
       type: object
       properties:
-        detail:
+        message:
           type: string
       required:
-        - detail
+        - message
     jobs.JobStatus:
       type: string
       enum:
@@ -686,10 +686,10 @@ components:
     error.ConflictError:
       type: object
       properties:
-        detail:
+        message:
           type: string
       required:
-        - detail
+        - message
     jobs.UpdateJobInfoRequest:
       type: object
       properties:

--- a/backend/oas/provider/paths/devices.yaml
+++ b/backend/oas/provider/paths/devices.yaml
@@ -70,7 +70,7 @@ devices.deviceId:
               schema:
                 $ref: '../schemas/error.yaml#/error.BadRequest'
               example:
-                detail: Bad request malformed input data
+                message: Bad request malformed input data
         '404':
           description: Not Found
           content:
@@ -78,7 +78,7 @@ devices.deviceId:
               schema:
                 $ref: '../schemas/error.yaml#/error.NotFoundError'
               example:
-                detail: Device not found
+                message: Device not found
         '500':
           description: Internal Server Error
           content:
@@ -86,4 +86,4 @@ devices.deviceId:
               schema:
                 $ref: '../schemas/error.yaml#/error.InternalServerError'
               example:
-                detail: Internal server error
+                message: Internal server error

--- a/backend/oas/provider/paths/hello.yaml
+++ b/backend/oas/provider/paths/hello.yaml
@@ -22,7 +22,7 @@ hello:
             schema:
               $ref: '../schemas/error.yaml#/error.InternalServerError'
             example:
-              detail: システムエラーが発生しました。
+              message: システムエラーが発生しました。
 
 hello.name:
   get:
@@ -55,7 +55,7 @@ hello.name:
             schema:
               $ref: '../schemas/error.yaml#/error.BadRequest'
             example:
-              detail: invalid task_id
+              message: invalid task_id
       '500':
         description: Internal Server Error
         content:
@@ -63,5 +63,5 @@ hello.name:
             schema:
               $ref: '../schemas/error.yaml#/error.InternalServerError'
             example:
-              detail: internal server error
+              message: internal server error
 

--- a/backend/oas/provider/paths/jobs.yaml
+++ b/backend/oas/provider/paths/jobs.yaml
@@ -54,7 +54,7 @@ jobs:
             schema:
               $ref: "../schemas/error.yaml#/error.BadRequest"
             example:
-              detail: Bad request malformed input data
+              message: Bad request malformed input data
       "500":
         description: Internal Server Error
         content:
@@ -62,7 +62,7 @@ jobs:
             schema:
               $ref: "../schemas/error.yaml#/error.InternalServerError"
             example:
-              detail: Internal server error
+              message: Internal server error
 
 jobs.jobId:
   get:
@@ -92,7 +92,7 @@ jobs.jobId:
             schema:
               $ref: "../schemas/error.yaml#/error.BadRequest"
             example:
-              detail: Bad request malformed input data
+              message: Bad request malformed input data
       "404":
         description: Not Found
         content:
@@ -100,7 +100,7 @@ jobs.jobId:
             schema:
               $ref: "../schemas/error.yaml#/error.NotFoundError"
             example:
-              detail: job not found
+              message: job not found
   patch:
     summary: "Modify selected quantum job (update status)."
     description: 'Used by device to set job status to "running".<br/>Other statuses are set by CloudAPI automatically when result is created'
@@ -136,7 +136,7 @@ jobs.jobId:
             schema:
               $ref: "../schemas/error.yaml#/error.NotFoundError"
             example:
-              detail: Job not found
+              message: Job not found
       "409":
         description: Returned when the specified job is not in a status thatt allows transition to the requested status.
         content:
@@ -144,7 +144,7 @@ jobs.jobId:
             schema:
               $ref: "../schemas/error.yaml#/error.ConflictError"
             example:
-              detail: The specified job is not in a status thatt allows transition to the requested status.
+              message: The specified job is not in a status thatt allows transition to the requested status.
 jobs.jobInfo:
   patch:
     summary: "Update selected quantum job's job_info by placing job results"
@@ -183,7 +183,7 @@ jobs.jobInfo:
             schema:
               $ref: "../schemas/error.yaml#/error.BadRequest"
             example:
-              detail: Bad request malformed input data
+              message: Bad request malformed input data
       "404":
         description: Not Found
         content:
@@ -191,4 +191,4 @@ jobs.jobInfo:
             schema:
               $ref: "../schemas/error.yaml#/error.NotFoundError"
             example:
-              detail: Job not found
+              message: Job not found

--- a/backend/oas/provider/schemas/error.yaml
+++ b/backend/oas/provider/schemas/error.yaml
@@ -1,28 +1,28 @@
 error.BadRequest:
   type: object
   properties:
-    detail:
+    message:
       type: string
   required:
-    - detail
+    - message
 error.InternalServerError:
   type: object
   properties:
-    detail:
+    message:
       type: string
   required:
-    - detail
+    - message
 error.NotFoundError:
   type: object
   properties:
-    detail:
+    message:
       type: string
   required:
-    - detail
+    - message
 error.ConflictError:
   type: object
   properties:
-    detail:
+    message:
       type: string
   required:
-    - detail
+    - message

--- a/backend/oas/user/openapi.yaml
+++ b/backend/oas/user/openapi.yaml
@@ -38,7 +38,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.UnauthorizedError'
               example:
-                detail: Unauthorized
+                message: Unauthorized
         '500':
           description: Internal Server Error
           content:
@@ -179,7 +179,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.UnauthorizedError'
               example:
-                detail: Unauthorized
+                message: Unauthorized
     post:
       tags:
         - job
@@ -244,7 +244,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.BadRequest'
               example:
-                detail: Bad request malformed input data
+                message: Bad request malformed input data
         '401':
           description: Unauthorized
           content:
@@ -252,7 +252,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.UnauthorizedError'
               example:
-                detail: Unauthorized
+                message: Unauthorized
   /jobs/{job_id}:
     get:
       tags:
@@ -283,7 +283,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.BadRequest'
               example:
-                detail: Bad request malformed input data
+                message: Bad request malformed input data
         '401':
           description: Unauthorized
           content:
@@ -291,7 +291,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.UnauthorizedError'
               example:
-                detail: Unauthorized
+                message: Unauthorized
         '404':
           description: Not Found
           content:
@@ -299,7 +299,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.NotFoundError'
               example:
-                detail: job not found
+                message: job not found
     delete:
       tags:
         - job
@@ -331,7 +331,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.BadRequest'
               example:
-                detail: Bad request malformed input data
+                message: Bad request malformed input data
         '401':
           description: Unauthorized
           content:
@@ -339,7 +339,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.UnauthorizedError'
               example:
-                detail: Unauthorized
+                message: Unauthorized
         '404':
           description: Not Found
           content:
@@ -347,7 +347,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.NotFoundError'
               example:
-                detail: job not found
+                message: job not found
   /jobs/{job_id}/status:
     get:
       tags:
@@ -378,7 +378,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.BadRequest'
               example:
-                detail: Bad request malformed input data
+                message: Bad request malformed input data
         '401':
           description: Unauthorized
           content:
@@ -386,7 +386,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.UnauthorizedError'
               example:
-                detail: Unauthorized
+                message: Unauthorized
         '404':
           description: Not Found
           content:
@@ -394,7 +394,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.NotFoundError'
               example:
-                detail: job not found
+                message: job not found
   /jobs/{job_id}/cancel:
     post:
       tags:
@@ -427,7 +427,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.BadRequest'
               example:
-                detail: Bad request malformed input data
+                message: Bad request malformed input data
         '401':
           description: Unauthorized
           content:
@@ -435,7 +435,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.UnauthorizedError'
               example:
-                detail: Unauthorized
+                message: Unauthorized
         '404':
           description: Not Found
           content:
@@ -443,7 +443,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error.NotFoundError'
               example:
-                detail: job not found
+                message: job not found
 components:
   securitySchemes:
     BearerAuth:
@@ -597,24 +597,24 @@ components:
     error.UnauthorizedError:
       type: object
       properties:
-        detail:
+        message:
           type: string
       required:
-        - detail
+        - message
     error.InternalServerError:
       type: object
       properties:
-        detail:
+        message:
           type: string
       required:
-        - detail
+        - message
     error.NotFoundError:
       type: object
       properties:
-        detail:
+        message:
           type: string
       required:
-        - detail
+        - message
     jobs.JobId:
       type: string
       example: 7af020f6-2e38-4d70-8cf0-4349650ea08c
@@ -846,10 +846,10 @@ components:
     error.BadRequest:
       type: object
       properties:
-        detail:
+        message:
           type: string
       required:
-        - detail
+        - message
     jobs.JobDef:
       type: object
       properties:

--- a/backend/oas/user/paths/devices.yaml
+++ b/backend/oas/user/paths/devices.yaml
@@ -28,7 +28,7 @@ devices:
             schema:
               $ref: '../schemas/error.yaml#/error.UnauthorizedError'
             example:
-              detail: Unauthorized
+              message: Unauthorized
       '500':
         description: Internal Server Error
         content:

--- a/backend/oas/user/paths/jobs.yaml
+++ b/backend/oas/user/paths/jobs.yaml
@@ -100,7 +100,7 @@ jobs:
             schema:
               $ref: '../schemas/error.yaml#/error.UnauthorizedError'
             example:
-              detail: Unauthorized
+              message: Unauthorized
   post:
     tags:
       - job
@@ -172,7 +172,7 @@ jobs:
             schema:
               $ref: "../schemas/error.yaml#/error.BadRequest"
             example:
-              detail: Bad request malformed input data
+              message: Bad request malformed input data
       "401":
         description: Unauthorized
         content:
@@ -180,7 +180,7 @@ jobs:
             schema:
               $ref: "../schemas/error.yaml#/error.UnauthorizedError"
             example:
-              detail: Unauthorized
+              message: Unauthorized
 
 jobs.jobId:
   get:
@@ -211,7 +211,7 @@ jobs.jobId:
             schema:
               $ref: "../schemas/error.yaml#/error.BadRequest"
             example:
-              detail: Bad request malformed input data
+              message: Bad request malformed input data
       "401":
         description: Unauthorized
         content:
@@ -219,7 +219,7 @@ jobs.jobId:
             schema:
               $ref: "../schemas/error.yaml#/error.UnauthorizedError"
             example:
-              detail: Unauthorized
+              message: Unauthorized
       "404":
         description: Not Found
         content:
@@ -227,7 +227,7 @@ jobs.jobId:
             schema:
               $ref: "../schemas/error.yaml#/error.NotFoundError"
             example:
-              detail: job not found
+              message: job not found
   delete:
     tags:
       - job
@@ -258,7 +258,7 @@ jobs.jobId:
             schema:
               $ref: "../schemas/error.yaml#/error.BadRequest"
             example:
-              detail: Bad request malformed input data
+              message: Bad request malformed input data
       "401":
         description: Unauthorized
         content:
@@ -266,7 +266,7 @@ jobs.jobId:
             schema:
               $ref: "../schemas/error.yaml#/error.UnauthorizedError"
             example:
-              detail: Unauthorized
+              message: Unauthorized
       "404":
         description: Not Found
         content:
@@ -274,7 +274,7 @@ jobs.jobId:
             schema:
               $ref: "../schemas/error.yaml#/error.NotFoundError"
             example:
-              detail: job not found
+              message: job not found
 
 jobs.jobId.status:
   get:
@@ -305,7 +305,7 @@ jobs.jobId.status:
             schema:
               $ref: "../schemas/error.yaml#/error.BadRequest"
             example:
-              detail: Bad request malformed input data
+              message: Bad request malformed input data
       "401":
         description: Unauthorized
         content:
@@ -313,7 +313,7 @@ jobs.jobId.status:
             schema:
               $ref: "../schemas/error.yaml#/error.UnauthorizedError"
             example:
-              detail: Unauthorized
+              message: Unauthorized
       "404":
         description: Not Found
         content:
@@ -321,7 +321,7 @@ jobs.jobId.status:
             schema:
               $ref: "../schemas/error.yaml#/error.NotFoundError"
             example:
-              detail: job not found
+              message: job not found
 
 jobs.jobId.cancel:
   post:
@@ -354,7 +354,7 @@ jobs.jobId.cancel:
             schema:
               $ref: "../schemas/error.yaml#/error.BadRequest"
             example:
-              detail: Bad request malformed input data
+              message: Bad request malformed input data
       "401":
         description: Unauthorized
         content:
@@ -362,7 +362,7 @@ jobs.jobId.cancel:
             schema:
               $ref: "../schemas/error.yaml#/error.UnauthorizedError"
             example:
-              detail: Unauthorized
+              message: Unauthorized
       "404":
         description: Not Found
         content:
@@ -370,4 +370,4 @@ jobs.jobId.cancel:
             schema:
               $ref: "../schemas/error.yaml#/error.NotFoundError"
             example:
-              detail: job not found
+              message: job not found

--- a/backend/oas/user/schemas/error.yaml
+++ b/backend/oas/user/schemas/error.yaml
@@ -1,28 +1,28 @@
 error.BadRequest:
   type: object
   properties:
-    detail:
+    message:
       type: string
   required:
-    - detail
+    - message
 error.UnauthorizedError:
   type: object
   properties:
-    detail:
+    message:
       type: string
   required:
-    - detail
+    - message
 error.NotFoundError:
   type: object
   properties:
-    detail:
+    message:
       type: string
   required:
-    - detail
+    - message
 error.InternalServerError:
   type: object
   properties:
-    detail:
+    message:
       type: string
   required:
-    - detail
+    - message

--- a/backend/oqtopus_cloud/provider/routers/devices.py
+++ b/backend/oqtopus_cloud/provider/routers/devices.py
@@ -18,9 +18,9 @@ from oqtopus_cloud.provider.schemas.devices import (
 )
 from oqtopus_cloud.provider.schemas.errors import (
     BadRequestResponse,
-    Detail,
     ErrorResponse,
     InternalServerErrorResponse,
+    Message,
     NotFoundErrorResponse,
 )
 from sqlalchemy.orm import Session
@@ -122,9 +122,9 @@ def update_device_calibration(
     if device.device_type != DeviceType.QPU.value:
         return BadRequestResponse("Calibration is only supported for QPU devices")
     if device_info is None:
-        return BadRequestResponse(detail="device_info is required")
+        return BadRequestResponse(message="device_info is required")
     if calibrated_at is None:
-        return BadRequestResponse(detail="calibrated_at is required")
+        return BadRequestResponse(message="calibrated_at is required")
     # device.calibration_data = calibration_data.model_dump_json()
     device.device_info = device_info
     device.calibrated_at = calibrated_at
@@ -136,9 +136,9 @@ def update_device_calibration(
     "/devices/{device_id}",
     response_model=DeviceDataUpdateResponse,
     responses={
-        400: {"model": Detail},
-        404: {"model": Detail},
-        500: {"model": Detail},
+        400: {"model": Message},
+        404: {"model": Message},
+        500: {"model": Message},
     },
 )
 @tracer.capture_method

--- a/backend/oqtopus_cloud/provider/routers/jobs.py
+++ b/backend/oqtopus_cloud/provider/routers/jobs.py
@@ -9,9 +9,9 @@ from oqtopus_cloud.provider.conf import logger, tracer
 from oqtopus_cloud.provider.schemas.errors import (
     BadRequestResponse,
     ConflictErrorResponse,
-    Detail,
     ErrorResponse,
     InternalServerErrorResponse,
+    Message,
     NotFoundErrorResponse,
 )
 from oqtopus_cloud.provider.schemas.jobs import (
@@ -41,7 +41,7 @@ JobId = str
 @router.get(
     "/jobs",
     response_model=list[JobDef | GetJobsResponse],
-    responses={500: {"model": Detail}},
+    responses={500: {"model": Message}},
 )
 @tracer.capture_method
 def get_jobs(
@@ -79,7 +79,7 @@ def get_jobs(
                 ]
                 invalid_fields_list = [fields_list[i] for i in invalid_indices]
                 return InternalServerErrorResponse(
-                    detail=f"fields {invalid_fields_list} is invalid"
+                    message=f"fields {invalid_fields_list} is invalid"
                 )
         else:
             select_stmt = select(Job).filter(Job.device_id == device_id)
@@ -114,13 +114,17 @@ def get_jobs(
         return results
     except Exception as e:
         logger.info(f"error: {str(e)}")
-        return InternalServerErrorResponse(detail=str(e))
+        return InternalServerErrorResponse(message=str(e))
 
 
 @router.get(
     "/jobs/{job_id}",
     response_model=JobDef,
-    responses={404: {"model": Detail}, 400: {"model": Detail}, 500: {"model": Detail}},
+    responses={
+        404: {"model": Message},
+        400: {"model": Message},
+        500: {"model": Message},
+    },
 )
 @tracer.capture_method
 def get_job(
@@ -146,9 +150,9 @@ def get_job(
     "/jobs/{job_id}",
     response_model=JobStatusUpdateResponse,
     responses={
-        404: {"model": Detail},
-        409: {"model": Detail},
-        500: {"model": Detail},
+        404: {"model": Message},
+        409: {"model": Message},
+        500: {"model": Message},
     },
 )
 @tracer.capture_method
@@ -180,9 +184,9 @@ def update_job(
     "/jobs/{job_id}/job_info",
     response_model=UpdateJobInfoResponse,
     responses={
-        400: {"model": Detail},
-        404: {"model": Detail},
-        500: {"model": Detail},
+        400: {"model": Message},
+        404: {"model": Message},
+        500: {"model": Message},
     },
 )
 @tracer.capture_method
@@ -213,7 +217,7 @@ def update_job_info(
 
     if request.reason is not None and request.result is not None:
         return BadRequestResponse(
-            detail="You cannot specify both a result and a reason."
+            message="You cannot specify both a result and a reason."
         )
 
     try:

--- a/backend/oqtopus_cloud/provider/schemas/error.py
+++ b/backend/oqtopus_cloud/provider/schemas/error.py
@@ -8,16 +8,16 @@ from pydantic import BaseModel
 
 
 class BadRequest(BaseModel):
-    detail: str
+    message: str
 
 
 class NotFoundError(BaseModel):
-    detail: str
+    message: str
 
 
 class InternalServerError(BaseModel):
-    detail: str
+    message: str
 
 
 class ConflictError(BaseModel):
-    detail: str
+    message: str

--- a/backend/oqtopus_cloud/provider/schemas/errors.py
+++ b/backend/oqtopus_cloud/provider/schemas/errors.py
@@ -12,7 +12,7 @@ class ErrorResponse(JSONResponse):
     pass
 
 
-class Detail(BaseModel):
+class Message(BaseModel):
     """A simple message response.
 
     Args:
@@ -23,7 +23,7 @@ class Detail(BaseModel):
 
     """
 
-    detail: str
+    message: str
 
 
 class BadRequestResponse(ErrorResponse):
@@ -31,7 +31,7 @@ class BadRequestResponse(ErrorResponse):
     Represents a response for a bad request.
 
     Args:
-        detail (str): The detailed error message.
+        message (str): The detailed error message.
 
     Attributes:
         status_code (int): The HTTP status code for the response.
@@ -41,11 +41,11 @@ class BadRequestResponse(ErrorResponse):
 
     def __init__(
         self,
-        detail: str,
+        message: str,
     ):
         super().__init__(
             status_code=400,
-            content={"detail": detail},
+            content={"message": message},
         )
 
 
@@ -54,21 +54,21 @@ class InternalServerErrorResponse(ErrorResponse):
     Represents an internal server error response.
 
     Args:
-        detail (str): The error message or details of the internal server error.
+        message (str): The error message or details of the internal server error.
 
     Attributes:
         status_code (int): The HTTP status code for the internal server error response.
-        content (dict): The content of the internal server error response, containing the error detail.
+        content (dict): The content of the internal server error response, containing the error message.
 
     """
 
     def __init__(
         self,
-        detail: str,
+        message: str,
     ):
         super().__init__(
             status_code=500,
-            content={"detail": detail},
+            content={"message": message},
         )
 
 
@@ -77,7 +77,7 @@ class NotFoundErrorResponse(ErrorResponse):
     Represents an error response for a resource not found.
 
     Args:
-        detail (str): The detailed error message.
+        message (str): The detailed error message.
 
     Attributes:
         status_code (int): The HTTP status code of the error response.
@@ -87,11 +87,11 @@ class NotFoundErrorResponse(ErrorResponse):
 
     def __init__(
         self,
-        detail: str,
+        message: str,
     ):
         super().__init__(
             status_code=404,
-            content={"detail": detail},
+            content={"message": message},
         )
 
 
@@ -100,7 +100,7 @@ class ConflictErrorResponse(ErrorResponse):
     Represents an error response for a conflict (HTTP status code 409).
 
     Args:
-        detail (str): The detailed error message.
+        message (str): The detailed error message.
 
     Attributes:
         status_code (int): The HTTP status code for the error response (409).
@@ -110,9 +110,9 @@ class ConflictErrorResponse(ErrorResponse):
 
     def __init__(
         self,
-        detail: str,
+        message: str,
     ):
         super().__init__(
             status_code=409,
-            content={"detail": detail},
+            content={"message": message},
         )

--- a/backend/oqtopus_cloud/user/routers/devices.py
+++ b/backend/oqtopus_cloud/user/routers/devices.py
@@ -14,9 +14,9 @@ from oqtopus_cloud.user.schemas.devices import (
     DeviceInfo,
 )
 from oqtopus_cloud.user.schemas.errors import (
-    Detail,
     ErrorResponse,
     InternalServerErrorResponse,
+    Message,
     NotFoundErrorResponse,
 )
 
@@ -29,7 +29,7 @@ router: APIRouter = APIRouter(route_class=LoggerRouteHandler)
 
 
 @router.get(
-    "/devices", response_model=list[DeviceInfo], responses={500: {"model": Detail}}
+    "/devices", response_model=list[DeviceInfo], responses={500: {"model": Message}}
 )
 @tracer.capture_method
 def get_devices(
@@ -41,13 +41,13 @@ def get_devices(
         return [model_to_schema(device) for device in devices]
     except Exception as e:
         logger.error(f"error: {str(e)}", stack_info=True)
-        return InternalServerErrorResponse(detail=str(e))
+        return InternalServerErrorResponse(message=str(e))
 
 
 @router.get(
     "/devices/{device_id}",
     response_model=DeviceInfo,
-    responses={404: {"model": Detail}, 500: {"model": Detail}},
+    responses={404: {"model": Message}, 500: {"model": Message}},
 )
 @tracer.capture_method
 def get_device(
@@ -71,12 +71,12 @@ def get_device(
             response = model_to_schema(device)
             return response
         else:
-            detail = f"device_id={device_id} is not found."
-            logger.info(detail)
-            return NotFoundErrorResponse(detail=detail)
+            message = f"device_id={device_id} is not found."
+            logger.info(message)
+            return NotFoundErrorResponse(message=message)
     except Exception as e:
         logger.error(f"error: {str(e)}", stack_info=True)
-        return InternalServerErrorResponse(detail=str(e))
+        return InternalServerErrorResponse(message=str(e))
 
 
 MAP_MODEL_TO_SCHEMA = {

--- a/backend/oqtopus_cloud/user/routers/jobs.py
+++ b/backend/oqtopus_cloud/user/routers/jobs.py
@@ -22,9 +22,9 @@ from oqtopus_cloud.common.session import (
 from oqtopus_cloud.user.conf import logger, tracer
 from oqtopus_cloud.user.schemas.errors import (
     BadRequestResponse,
-    Detail,
     ErrorResponse,
     InternalServerErrorResponse,
+    Message,
     NotFoundErrorResponse,
 )
 from oqtopus_cloud.user.schemas.jobs import (
@@ -48,14 +48,14 @@ router: APIRouter = APIRouter(route_class=LoggerRouteHandler)
 
 
 class BadRequest(Exception):
-    def __init__(self, detail: str):
-        self.detail = detail
+    def __init__(self, message: str):
+        self.message = message
 
 
 @router.get(
     "/jobs",
     response_model=list[GetJobsResponse | JobDef],
-    responses={500: {"model": Detail}},
+    responses={500: {"model": Message}},
 )
 @tracer.capture_method
 def get_jobs(
@@ -107,7 +107,7 @@ def get_jobs(
                 ]
                 invalid_fields_list = [fields_list[i] for i in invalid_indices]
                 return InternalServerErrorResponse(
-                    detail=f"fields {invalid_fields_list} is invalid"
+                    message=f"fields {invalid_fields_list} is invalid"
                 )
         else:
             stmt = select(Job).filter(Job.owner == owner).order_by(arg_order)
@@ -143,7 +143,7 @@ def get_jobs(
         return results
     except Exception as e:
         logger.info(f"error: {str(e)}")
-        return InternalServerErrorResponse(detail=str(e))
+        return InternalServerErrorResponse(message=str(e))
 
 
 def validate_name(request: JobDef) -> str | None:
@@ -161,7 +161,7 @@ def validate_description(
 @router.post(
     "/jobs",
     response_model=SubmitJobResponse,
-    responses={400: {"model": Detail}, 500: {"model": Detail}},
+    responses={400: {"model": Message}, 500: {"model": Message}},
 )
 @tracer.capture_method
 def submit_jobs(
@@ -172,7 +172,7 @@ def submit_jobs(
     try:
         device = db.get(Device, request.device_id)  # type: ignore
         if device is None:
-            return BadRequestResponse(detail="device not found")
+            return BadRequestResponse(message="device not found")
         owner = event.state.owner
         logger.info("invoked!", extra={"owner": owner})
         if device.status != "available":
@@ -205,13 +205,17 @@ def submit_jobs(
         return SubmitJobResponse(job_id=job.id)
     except Exception as e:
         logger.info(f"error: {str(e)}")
-        return InternalServerErrorResponse(detail=str(e))
+        return InternalServerErrorResponse(message=str(e))
 
 
 @router.get(
     "/jobs/{job_id}",
     response_model=JobDef,
-    responses={400: {"model": Detail}, 404: {"model": Detail}, 500: {"model": Detail}},
+    responses={
+        400: {"model": Message},
+        404: {"model": Message},
+        500: {"model": Message},
+    },
 )
 @tracer.capture_method
 def get_job(
@@ -224,21 +228,25 @@ def get_job(
         logger.info("invoked!", extra={"owner": owner, "job_id": job_id})
         job_model = db.query(Job).filter(Job.id == job_id, Job.owner == owner).first()
         if job_model is None:
-            return NotFoundErrorResponse(detail="job not found with the given id")
+            return NotFoundErrorResponse(message="job not found with the given id")
         job = model_to_schema(job_model)
         if isinstance(job, ValueError):
             logger.warning("warn: Failed to encode job model to schema.")
-            return NotFoundErrorResponse(detail="job not found with the given id")
+            return NotFoundErrorResponse(message="job not found with the given id")
         return job
     except Exception as e:
         logger.info(f"error: {str(e)}")
-        return InternalServerErrorResponse(detail=str(e))
+        return InternalServerErrorResponse(message=str(e))
 
 
 @router.delete(
     "/jobs/{job_id}",
     response_model=SuccessResponse,
-    responses={400: {"model": Detail}, 404: {"model": Detail}, 500: {"model": Detail}},
+    responses={
+        400: {"model": Message},
+        404: {"model": Message},
+        500: {"model": Message},
+    },
 )
 @tracer.capture_method
 def delete_job(
@@ -252,11 +260,11 @@ def delete_job(
         job = db.get(Job, job_id)
 
         if job is None:
-            return NotFoundErrorResponse(detail="job not found with the given id")
+            return NotFoundErrorResponse(message="job not found with the given id")
 
         if job.owner != owner or job.status not in ["succeeded", "failed", "cancelled"]:
             return NotFoundErrorResponse(
-                detail=f"{job_id} job is not in valid status for deletion (valid statuses for deletion: 'succeeded', 'failed' and 'cancelled')"
+                message=f"{job_id} job is not in valid status for deletion (valid statuses for deletion: 'succeeded', 'failed' and 'cancelled')"
             )
 
         db.delete(job)
@@ -264,13 +272,17 @@ def delete_job(
         return SuccessResponse(message="job deleted")
     except Exception as e:
         logger.info(f"error: {str(e)}")
-        return InternalServerErrorResponse(detail=str(e))
+        return InternalServerErrorResponse(message=str(e))
 
 
 @router.get(
     "/jobs/{job_id}/status",
     response_model=GetJobStatusResponse,
-    responses={400: {"model": Detail}, 404: {"model": Detail}, 500: {"model": Detail}},
+    responses={
+        400: {"model": Message},
+        404: {"model": Message},
+        500: {"model": Message},
+    },
 )
 @tracer.capture_method
 def get_job_status(
@@ -289,14 +301,18 @@ def get_job_status(
         .first()
     )
     if job is None:
-        return NotFoundErrorResponse(detail="job not found with the given id")
+        return NotFoundErrorResponse(message="job not found with the given id")
     return GetJobStatusResponse(job_id=job_id, status=job.status)
 
 
 @router.post(
     "/jobs/{job_id}/cancel",
     response_model=SuccessResponse,
-    responses={400: {"model": Detail}, 404: {"model": Detail}, 500: {"model": Detail}},
+    responses={
+        400: {"model": Message},
+        404: {"model": Message},
+        500: {"model": Message},
+    },
 )
 @tracer.capture_method
 def cancel_job(
@@ -311,10 +327,10 @@ def cancel_job(
         job = db.get(Job, job_id)
 
         if job is None:
-            return NotFoundErrorResponse(detail="job not found with the given id")
+            return NotFoundErrorResponse(message="job not found with the given id")
         if job.owner != owner or job.status not in ["ready", "submitted", "running"]:
             return NotFoundErrorResponse(
-                detail=f"{job_id} job is not in valid status for cancellation (valid statuses for cancellation: 'ready', 'submitted' and 'running')"
+                message=f"{job_id} job is not in valid status for cancellation (valid statuses for cancellation: 'ready', 'submitted' and 'running')"
             )
         if job.status in ["submitted", "ready", "running"]:
             logger.info(
@@ -325,7 +341,7 @@ def cancel_job(
         return SuccessResponse(message="cancel request accepted")
     except Exception as e:
         logger.info(f"error: {str(e)}")
-        return InternalServerErrorResponse(detail=str(e))
+        return InternalServerErrorResponse(message=str(e))
 
 
 # TODO: match parameter names of model and schema

--- a/backend/oqtopus_cloud/user/schemas/error.py
+++ b/backend/oqtopus_cloud/user/schemas/error.py
@@ -8,16 +8,16 @@ from pydantic import BaseModel
 
 
 class UnauthorizedError(BaseModel):
-    detail: str
+    message: str
 
 
 class InternalServerError(BaseModel):
-    detail: str
+    message: str
 
 
 class NotFoundError(BaseModel):
-    detail: str
+    message: str
 
 
 class BadRequest(BaseModel):
-    detail: str
+    message: str

--- a/backend/oqtopus_cloud/user/schemas/errors.py
+++ b/backend/oqtopus_cloud/user/schemas/errors.py
@@ -12,7 +12,7 @@ class ErrorResponse(JSONResponse):
     pass
 
 
-class Detail(BaseModel):
+class Message(BaseModel):
     """A simple message response.
 
     Args:
@@ -23,7 +23,7 @@ class Detail(BaseModel):
 
     """
 
-    detail: str
+    message: str
 
 
 class BadRequestResponse(ErrorResponse):
@@ -31,7 +31,7 @@ class BadRequestResponse(ErrorResponse):
     Represents a response for a bad request.
 
     Args:
-        detail (str): The detailed error message.
+        message (str): The detailed error message.
 
     Attributes:
         status_code (int): The HTTP status code for the response.
@@ -41,11 +41,11 @@ class BadRequestResponse(ErrorResponse):
 
     def __init__(
         self,
-        detail: str,
+        message: str,
     ):
         super().__init__(
             status_code=400,
-            content={"detail": detail},
+            content={"message": message},
         )
 
 
@@ -54,21 +54,21 @@ class InternalServerErrorResponse(ErrorResponse):
     Represents an internal server error response.
 
     Args:
-        detail (str): The error message or details of the internal server error.
+        message (str): The error message or details of the internal server error.
 
     Attributes:
         status_code (int): The HTTP status code for the internal server error response.
-        content (dict): The content of the internal server error response, containing the error detail.
+        content (dict): The content of the internal server error response, containing the error message.
 
     """
 
     def __init__(
         self,
-        detail: str,
+        message: str,
     ):
         super().__init__(
             status_code=500,
-            content={"detail": detail},
+            content={"message": message},
         )
 
 
@@ -77,7 +77,7 @@ class NotFoundErrorResponse(ErrorResponse):
     Represents an error response for a resource not found.
 
     Args:
-        detail (str): The detailed error message.
+        message (str): The detailed error message.
 
     Attributes:
         status_code (int): The HTTP status code of the error response.
@@ -87,11 +87,11 @@ class NotFoundErrorResponse(ErrorResponse):
 
     def __init__(
         self,
-        detail: str,
+        message: str,
     ):
         super().__init__(
             status_code=404,
-            content={"detail": detail},
+            content={"message": message},
         )
 
 
@@ -100,7 +100,7 @@ class ConflictErrorResponse(ErrorResponse):
     Represents an error response for a conflict (HTTP status code 409).
 
     Args:
-        detail (str): The detailed error message.
+        message (str): The detailed error message.
 
     Attributes:
         status_code (int): The HTTP status code for the error response (409).
@@ -110,9 +110,9 @@ class ConflictErrorResponse(ErrorResponse):
 
     def __init__(
         self,
-        detail: str,
+        message: str,
     ):
         super().__init__(
             status_code=409,
-            content={"detail": detail},
+            content={"message": message},
         )

--- a/backend/tests/oqtopus_cloud/user/routers/test_jobs.py
+++ b/backend/tests/oqtopus_cloud/user/routers/test_jobs.py
@@ -70,7 +70,7 @@ def test_get_job_404(
     print(test_db)  # => 1
     response = client.get("/jobs/e8a60c14-8838-46c9-816a-30191d6ab517")
     assert response.status_code == 404
-    assert response.json() == {"detail": "job not found with the given id"}
+    assert response.json() == {"message": "job not found with the given id"}
 
 
 def test_get_jobs_simple(
@@ -182,7 +182,7 @@ def test_get_jobs_invalid_fields(
     actual = response.json()
     expect = json.loads(
         InternalServerErrorResponse(
-            detail=f"fields {["XXX", "YYY"]} is invalid"
+            message=f"fields {["XXX", "YYY"]} is invalid"
         ).body.decode()
     )
 


### PR DESCRIPTION
# 📃 Ticket
https://github.com/FujitsuResearch/QuantumCloudPlatform/issues/283

## ✍ Description
- refactor OpenAPI specifications and error response schemas in `errors.py` 
- I think it is better to use the schema generated from `datamodel-code-generator`, but it does not seem to support status codes, so I use the response model of `errors.py` written in the manual.

## 📸 Test Result
see CI result

## 🔗 Related PRs
<!--- Paste related PRs -->
