### PR TITLE
fix: job info message and result

### DIFF
--- a/backend/oqtopus_cloud/provider/routers/jobs.py
+++ b/backend/oqtopus_cloud/provider/routers/jobs.py
@@ -210,17 +210,16 @@ def update_job_info(
         if incoming is None:
             return (status, job_info)
 
-        job_info.transpiled_program = incoming.transpiled_program
+        if incoming.transpiled_program is not None:
+            job_info.transpiled_program = incoming.transpiled_program
 
         if incoming.result is not None:
             job_info.result = incoming.result
-            job_info.message = None
-            return (status or JobStatus.succeeded, job_info)
+            if status is None:
+                status = JobStatus.succeeded
 
-        elif incoming.message is not None:
+        if incoming.message is not None:
             job_info.message = incoming.message
-            job_info.result = None
-            return (status or JobStatus.failed, job_info)
 
         return (status, job_info)
 

--- a/backend/tests/oqtopus_cloud/provider/routers/test_jobs.py
+++ b/backend/tests/oqtopus_cloud/provider/routers/test_jobs.py
@@ -337,6 +337,7 @@ def test_update_job_info_reason(test_db: Session):
     # Submitting
     message = "Oops, job failed!"
     body = UpdateJobInfoRequest(
+        overwrite_status=JobStatus.failed,
         job_info=UpdateJobInfo(message=message),
     )
     submit_resp = client.patch(


### PR DESCRIPTION
# 📃 Ticket
- https://github.com/FujitsuResearch/QuantumCloudPlatform/issues/308

## ✍ Description
The logic for calculating job_info and status has been revised.
Now, the job status is automatically updated only when setting the job result.
In all other cases, the updated status must be explicitly specified using the `overwrite_status` property, including for `failed` states.
 
## 📸 Test Result
<!--- Paste `make test result` -->

## 🔗 Related PRs
<!--- Paste related PRs -->
