### PR TITLE
fix: #78 coverage action error

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -87,6 +87,8 @@ jobs:
       with:
         name: .coverage-provider
         path: ./
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip==24.0

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -65,6 +65,7 @@ jobs:
       with:
         name: .coverage-${{ matrix.target }}
         path: ./backend/.coverage-${{ matrix.target }}
+        include-hidden-files: true
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -72,6 +72,8 @@ jobs:
     needs: test
 
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - name: Download .coverage-common artifacts
       uses: actions/download-artifact@v4
       with:
@@ -87,8 +89,6 @@ jobs:
       with:
         name: .coverage-provider
         path: ./
-    - name: Checkout repository
-      uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip==24.0


### PR DESCRIPTION
# 📃 Ticket
#78 

## ✍ Description
Issue with not finding `.coverage-common`: Explicitly set the `include-hidden-files` option to true.
Issue with not finding `pyproject.toml`: Add a checkout step for the repository.
