### PR TITLE
Feature/#292 remove "created_at" and "updated_at" from GET /jobs

### DIFF
--- a/backend/oas/provider/openapi.yaml
+++ b/backend/oas/provider/openapi.yaml
@@ -571,14 +571,6 @@ components:
           type: string
           format: date-time
           example: '2022-10-19T11:45:34+09:00'
-        created_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
-        updated_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
       required: []
       example:
         job_id: 7af020f6-2e38-4d70-8cf0-4349650ea08c
@@ -623,8 +615,6 @@ components:
         ready_at: '2022-10-19T11:45:34+09:00'
         running_at: '2022-10-19T11:45:34+09:00'
         ended_at: '2022-10-19T11:45:34+09:00'
-        created_at: '2022-10-19T11:45:34+09:00'
-        updated_at: '2022-10-19T11:45:34+09:00'
     jobs.JobType:
       type: string
       enum:
@@ -703,14 +693,6 @@ components:
           type: string
           format: date-time
           example: '2022-10-19T11:45:34+09:00'
-        created_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
-        updated_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
       required:
         - job_id
         - device_id
@@ -718,7 +700,6 @@ components:
         - job_info
         - shots
         - status
-        - created_at
       example:
         job_id: 7af020f6-2e38-4d70-8cf0-4349650ea08c
         name: Bell State Sampling
@@ -761,8 +742,6 @@ components:
         ready_at: '2022-10-19T11:45:34+09:00'
         running_at: '2022-10-19T11:45:34+09:00'
         ended_at: '2022-10-19T11:45:34+09:00'
-        created_at: '2022-10-19T11:45:34+09:00'
-        updated_at: '2022-10-19T11:45:34+09:00'
     jobs.JobStatusUpdate:
       type: object
       properties:

--- a/backend/oas/provider/schemas/jobs.yaml
+++ b/backend/oas/provider/schemas/jobs.yaml
@@ -213,14 +213,6 @@ jobs.JobDef:
       type: string
       format: date-time
       example: 2022-10-19T11:45:34+09:00
-    created_at:
-      type: string
-      format: date-time
-      example: 2022-10-19T11:45:34+09:00
-    updated_at:
-      type: string
-      format: date-time
-      example: 2022-10-19T11:45:34+09:00
   required:
     - job_id
     - device_id
@@ -228,7 +220,6 @@ jobs.JobDef:
     - job_info
     - shots
     - status
-    - created_at
   example:
       job_id: 7af020f6-2e38-4d70-8cf0-4349650ea08c
       name: Bell State Sampling
@@ -277,8 +268,6 @@ jobs.JobDef:
       ready_at: 2022-10-19T11:45:34+09:00
       running_at: 2022-10-19T11:45:34+09:00
       ended_at: 2022-10-19T11:45:34+09:00
-      created_at: 2022-10-19T11:45:34+09:00
-      updated_at: 2022-10-19T11:45:34+09:00
 
 jobs.GetJobsResponse:
   type: object
@@ -351,14 +340,6 @@ jobs.GetJobsResponse:
       type: string
       format: date-time
       example: 2022-10-19T11:45:34+09:00
-    created_at:
-      type: string
-      format: date-time
-      example: 2022-10-19T11:45:34+09:00
-    updated_at:
-      type: string
-      format: date-time
-      example: 2022-10-19T11:45:34+09:00
   required: []
   example:
       job_id: 7af020f6-2e38-4d70-8cf0-4349650ea08c
@@ -409,8 +390,6 @@ jobs.GetJobsResponse:
       ready_at: 2022-10-19T11:45:34+09:00
       running_at: 2022-10-19T11:45:34+09:00
       ended_at: 2022-10-19T11:45:34+09:00
-      created_at: 2022-10-19T11:45:34+09:00
-      updated_at: 2022-10-19T11:45:34+09:00
 
 jobs.JobStatusUpdate:
   type: object

