### PR TITLE
fix: `job_info` json format

### DIFF
--- a/backend/db/init/03.insert_job.sql
+++ b/backend/db/init/03.insert_job.sql
@@ -1,8 +1,8 @@
 INSERT INTO main.jobs (id, owner, name, description, device_id, job_info, transpiler_info, simulator_info, mitigation_info, job_type, shots, status, submitted_at)
-SELECT '01927422-86d4-73d6-abb4-f2de6a4f5910', 'admin', 'Test job 1', 'Test job 1 description', 'Kawasaki', '{\'code\': \'todo\'}', '', '', '', 'sampling', 1000, 'submitted', CURRENT_TIMESTAMP
+SELECT '01927422-86d4-73d6-abb4-f2de6a4f5910', 'admin', 'Test job 1', 'Test job 1 description', 'Kawasaki', '{"program": ["todo"]}', '', '', '', 'sampling', 1000, 'submitted', CURRENT_TIMESTAMP
 WHERE NOT EXISTS (SELECT * FROM main.jobs WHERE owner = 'admin' AND name = 'Test job 1');
 
 INSERT INTO main.jobs (id, owner, name, description, device_id, job_info, transpiler_info, simulator_info, mitigation_info, job_type, shots, status, submitted_at)
-SELECT '01927422-86d4-7cbf-98d3-32f5f1263cd9', 'admin', 'Test job 2', 'Test job 2 description', 'Kawasaki', '{\'code\': \'todo\'}', '', '', '', 'sampling', 1000, 'submitted', CURRENT_TIMESTAMP
+SELECT '01927422-86d4-7cbf-98d3-32f5f1263cd9', 'admin', 'Test job 2', 'Test job 2 description', 'Kawasaki', '{"program": ["todo"]}', '', '', '', 'sampling', 1000, 'submitted', CURRENT_TIMESTAMP
 WHERE NOT EXISTS (SELECT * FROM main.jobs WHERE owner = 'admin' AND name = 'Test job 2');
 


### PR DESCRIPTION
# 📃 Ticket
<!--- Paste related ticket -->

## ✍ Description
<!--- Describe your changes in detail -->

```diff
- '{\'code\': \'todo\'}'
+ '{"program": ["todo"]}'
```

It will fix

```
{"level":"INFO","location":"get_jobs:146","message":"error: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)","timestamp":"2025-02-06 12:41:50,128+0900","service":"user-api","correlation_id":"local-correlation-id","fastapi":{"path":"/devices","route":"/devices","method":"GET"}}
```
> error: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)","timestamp

and

```
{"level":"WARNING","location":"get_jobs:140","message":"Failed to decode job_info: 1 validation error for JobInfo\nprogram\n  Field required [type=missing, input_value={'code': 'todo'}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.10/v/missing","timestamp":"2025-02-06 12:43:26,598+0900","service":"user-api","correlation_id":"local-correlation-id","fastapi":{"path":"/devices","route":"/devices","method":"GET"}}
```
> Failed to decode job_info: 1 validation error for JobInfo\nprogram\n  Field required [type=missing, input_value={'code': 'todo'}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.10/v/missing


## 📸 Test Result
<!--- Paste `make test result` -->

## 🔗 Related PRs
<!--- Paste related PRs -->
