### PR TITLE
feat: Combine poetry setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,8 @@ help: ## Show this help message
 setup-hooks:
 	@bash scripts/setup_hooks.sh
 	@echo "Setup hooks successfully"
+
+setup-poetry:
+	@poetry env use ~/.pyenv/shims/python
+	@poetry config virtualenvs.in-project true
+	@poetry install

--- a/docs/en/developer_guidelines/setup.md
+++ b/docs/en/developer_guidelines/setup.md
@@ -83,11 +83,13 @@ pyenv local 3.12.3
 
 ### Poetry
 
-Set up poetry as part of the environment setup
+To set up poetry as part of the environment setup, run the following command:
 
 ```
 make setup-poetry
 ```
+
+This command is required to use the Python version installed with Pyenv, to set up the Python environment, and to install dependencies. This will create a `.venv` in the root directory.
 
 ## Starting the Documentation Server
 

--- a/docs/en/developer_guidelines/setup.md
+++ b/docs/en/developer_guidelines/setup.md
@@ -83,25 +83,11 @@ pyenv local 3.12.3
 
 ### Poetry
 
-To use the Python version installed with Pyenv, run the following command:
+Set up poetry as part of the environment setup
 
-```bash
-poetry env use ~/.pyenv/shims/python
 ```
-
-To set up the Python environment, run the following command:
-
-```bash
-poetry config virtualenvs.in-project true
+make setup-poetry
 ```
-
-Next, install the dependencies:
-
-```bash
-poetry install
-```
-
-This will create a `.venv` in the root directory.
 
 ## Starting the Documentation Server
 

--- a/docs/ja/developer_guidelines/setup.md
+++ b/docs/ja/developer_guidelines/setup.md
@@ -82,25 +82,13 @@ pyenv local 3.12.3
 
 ### Poetry
 
-PyenvでインストールしたPythonバージョンを使用するには、以下のコマンドを実行します：
+環境設定の一環でpoetryを設定するために、以下のコマンドを実行します：
 
-```bash
-poetry env use ~/.pyenv/shims/python
+```
+make setup-poetry
 ```
 
-Python環境をセットアップするには、以下のコマンドを実行します：
-
-```bash
-poetry config virtualenvs.in-project true
-```
-
-次に、依存関係をインストールします：
-
-```bash
-poetry install
-```
-
-これで、ルートディレクトリに.venvが作成されます。
+このコマンドは、PyenvでインストールされたPythonバージョンの使用、Python環境のセットアップ、依存関係のインストールに必要です。これにより、ルートディレクトリに `.venv` が作成されます。
 
 ## ドキュメンテーションサーバーの起動
 


### PR DESCRIPTION
# 📃 Ticket
https://github.com/oqtopus-team/oqtopus-cloud/issues/191

## ✍ Description
The following commands were combined into `make setup-poetry`
- `poetry env use ~/.pyenv/shims/python`
- `poetry config virtualenvs.in-project true`
- `poetry install`