--- a/backend/oas/user/openapi.yaml
+++ b/backend/oas/user/openapi.yaml
@@ -815,14 +815,6 @@ components:
           type: string
           format: date-time
           example: '2022-10-19T11:45:34+09:00'
-        created_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
-        updated_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
       required: []
       example:
         job_id: 7af020f6-2e38-4d70-8cf0-4349650ea08c
@@ -848,8 +840,6 @@ components:
         ready_at: '2022-10-19T11:45:34+09:00'
         running_at: '2022-10-19T11:45:34+09:00'
         ended_at: '2022-10-19T11:45:34+09:00'
-        created_at: '2022-10-19T11:45:34+09:00'
-        updated_at: '2022-10-19T11:45:34+09:00'
     jobs.SubmitJobInfo:
       description: All fields in this schema also exist in the `JobInfo` schema and have the same meaning as their counterparts in the `JobInfo` schema.
       type: object
@@ -914,14 +904,6 @@ components:
         status:
           $ref: '#/components/schemas/jobs.JobStatus'
           example: submitted
-        created_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
-        updated_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
       required:
         - name
         - device_id
@@ -993,14 +975,6 @@ components:
           type: string
           format: date-time
           example: '2022-10-19T11:45:34+09:00'
-        created_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
-        updated_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
       required:
         - job_id
         - name
@@ -1035,8 +1009,6 @@ components:
         ready_at: '2022-10-19T11:45:34+09:00'
         running_at: '2022-10-19T11:45:34+09:00'
         ended_at: '2022-10-19T11:45:34+09:00'
-        created_at: '2022-10-19T11:45:34+09:00'
-        updated_at: '2022-10-19T11:45:34+09:00'
     success.SuccessResponse:
       type: object
       properties:

--- a/backend/oas/user/schemas/jobs.yaml
+++ b/backend/oas/user/schemas/jobs.yaml
@@ -235,14 +235,6 @@ jobs.JobDef:
       type: string
       format: date-time
       example: 2022-10-19T11:45:34+09:00
-    created_at:
-      type: string
-      format: date-time
-      example: 2022-10-19T11:45:34+09:00
-    updated_at:
-      type: string
-      format: date-time
-      example: 2022-10-19T11:45:34+09:00
   required:
     - job_id
     - name
@@ -279,8 +271,6 @@ jobs.JobDef:
       ready_at: 2022-10-19T11:45:34+09:00
       running_at: 2022-10-19T11:45:34+09:00
       ended_at: 2022-10-19T11:45:34+09:00
-      created_at: 2022-10-19T11:45:34+09:00
-      updated_at: 2022-10-19T11:45:34+09:00
 
 jobs.SubmitJobInfo:
   description: "All fields in this schema also exist in the `JobInfo` schema and have the same meaning as their counterparts in the `JobInfo` schema."
@@ -351,14 +341,6 @@ jobs.SubmitJobRequest:
     status:
       $ref: "#/jobs.JobStatus"
       example: submitted
-    created_at:
-      type: string
-      format: date-time
-      example: 2022-10-19T11:45:34+09:00
-    updated_at:
-      type: string
-      format: date-time
-      example: 2022-10-19T11:45:34+09:00
   required:
     - name
     - device_id
@@ -416,14 +398,6 @@ jobs.GetJobsResponse:
       type: string
       format: date-time
       example: 2022-10-19T11:45:34+09:00
-    created_at:
-      type: string
-      format: date-time
-      example: 2022-10-19T11:45:34+09:00
-    updated_at:
-      type: string
-      format: date-time
-      example: 2022-10-19T11:45:34+09:00
   required: []
   example:
       job_id: 7af020f6-2e38-4d70-8cf0-4349650ea08c
@@ -452,5 +426,3 @@ jobs.GetJobsResponse:
       ready_at: 2022-10-19T11:45:34+09:00
       running_at: 2022-10-19T11:45:34+09:00
       ended_at: 2022-10-19T11:45:34+09:00
