### PR TITLE
Bugfix/#295 GET /jobs return normal jobs and ignore abnormal jobs

### DIFF
--- a/backend/oqtopus_cloud/provider/routers/jobs.py
+++ b/backend/oqtopus_cloud/provider/routers/jobs.py
@@ -104,7 +104,8 @@ def get_jobs(
             job = model_to_schema(model, fields_list)
             if isinstance(job, ValueError):
                 logger.warning(str(job))
-                return NotFoundErrorResponse("Job not found")
+                # ignore illegal jobs
+                continue
             else:
                 # if status is "submitted", then update status to "ready"
                 if decode_job_status(model.status) == JobStatus.submitted:

--- a/backend/oqtopus_cloud/user/routers/jobs.py
+++ b/backend/oqtopus_cloud/user/routers/jobs.py
@@ -48,6 +48,9 @@ utc = ZoneInfo("UTC")
 
 router: APIRouter = APIRouter(route_class=LoggerRouteHandler)
 
+DEFAULT_PAGE_INDEX = 1
+DEFAULT_ITEMS_PER_PAGE = 100
+
 
 class BadRequest(Exception):
     def __init__(self, message: str):
@@ -126,8 +129,8 @@ def get_jobs(
 
         set_params(
             Params(
-                size=int(size) if size is not None else 100,
-                page=int(page) if page is not None else 1,
+                size=int(size) if size is not None else DEFAULT_ITEMS_PER_PAGE,
+                page=int(page) if page is not None else DEFAULT_PAGE_INDEX,
             )
         )
         set_page(Page[Job])
@@ -139,7 +142,8 @@ def get_jobs(
         ]:
             if isinstance(job, ValueError):
                 logger.warning(str(job))
-                return NotFoundErrorResponse("Job not found")
+                # ignore illegal jobs
+                continue
             else:
                 results.append(job)
         return results

--- a/backend/tests/oqtopus_cloud/provider/routers/test_jobs.py
+++ b/backend/tests/oqtopus_cloud/provider/routers/test_jobs.py
@@ -151,6 +151,32 @@ def test_get_jobs(test_db: Session):
         assert job.status != JobStatus.submitted
 
 
+def test_get_jobs_ignore_illegal_job(
+    test_db,
+):
+    """_summary_
+    Simple GET /jobs tests
+    """
+
+    test_db.flush()
+    test_db.add(_get_job_model(1, JobType.sampling))
+    test_db.add(_get_job_model(2, JobType.sampling))
+    # job3 has invalid job_info
+    job_3 = _get_job_model(3, JobType.sampling)
+    job_3.job_info = json.dumps({"dummy": ["dummy"]})
+    test_db.add(job_3)
+    test_db.commit()
+
+    response = client.get("/jobs?device_id=SC2")
+    adapter = TypeAdapter(List[JobDef])
+    actual = adapter.validate_python(response.json())
+
+    assert response.status_code == 200
+    assert len(actual) == 2
+    assert actual[0].job_id == "testjob1id"
+    assert actual[1].job_id == "testjob2id"
+
+
 def test_get_jobs_filtering(test_db: Session):
     # Arrange
     test_db.flush()

--- a/backend/tests/oqtopus_cloud/user/routers/test_jobs.py
+++ b/backend/tests/oqtopus_cloud/user/routers/test_jobs.py
@@ -136,6 +136,32 @@ def test_get_jobs_simple(
     assert actual == expect
 
 
+def test_get_jobs_ignore_illegal_job(
+    test_db,
+):
+    """_summary_
+    Simple GET /jobs tests
+    """
+
+    test_db.flush()
+    test_db.add(_get_model(1))
+    test_db.add(_get_model(2))
+    # job3 has invalid job_info
+    job_3 = _get_model(3)
+    job_3.job_info = json.dumps({"dummy": ["dummy"]})
+    test_db.add(job_3)
+    test_db.commit()
+
+    response = client.get("/jobs")
+    adapter = TypeAdapter(List[JobDef])
+    actual = adapter.validate_python(response.json())
+
+    assert response.status_code == 200
+    assert len(actual) == 2
+    assert actual[0].job_id == "testjob1id"
+    assert actual[1].job_id == "testjob2id"
+
+
 def test_get_jobs_filtering_fields(
     test_db,
 ):


### PR DESCRIPTION
# 📃 Ticket
https://github.com/FujitsuResearch/QuantumCloudPlatform/issues/295

## ✍ Description
### Background
When GET /jobs is called, it returned a 404 error if only one job is abnormal and the others are normal.
It should return other normal jobs in this case.

### Changes
- if jobs is abnormal, it was ignored and record to log, and return other normal jobs
- add test case reproduce this situation

## 📸 Test Result
See CI logs

## 🔗 Related PRs
<!--- Paste related PRs -->
