### PR TITLE
feat: Add a process to delete S3 resources when SSE job is deleted. 

### DIFF
--- a/backend/oqtopus_cloud/user/routers/jobs.py
+++ b/backend/oqtopus_cloud/user/routers/jobs.py
@@ -292,6 +292,14 @@ def delete_job(
 
         db.delete(job)
         db.commit()
+
+        # delete the user program and logs from S3 when SSE
+        is_success_delete_s3 = delete_s3_folder(job)
+        if not is_success_delete_s3:
+            return InternalServerErrorResponse(
+                message="job deleted successfully, but failed to delete SSE related resources."
+            )
+
         return SuccessResponse(message="job deleted")
     except Exception as e:
         logger.info(f"error: {str(e)}")
@@ -475,6 +483,28 @@ def put_user_program_to_s3(job: Job) -> bool:
         return True
     except Exception as e:
         logger.exception(f"Failed to upload the user program to S3: {str(e)}")
+        return False
+
+
+def delete_s3_folder(job: Job) -> bool:
+    if job.job_type != JobType.sse:
+        return True
+
+    bucket_name = os.environ["SSE_BUCKET"]
+    try:
+        s3 = boto3.resource("s3")
+        bucket = s3.Bucket(bucket_name)
+        deleted_list = bucket.objects.filter(Prefix=f"{job.id}/").delete()
+        for deleted in deleted_list:
+            if deleted.get("Errors") and len(deleted.get("Errors")) > 0:
+                for error in deleted.get("Errors"):
+                    logger.error(
+                        f"Failed to delete the file from S3: {error.get("Message")}"
+                    )
+                return False
+        return True
+    except Exception as e:
+        logger.exception(f"Failed to delete the folder from S3: {str(e)}")
         return False
 
 

--- a/backend/tests/oqtopus_cloud/user/routers/test_jobs.py
+++ b/backend/tests/oqtopus_cloud/user/routers/test_jobs.py
@@ -1110,3 +1110,207 @@ def test_put_user_program_to_s3_no_program(
     # Submitting
     submit_resp = client.post("/jobs", content=body.model_dump_json())
     assert submit_resp.status_code == 500
+
+
+@mock_aws
+def test_delete_s3_folder(
+    test_db,
+):
+    """_summary_
+    Test for delete s3 folder from S3 when SSE
+    """
+
+    test_db.flush()
+    job_model = _get_model(1)
+    job_model.job_type = "sse"
+    job_model.status = "succeeded"
+    test_db.add(job_model)
+    test_db.commit()
+
+    bucket_name = os.environ["SSE_BUCKET"]
+    s3client = boto3.client("s3")
+    s3client.create_bucket(
+        Bucket=bucket_name,
+        CreateBucketConfiguration={"LocationConstraint": "ap-northeast-1"},
+    )
+    s3client.put_object(Bucket=bucket_name, Key=f"testjob1id/oqtopus_test_program.py", Body="program1")
+    s3client.put_object(Bucket=bucket_name, Key=f"testjob1id/oqtopus_test_log.log", Body="log1")
+    s3client.put_object(Bucket=bucket_name, Key=f"testjob2id/oqtopus_test_program.py", Body="program2")
+    s3client.put_object(Bucket=bucket_name, Key=f"testjob2id/oqtopus_test_log.log", Body="log2")
+
+    # Request
+    delete_resp = client.delete("/jobs/testjob1id")
+    assert delete_resp.status_code == 200
+
+    objects = s3client.list_objects_v2(Bucket=bucket_name, Prefix="testjob1id")
+    assert "Contents" not in objects
+    objects = s3client.list_objects_v2(Bucket=bucket_name, Prefix="testjob2id")
+    assert "Contents" in objects
+    assert len(objects["Contents"]) == 2
+    assert objects["Contents"][0]["Key"] in ["testjob2id/oqtopus_test_program.py", "testjob2id/oqtopus_test_log.log"]
+    assert objects["Contents"][1]["Key"] in ["testjob2id/oqtopus_test_program.py", "testjob2id/oqtopus_test_log.log"]
+    job = test_db.get(Job, "testjob1id")
+    assert job is None
+
+    # clean up
+    s3client.delete_object(Bucket=bucket_name, Key="testjob2id/oqtopus_test_program.py")
+    s3client.delete_object(Bucket=bucket_name, Key="testjob2id/oqtopus_test_log.log")
+    s3client.delete_object(Bucket=bucket_name, Key="testjob2id/")
+    s3client.delete_bucket(Bucket=bucket_name)
+
+
+@mock_aws
+def test_delete_s3_folder_no_folder(
+    test_db,
+):
+    """_summary_
+    Test for delete s3 folder from S3 when SSE
+    """
+
+    test_db.flush()
+    job_model = _get_model(1)
+    job_model.job_type = "sse"
+    job_model.status = "succeeded"
+    test_db.add(job_model)
+    test_db.commit()
+
+    bucket_name = os.environ["SSE_BUCKET"]
+    s3client = boto3.client("s3")
+    s3client.create_bucket(
+        Bucket=bucket_name,
+        CreateBucketConfiguration={"LocationConstraint": "ap-northeast-1"},
+    )
+
+    # Request
+    delete_resp = client.delete("/jobs/testjob1id")
+    assert delete_resp.status_code == 200
+
+    objects = s3client.list_objects_v2(Bucket=bucket_name, Prefix="testjob1id")
+    assert "Contents" not in objects
+    job = test_db.get(Job, "testjob1id")
+    assert job is None
+
+    # clean up
+    s3client.delete_bucket(Bucket=bucket_name)
+
+
+@mock_aws
+def test_delete_s3_folder_no_file(
+    test_db,
+):
+    """_summary_
+    Test for delete s3 folder from S3 when SSE
+    """
+
+    test_db.flush()
+    job_model = _get_model(1)
+    job_model.job_type = "sse"
+    job_model.status = "succeeded"
+    test_db.add(job_model)
+    test_db.commit()
+
+    bucket_name = os.environ["SSE_BUCKET"]
+    s3client = boto3.client("s3")
+    s3client.create_bucket(
+        Bucket=bucket_name,
+        CreateBucketConfiguration={"LocationConstraint": "ap-northeast-1"},
+    )
+    s3client.put_object(Bucket=bucket_name, Key=f"testjob1id/", Body="program1")
+
+    # Request
+    delete_resp = client.delete("/jobs/testjob1id")
+    assert delete_resp.status_code == 200
+
+    objects = s3client.list_objects_v2(Bucket=bucket_name, Prefix="testjob1id")
+    assert "Contents" not in objects
+    job = test_db.get(Job, "testjob1id")
+    assert job is None
+
+    # clean up
+    s3client.delete_object(Bucket=bucket_name, Key="testjob1id/")
+    s3client.delete_bucket(Bucket=bucket_name)
+
+
+@mock_aws
+def test_delete_s3_folder_folder_only(
+    test_db,
+):
+    """_summary_
+    Test for delete s3 folder from S3 when SSE
+    """
+
+    test_db.flush()
+    job_model = _get_model(1)
+    job_model.job_type = "sse"
+    job_model.status = "succeeded"
+    test_db.add(job_model)
+    test_db.commit()
+
+    bucket_name = os.environ["SSE_BUCKET"]
+    s3client = boto3.client("s3")
+    s3client.create_bucket(
+        Bucket=bucket_name,
+        CreateBucketConfiguration={"LocationConstraint": "ap-northeast-1"},
+    )
+    s3client.put_object(Bucket=bucket_name, Key=f"testjob1id/", Body="program1")
+
+    # Request
+    delete_resp = client.delete("/jobs/testjob1id")
+    assert delete_resp.status_code == 200
+
+    objects = s3client.list_objects_v2(Bucket=bucket_name, Prefix="testjob1id")
+    assert "Contents" not in objects
+    job = test_db.get(Job, "testjob1id")
+    assert job is None
+
+    # clean up
+    s3client.delete_object(Bucket=bucket_name, Key="testjob1id/")
+    s3client.delete_bucket(Bucket=bucket_name)
+
+
+@mock_aws
+def test_delete_s3_not_sse_job(
+    test_db,
+):
+    """_summary_
+    Test for delete s3 folder from S3 when SSE
+    """
+
+    test_db.flush()
+    job_model = _get_model(1)
+    job_model.job_type = "sampling"
+    job_model.status = "succeeded"
+    test_db.add(job_model)
+    test_db.commit()
+
+    # Request
+    delete_resp = client.delete("/jobs/testjob1id")
+    assert delete_resp.status_code == 200
+
+    job = test_db.get(Job, "testjob1id")
+    assert job is None
+
+
+@mock_aws
+def test_delete_s3_folder_exception(
+    test_db,
+):
+    """_summary_
+    Test for delete s3 folder from S3 when SSE
+    """
+
+    test_db.flush()
+    job_model = _get_model(1)
+    job_model.job_type = "sse"
+    job_model.status = "succeeded"
+    test_db.add(job_model)
+    test_db.commit()
+
+    # do not create bucket to raise exception
+
+    # Request
+    delete_resp = client.delete("/jobs/testjob1id")
+    assert delete_resp.status_code == 500
+
+    job = test_db.get(Job, "testjob1id")
+    assert job is None


### PR DESCRIPTION
# 📃 Ticket
- https://github.com/FujitsuResearch/QuantumCloudPlatform/issues/361

## ✍ Description
- Add a  process to delete S3 resources when SSE job is deleted using DELETE job API.

## 📸 Test Result
<!--- Paste `make test result` -->

## 🔗 Related PRs
<!--- Paste related PRs -->
