### PR TITLE
feat: TranspileResult JSON

### DIFF
--- a/backend/oas/provider/openapi.yaml
+++ b/backend/oas/provider/openapi.yaml
@@ -650,10 +650,14 @@ components:
           nullable: true
           example: OPENQASM 3; include "stdgates.inc"; qubit[2] _all_qubits; let q = _all_qubits[0:1]; h q[0]; cx q[0], q[1];
         stats:
-          type: string
+          type: object
+          properties: {}
+          additionalProperties: true
           nullable: true
         virtual_physical_mapping:
-          type: string
+          type: object
+          properties: {}
+          additionalProperties: true
           nullable: true
       required:
         - transpiled_program

--- a/backend/oas/provider/schemas/jobs.yaml
+++ b/backend/oas/provider/schemas/jobs.yaml
@@ -111,10 +111,14 @@ jobs.TranspileResult:
         h q[0];
         cx q[0], q[1];
     stats:
-      type: string
+      type: object
+      properties: {}
+      additionalProperties: true
       nullable: true
     virtual_physical_mapping:
-      type: string
+      type: object
+      properties: {}
+      additionalProperties: true
       nullable: true
   required:
     - transpiled_program

--- a/backend/oas/user/openapi.yaml
+++ b/backend/oas/user/openapi.yaml
@@ -888,10 +888,14 @@ components:
           nullable: true
           example: OPENQASM 3; include "stdgates.inc"; qubit[2] _all_qubits; let q = _all_qubits[0:1]; h q[0]; cx q[0], q[1];
         stats:
-          type: string
+          type: object
+          properties: {}
+          additionalProperties: true
           nullable: true
         virtual_physical_mapping:
-          type: string
+          type: object
+          properties: {}
+          additionalProperties: true
           nullable: true
       required:
         - transpiled_program

--- a/backend/oas/user/schemas/jobs.yaml
+++ b/backend/oas/user/schemas/jobs.yaml
@@ -98,10 +98,14 @@ jobs.TranspileResult:
         h q[0];
         cx q[0], q[1];
     stats:
-      type: string
+      type: object
+      properties: {}
+      additionalProperties: true
       nullable: true
     virtual_physical_mapping:
-      type: string
+      type: object
+      properties: {}
+      additionalProperties: true
       nullable: true
   required:
     - transpiled_program

--- a/backend/oqtopus_cloud/provider/schemas/jobs.py
+++ b/backend/oqtopus_cloud/provider/schemas/jobs.py
@@ -90,8 +90,8 @@ class TranspileResult(BaseModel):
             ]
         ),
     ] = None
-    stats: Annotated[str | None, Field(...)] = None
-    virtual_physical_mapping: Annotated[str | None, Field(...)] = None
+    stats: Annotated[dict[str, Any] | None, Field(...)]
+    virtual_physical_mapping: Annotated[dict[str, Any] | None, Field(...)]
 
 
 class JobInfo(BaseModel):

--- a/backend/oqtopus_cloud/user/schemas/jobs.py
+++ b/backend/oqtopus_cloud/user/schemas/jobs.py
@@ -93,8 +93,8 @@ class TranspileResult(BaseModel):
             ]
         ),
     ] = None
-    stats: Annotated[str | None, Field(...)] = None
-    virtual_physical_mapping: Annotated[str | None, Field(...)] = None
+    stats: Annotated[dict[str, Any] | None, Field(...)]
+    virtual_physical_mapping: Annotated[dict[str, Any] | None, Field(...)]
 
 
 class JobInfo(BaseModel):

--- a/backend/tests/oqtopus_cloud/provider/routers/test_jobs.py
+++ b/backend/tests/oqtopus_cloud/provider/routers/test_jobs.py
@@ -346,8 +346,8 @@ def test_update_job_info_transpile_result(test_db: Session):
     # Submitting
     transpile_result = TranspileResult(
         transpiled_program="transpiled_program",
-        stats="stats",
-        virtual_physical_mapping="vpm",
+        stats={"field": "value"},
+        virtual_physical_mapping={"field": "value"},
     )
     body = UpdateJobInfoRequest(
         overwrite_status=JobStatus.ready,


### PR DESCRIPTION
# 📃 Ticket
None.

## ✍ Description
This PR changes the OAS definition of the job transpile result so that the `stats` and  `virtual_physical_mappings` be JSON with arbitrary fields, not a string.
This is a breaking change, so after this PR is merged, current jobs with transpile_result will be never fetched through GET /jobs endpoint.
  
## 📸 Test Result
<!--- Paste `make test result` -->

## 🔗 Related PRs
<!--- Paste related PRs -->
