### PR TITLE
fix: Updating tool.poetry version fixed

### DIFF
--- a/.github/workflows/update_version.yaml
+++ b/.github/workflows/update_version.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: .python-version
+          python-version-file: .python-version
 
       - name: Install Poetry
         run: |

--- a/.github/workflows/update_version.yaml
+++ b/.github/workflows/update_version.yaml
@@ -22,6 +22,16 @@ jobs:
           echo "VERSION: $VERSION"
           echo "::set-output name=version::$VERSION"
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: .python-version
+
+      - name: Install Poetry
+        run: |
+          pip install poetry poetry-plugin-export
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
       - name: Update version in pyproject.toml
         run: |
           poetry version ${{ steps.extract_version.outputs.version }}

--- a/.github/workflows/update_version.yaml
+++ b/.github/workflows/update_version.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Update version in pyproject.toml
         run: |
-          sed -i 's/version = "[^"]*"/version = "${{ steps.extract_version.outputs.version }}"/' pyproject.toml
+          poetry version ${{ steps.extract_version.outputs.version }}
 
       - name: Display pyproject.toml after modification
         run: cat pyproject.toml


### PR DESCRIPTION
# 📃 Ticket
https://github.com/FujitsuResearch/QuantumCloudPlatform/issues/365

## ✍ Description
The old way affected versions of unrelated packages.
This version only updates the version of tool.poetry

## 📸 Test Result
Without PR by bot
https://github.com/oqtopus-team/oqtopus-cloud/actions/runs/13809672768/job/38628173830

## 🔗 Related PRs
