### PR TITLE
Hotfix/#319 shots value range

### DIFF
--- a/backend/oas/user/openapi.yaml
+++ b/backend/oas/user/openapi.yaml
@@ -908,6 +908,8 @@ components:
           example: '{}'
         shots:
           type: integer
+          minimum: 1
+          maximum: 10000000
           example: 1000
         status:
           $ref: '#/components/schemas/jobs.JobStatus'

--- a/backend/oas/user/schemas/jobs.yaml
+++ b/backend/oas/user/schemas/jobs.yaml
@@ -345,6 +345,8 @@ jobs.SubmitJobRequest:
       example: "{}"
     shots:
       type: integer
+      minimum: 1
+      maximum: 1e7
       example: 1000
     status:
       $ref: "#/jobs.JobStatus"

--- a/backend/oqtopus_cloud/user/schemas/jobs.py
+++ b/backend/oqtopus_cloud/user/schemas/jobs.py
@@ -208,7 +208,7 @@ class SubmitJobRequest(BaseModel):
     """
     When specified, valid JSON string is required
     """
-    shots: Annotated[int, Field(examples=[1000])]
+    shots: Annotated[int, Field(examples=[1000], ge=1, le=10000000)]
     status: Annotated[JobStatus | None, Field(examples=["submitted"])] = None
     created_at: Annotated[
         AwareDatetime | None, Field(examples=["2022-10-19T11:45:34+09:00"])

--- a/backend/tests/oqtopus_cloud/user/routers/test_jobs.py
+++ b/backend/tests/oqtopus_cloud/user/routers/test_jobs.py
@@ -26,6 +26,7 @@ from oqtopus_cloud.user.schemas.jobs import (
     SubmitJobRequest,
     SubmitJobResponse,
 )
+from pydantic import ValidationError
 from pydantic.type_adapter import TypeAdapter
 from sqlalchemy import select
 
@@ -692,3 +693,38 @@ def test_submit_job_compat_error(test_db):
     # Submitting
     submit_resp = client.post("/jobs", content=body.model_dump_json())
     assert submit_resp.status_code == 400
+
+
+def test_submit_job_shots_boundary(test_db):
+    """_summary_
+    Test for checking out of range shots
+    """
+
+    try:
+        SubmitJobRequest(
+            name="submit-job-test",
+            device_id="Kawasaki",
+            job_type=JobType.sampling,
+            job_info=SubmitJobInfo(program=["codecodecode"]),
+            shots=1e7 + 1,
+        )
+    except ValidationError as e:
+        error_title = e.title
+
+    # expcet to raise ValidationError by pydantic
+    assert error_title == "SubmitJobRequest"
+
+    error_title = ""
+    try:
+        SubmitJobRequest(
+            name="submit-job-test",
+            device_id="Kawasaki",
+            job_type=JobType.sampling,
+            job_info=SubmitJobInfo(program=["codecodecode"]),
+            shots=1e7,
+        )
+    except ValidationError as e:
+        error_title = e.title
+
+    # expcet no ValidationError
+    assert error_title == ""


### PR DESCRIPTION
# 📃 Ticket
https://github.com/FujitsuResearch/QuantumCloudPlatform/issues/319

## ✍ Description
### Background
As for shots parameter, jobs.GetJobsResponse schema has min(1) and max(1e7) attribute, but jobs.SubmitJobsRequest shema does not have neither.
Therefore, the job has 1e8 shots can be accepted, but the same job cannot be retrieved from user.

### Changes
- add min-max range to jobs.SubmitJobsRequest schema in OAS
- add a boundary test for shots parameter

## 📸 Test Result
See CI logs

## 🔗 Related PRs
<!--- Paste related PRs -->
