### PR TITLE
Bugfix/#297 cancel response

### DIFF
--- a/backend/oqtopus_cloud/user/routers/jobs.py
+++ b/backend/oqtopus_cloud/user/routers/jobs.py
@@ -334,7 +334,12 @@ def cancel_job(
 
         if job is None:
             return NotFoundErrorResponse(message="job not found with the given id")
-        if job.owner != owner or job.status not in ["ready", "submitted", "running"]:
+        if job.owner != owner or job.status not in [
+            "ready",
+            "submitted",
+            "running",
+            "cancelled",
+        ]:
             return NotFoundErrorResponse(
                 message=f"{job_id} job is not in valid status for cancellation (valid statuses for cancellation: 'ready', 'submitted' and 'running')"
             )

--- a/backend/tests/oqtopus_cloud/user/routers/test_jobs.py
+++ b/backend/tests/oqtopus_cloud/user/routers/test_jobs.py
@@ -608,7 +608,7 @@ def test_submit_get(
     assert resp_job.job_info.result is None
 
 
-def test_submit_delete(test_db):
+def test_submit_cancel_delete(test_db):
     """_summary_
     Test for **the invariance of submit and delete**:
     submitting a job and then sequentially deleting it should result in no remaining effects."
@@ -648,6 +648,11 @@ def test_submit_delete(test_db):
     # Deleting the job of reteurned job_id (Before deleting, canceling is required)
     cancel_resp = client.post(f"/jobs/{resp_job_id}/cancel")
     assert cancel_resp.status_code == 200
+
+    # After cancelling, the same cancel request returs 200
+    cancel_resp = client.post(f"/jobs/{resp_job_id}/cancel")
+    assert cancel_resp.status_code == 200
+
     delete_resp = client.delete(f"/jobs/{resp_job_id}")
     assert delete_resp.status_code == 200
 


### PR DESCRIPTION
# 📃 Ticket
https://github.com/FujitsuResearch/QuantumCloudPlatform/issues/297

## ✍ Description
### Background
If the cancel request to a job cancelled already, the response code 404 is returned.
It should return 200 because the job is cancelled successfully.

### Changes
- a cancel request return 200 if job status is already `cancelled`
- add test case to confirm this change

## 📸 Test Result
See CI logs

## 🔗 Related PRs
<!--- Paste related PRs -->
