### PR TITLE
refactor: remove "sampling" from operationId

### DIFF
--- a/backend/oas/user/openapi.yaml
+++ b/backend/oas/user/openapi.yaml
@@ -269,7 +269,7 @@ paths:
         - job
       summary: Get selected job
       description: Get selected job
-      operationId: getSamplingJob
+      operationId: getJob
       security:
         - BearerAuth: []
       parameters:
@@ -315,7 +315,7 @@ paths:
         - job
       summary: Delete job
       description: 'Deletes quantum job and related result<br/><br/>Operation is valid only for job with status: succeeded, failed and cancelled. submitted, ready and running jobs must be cancelled before deletion.'
-      operationId: deleteSamplingJob
+      operationId: deleteJob
       security:
         - BearerAuth: []
       parameters:
@@ -364,7 +364,7 @@ paths:
         - job
       summary: Get selected job's status
       description: Get selected job's status
-      operationId: getSamplingJobStatus
+      operationId: getJobStatus
       security:
         - BearerAuth: []
       parameters:
@@ -411,7 +411,7 @@ paths:
         - job
       summary: Cancel job
       description: 'Start a procedure to cancel quantum job.<br/><br/> Operation is valid only for job with status: submitted, ready or running.'
-      operationId: cancelSamplingJob
+      operationId: cancelJob
       security:
         - BearerAuth: []
       parameters:

--- a/backend/oas/user/paths/jobs.yaml
+++ b/backend/oas/user/paths/jobs.yaml
@@ -200,7 +200,7 @@ jobs.jobId:
       - job
     summary: "Get selected job"
     description: "Get selected job"
-    operationId: getSamplingJob
+    operationId: getJob
     security:
       - BearerAuth: []
     parameters:
@@ -245,7 +245,7 @@ jobs.jobId:
       - job
     summary: "Delete job"
     description: "Deletes quantum job and related result<br/><br/>Operation is valid only for job with status: succeeded, failed and cancelled. submitted, ready and running jobs must be cancelled before deletion."
-    operationId: deleteSamplingJob
+    operationId: deleteJob
     security:
       - BearerAuth: []
     parameters:
@@ -294,7 +294,7 @@ jobs.jobId.status:
       - job
     summary: "Get selected job's status"
     description: "Get selected job's status"
-    operationId: getSamplingJobStatus
+    operationId: getJobStatus
     security:
       - BearerAuth: []
     parameters:
@@ -341,7 +341,7 @@ jobs.jobId.cancel:
       - job
     summary: "Cancel job"
     description: "Start a procedure to cancel quantum job.<br/><br/> Operation is valid only for job with status: submitted, ready or running."
-    operationId: cancelSamplingJob
+    operationId: cancelJob
     security:
       - BearerAuth: []
     parameters:


### PR DESCRIPTION
# 📃 Ticket
https://github.com/FujitsuResearch/QuantumCloudPlatform/issues/293

## ✍ Description
Removed the "sampling" character from the OAS operationID because it still had the old specification

## 📸 Test Result
See CI logs

## 🔗 Related PRs
<!--- Paste related PRs -->