-      created_at: 2022-10-19T11:45:34+09:00
-      updated_at: 2022-10-19T11:45:34+09:00

--- a/backend/oqtopus_cloud/provider/routers/jobs.py
+++ b/backend/oqtopus_cloud/provider/routers/jobs.py
@@ -371,8 +371,6 @@ def model_to_schema(
             ready_at=localize(model.ready_at),
             running_at=localize(model.running_at),
             ended_at=localize(model.ended_at),
-            created_at=pytz.utc.localize(model.created_at),
-            updated_at=localize(model.updated_at),
         )
     elif fields is not None:
         dict_schema: dict[str, Any] = {}

--- a/backend/oqtopus_cloud/provider/schemas/jobs.py
+++ b/backend/oqtopus_cloud/provider/schemas/jobs.py
@@ -151,12 +151,6 @@ class GetJobsResponse(BaseModel):
     ended_at: Annotated[
         AwareDatetime | None, Field(examples=["2022-10-19T11:45:34+09:00"])
     ] = None
-    created_at: Annotated[
-        AwareDatetime | None, Field(examples=["2022-10-19T11:45:34+09:00"])
-    ] = None
-    updated_at: Annotated[
-        AwareDatetime | None, Field(examples=["2022-10-19T11:45:34+09:00"])
-    ] = None
 
 
 class JobType(str, Enum):
@@ -205,10 +199,6 @@ class JobDef(BaseModel):
         AwareDatetime | None, Field(examples=["2022-10-19T11:45:34+09:00"])
     ] = None
     ended_at: Annotated[
-        AwareDatetime | None, Field(examples=["2022-10-19T11:45:34+09:00"])
-    ] = None
-    created_at: Annotated[AwareDatetime, Field(examples=["2022-10-19T11:45:34+09:00"])]
-    updated_at: Annotated[
         AwareDatetime | None, Field(examples=["2022-10-19T11:45:34+09:00"])
     ] = None
 

--- a/backend/oqtopus_cloud/user/routers/jobs.py
+++ b/backend/oqtopus_cloud/user/routers/jobs.py
@@ -429,8 +429,6 @@ def model_to_schema(
             ready_at=localize(model.ready_at),
             running_at=localize(model.running_at),
             ended_at=localize(model.ended_at),
-            created_at=localize(model.created_at),
-            updated_at=localize(model.updated_at),
         )
     elif fields is not None:
         dict_schema: dict[str, Any] = {}

--- a/backend/oqtopus_cloud/user/schemas/jobs.py
+++ b/backend/oqtopus_cloud/user/schemas/jobs.py
@@ -157,12 +157,6 @@ class GetJobsResponse(BaseModel):
     ended_at: Annotated[
         AwareDatetime | None, Field(examples=["2022-10-19T11:45:34+09:00"])
     ] = None
-    created_at: Annotated[
-        AwareDatetime | None, Field(examples=["2022-10-19T11:45:34+09:00"])
-    ] = None
-    updated_at: Annotated[
-        AwareDatetime | None, Field(examples=["2022-10-19T11:45:34+09:00"])
-    ] = None
 
 
 class SubmitJobInfo(BaseModel):
@@ -210,12 +204,6 @@ class SubmitJobRequest(BaseModel):
     """
     shots: Annotated[int, Field(examples=[1000], ge=1, le=10000000)]
     status: Annotated[JobStatus | None, Field(examples=["submitted"])] = None
-    created_at: Annotated[
-        AwareDatetime | None, Field(examples=["2022-10-19T11:45:34+09:00"])
-    ] = None
-    updated_at: Annotated[
-        AwareDatetime | None, Field(examples=["2022-10-19T11:45:34+09:00"])
-    ] = None
 
 
 class SubmitJobResponse(BaseModel):
@@ -267,12 +255,6 @@ class JobDef(BaseModel):
         AwareDatetime | None, Field(examples=["2022-10-19T11:45:34+09:00"])
     ] = None
     ended_at: Annotated[
-        AwareDatetime | None, Field(examples=["2022-10-19T11:45:34+09:00"])
-    ] = None
-    created_at: Annotated[
-        AwareDatetime | None, Field(examples=["2022-10-19T11:45:34+09:00"])
-    ] = None
-    updated_at: Annotated[
         AwareDatetime | None, Field(examples=["2022-10-19T11:45:34+09:00"])
     ] = None
 

--- a/backend/tests/oqtopus_cloud/user/routers/test_jobs.py
+++ b/backend/tests/oqtopus_cloud/user/routers/test_jobs.py
@@ -105,8 +105,6 @@ def test_get_jobs_simple(
             ready_at=None,
             running_at=None,
             ended_at=None,
-            created_at=pytz.utc.localize(datetime(2024, 3, 4, 12, 34, 56)),
-            updated_at=None,
         ),
         JobDef(
             job_id="testjob2id",
@@ -127,8 +125,6 @@ def test_get_jobs_simple(
             ready_at=None,
             running_at=None,
             ended_at=None,
-            created_at=pytz.utc.localize(datetime(2024, 3, 5, 12, 34, 56)),
-            updated_at=None,
         ),
     ]
 
@@ -229,8 +225,6 @@ def test_get_jobs_filtering_start_time(
             ready_at=None,
             running_at=None,
             ended_at=None,
-            created_at=pytz.utc.localize(datetime(2024, 3, 5, 12, 34, 56)),
-            updated_at=None,
         ),
     ]
 
@@ -273,8 +267,6 @@ def test_get_jobs_filtering_end_time(
             ready_at=None,
             running_at=None,
             ended_at=None,
-            created_at=pytz.utc.localize(datetime(2024, 3, 4, 12, 34, 56)),
-            updated_at=None,
         ),
     ]
 
@@ -317,8 +309,6 @@ def test_get_jobs_filtering_search_string(
             ready_at=None,
             running_at=None,
             ended_at=None,
-            created_at=pytz.utc.localize(datetime(2024, 3, 4, 12, 34, 56)),
-            updated_at=None,
         ),
     ]
 
@@ -361,8 +351,6 @@ def test_get_jobs_desc_order(
             ready_at=None,
             running_at=None,
             ended_at=None,
-            created_at=pytz.utc.localize(datetime(2024, 3, 5, 12, 34, 56)),
-            updated_at=None,
         ),
         GetJobsResponse(
             job_id="testjob1id",
@@ -383,8 +371,6 @@ def test_get_jobs_desc_order(
             ready_at=None,
             running_at=None,
             ended_at=None,
-            created_at=pytz.utc.localize(datetime(2024, 3, 4, 12, 34, 56)),
-            updated_at=None,
         ),
     ]
 
@@ -527,7 +513,6 @@ def test_get_jobs_handler(
         ready_at=None,
         running_at=None,
         ended_at=None,
-        created_at=pytz.utc.localize(datetime(2024, 3, 4, 12, 34, 56)),
     )
     assert jobs[0] == expected
 
@@ -708,7 +693,7 @@ def test_submit_job_shots_boundary(test_db):
             device_id="Kawasaki",
             job_type=JobType.sampling,
             job_info=SubmitJobInfo(program=["codecodecode"]),
-            shots=1e7 + 1,
+            shots=int(1e7) + 1,
         )
     except ValidationError as e:
         error_title = e.title
@@ -723,7 +708,7 @@ def test_submit_job_shots_boundary(test_db):
             device_id="Kawasaki",
             job_type=JobType.sampling,
             job_info=SubmitJobInfo(program=["codecodecode"]),
-            shots=1e7,
+            shots=int(1e7),
         )
     except ValidationError as e:
         error_title = e.title

--- a/docs/oas/provider/openapi.yaml
+++ b/docs/oas/provider/openapi.yaml
@@ -571,14 +571,6 @@ components:
           type: string
           format: date-time
           example: '2022-10-19T11:45:34+09:00'
-        created_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
-        updated_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
       required: []
       example:
         job_id: 7af020f6-2e38-4d70-8cf0-4349650ea08c
@@ -623,8 +615,6 @@ components:
         ready_at: '2022-10-19T11:45:34+09:00'
         running_at: '2022-10-19T11:45:34+09:00'
         ended_at: '2022-10-19T11:45:34+09:00'
-        created_at: '2022-10-19T11:45:34+09:00'
-        updated_at: '2022-10-19T11:45:34+09:00'
     jobs.JobType:
       type: string
       enum:
@@ -703,14 +693,6 @@ components:
           type: string
           format: date-time
           example: '2022-10-19T11:45:34+09:00'
-        created_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
-        updated_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
       required:
         - job_id
         - device_id
@@ -718,7 +700,6 @@ components:
         - job_info
         - shots
         - status
-        - created_at
       example:
         job_id: 7af020f6-2e38-4d70-8cf0-4349650ea08c
         name: Bell State Sampling
@@ -761,8 +742,6 @@ components:
         ready_at: '2022-10-19T11:45:34+09:00'
         running_at: '2022-10-19T11:45:34+09:00'
         ended_at: '2022-10-19T11:45:34+09:00'
-        created_at: '2022-10-19T11:45:34+09:00'
-        updated_at: '2022-10-19T11:45:34+09:00'
     jobs.JobStatusUpdate:
       type: object
       properties:

--- a/docs/oas/user/openapi.yaml
+++ b/docs/oas/user/openapi.yaml
@@ -815,14 +815,6 @@ components:
           type: string
           format: date-time
           example: '2022-10-19T11:45:34+09:00'
-        created_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
-        updated_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
       required: []
       example:
         job_id: 7af020f6-2e38-4d70-8cf0-4349650ea08c
@@ -848,8 +840,6 @@ components:
         ready_at: '2022-10-19T11:45:34+09:00'
         running_at: '2022-10-19T11:45:34+09:00'
         ended_at: '2022-10-19T11:45:34+09:00'
-        created_at: '2022-10-19T11:45:34+09:00'
-        updated_at: '2022-10-19T11:45:34+09:00'
     jobs.SubmitJobInfo:
       description: All fields in this schema also exist in the `JobInfo` schema and have the same meaning as their counterparts in the `JobInfo` schema.
       type: object
@@ -908,18 +898,12 @@ components:
           example: '{}'
         shots:
           type: integer
+          minimum: 1
+          maximum: 10000000
           example: 1000
         status:
           $ref: '#/components/schemas/jobs.JobStatus'
           example: submitted
-        created_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
-        updated_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
       required:
         - name
         - device_id
@@ -991,14 +975,6 @@ components:
           type: string
           format: date-time
           example: '2022-10-19T11:45:34+09:00'
-        created_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
-        updated_at:
-          type: string
-          format: date-time
-          example: '2022-10-19T11:45:34+09:00'
       required:
         - job_id
         - name
@@ -1033,8 +1009,6 @@ components:
         ready_at: '2022-10-19T11:45:34+09:00'
         running_at: '2022-10-19T11:45:34+09:00'
         ended_at: '2022-10-19T11:45:34+09:00'
-        created_at: '2022-10-19T11:45:34+09:00'
-        updated_at: '2022-10-19T11:45:34+09:00'
     success.SuccessResponse:
       type: object
       properties:


### PR DESCRIPTION
# 📃 Ticket
https://github.com/FujitsuResearch/QuantumCloudPlatform/issues/292

## ✍ Description
### Background
`created_at` and `updated_at` should not be returned to user or provider because they are system internal information to record when tables are updated.
### Changes
- remove `created_at` and `updated_at` fields from `JobDef` and `GetJobsResponse` schema in OAS
- modify related python codes and tests

## 📸 Test Result
See CI logs

## 🔗 Related PRs
<!--- Paste related PRs -->
