### PR TITLE
fix: fix devices model to respect timezone

### DIFF
--- a/backend/oqtopus_cloud/common/model_util.py
+++ b/backend/oqtopus_cloud/common/model_util.py
@@ -1,4 +1,7 @@
+import datetime
 from typing import Any, Dict
+
+from sqlalchemy.types import DateTime, TypeDecorator
 
 
 def model_to_dict(model: Any) -> Dict[Any, Any]:
@@ -16,3 +19,19 @@ def model_to_schema_dict(
     for model_field, schema_field in map_model_to_schema.items():
         schema_dict[schema_field] = model_dict[model_field]
     return schema_dict
+
+
+class DateTimeTz(TypeDecorator):
+    impl = DateTime
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        # DB保存時: UTCに変換して保存
+        if value is not None and value.tzinfo is not None:
+            return value.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+        return value
+
+    def process_result_value(self, value, dialect):
+        if value is not None:
+            return value.replace(tzinfo=datetime.timezone.utc)
+        return value

--- a/backend/oqtopus_cloud/common/models/device.py
+++ b/backend/oqtopus_cloud/common/models/device.py
@@ -5,6 +5,7 @@ from typing import Optional
 from sqlalchemy import TIMESTAMP, Enum, String
 from sqlalchemy.orm import Mapped, mapped_column
 
+from oqtopus_cloud.common.model_util import DateTimeTz
 from oqtopus_cloud.common.models.base import (
     Base,
 )
@@ -52,6 +53,7 @@ class Device(Base):
         default="unavailable",
     )
     available_at: Mapped[Optional[datetime.datetime]] = mapped_column(
+        DateTimeTz(),
         nullable=True,
     )
     pending_jobs: Mapped[int] = mapped_column(
@@ -70,7 +72,7 @@ class Device(Base):
         nullable=False,
     )
     device_info: Mapped[str]
-    calibrated_at: Mapped[datetime.datetime]
+    calibrated_at: Mapped[datetime.datetime] = mapped_column(DateTimeTz())
     description: Mapped[str] = mapped_column(
         String(128),
         nullable=False,

--- a/backend/oqtopus_cloud/provider/routers/devices.py
+++ b/backend/oqtopus_cloud/provider/routers/devices.py
@@ -157,6 +157,7 @@ def update_device_calibration(
             return NotFoundErrorResponse(f"device_id={device_id} is not found.")
         device_info = request.device_info
         calibrated_at = request.calibrated_at
+        logger.info(f"{calibrated_at}")
         if device.device_type != DeviceType.QPU.value:
             return BadRequestResponse("Calibration is only supported for QPU devices")
         if device_info is None:

--- a/backend/oqtopus_cloud/user/routers/devices.py
+++ b/backend/oqtopus_cloud/user/routers/devices.py
@@ -1,7 +1,5 @@
 import json
-from datetime import datetime
 
-import pytz
 from fastapi import APIRouter, Depends
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -96,24 +94,18 @@ MAP_MODEL_TO_SCHEMA = {
 }
 
 
-def localize(dt: datetime | None) -> datetime | None:
-    if dt is None:
-        return None
-    return pytz.utc.localize(dt)
-
-
 def model_to_schema(model: Device) -> DeviceInfo:
     dict = {
         "device_id": getattr(model, "id", None),
         "device_type": getattr(model, "device_type", None),
         "status": model.status,
-        "available_at": localize(getattr(model, "available_at", None)),
+        "available_at": getattr(model, "available_at", None),
         "n_pending_jobs": getattr(model, "pending_jobs", None),
         "n_qubits": getattr(model, "n_qubits", None),
         "basis_gates": json.loads(getattr(model, "basis_gates", "[]")),
         "supported_instructions": json.loads(getattr(model, "instructions", "[]")),
         "device_info": getattr(model, "device_info", None),
-        "calibrated_at": localize(getattr(model, "calibrated_at", None)),
+        "calibrated_at": getattr(model, "calibrated_at", None),
         "description": model.description,
     }
     return DeviceInfo.model_validate(dict)

--- a/backend/tests/oqtopus_cloud/provider/routers/test_devices.py
+++ b/backend/tests/oqtopus_cloud/provider/routers/test_devices.py
@@ -2,10 +2,11 @@ import json
 from datetime import datetime, timezone
 from typing import Dict
 
-import pytz
+from fastapi.testclient import TestClient
 from oqtopus_cloud.common.models.device import (
     Device,
 )
+from oqtopus_cloud.provider.lambda_function import app
 from oqtopus_cloud.provider.routers.devices import (
     update_device,
     update_device_calibration,
@@ -23,6 +24,7 @@ from zoneinfo import ZoneInfo
 
 # jst = ZoneInfo("Asia/Tokyo")
 utc = ZoneInfo("UTC")
+client = TestClient(app)
 
 
 def _get_calibration_dict() -> Dict:
@@ -138,6 +140,23 @@ def test_update_device_calibration(test_db):
     # Assert
     expected = DeviceDataUpdateResponse(message="Device's data updated")
     assert actual == expected
+
+
+def test_update_device_info_timezone(test_db):
+    # Arrange
+    test_db.add(_get_model_qpu())
+    test_db.commit()
+
+    req = DeviceInfoUpdate.model_validate_json(
+        '{ "device_info": "{}", "calibrated_at": "2025-04-01T12:34:56.789000+09:00" }'
+    )
+
+    resp = client.patch("/devices/SC/device_info", content=req.model_dump_json())
+    assert resp.status_code == 200
+    device = test_db.get(Device, "SC")
+    assert device.calibrated_at == datetime(
+        2025, 4, 1, 3, 34, 56, 789000, tzinfo=timezone.utc
+    )
 
 
 # TODO: add invalid test cases

--- a/backend/tests/oqtopus_cloud/user/routers/test_devices.py
+++ b/backend/tests/oqtopus_cloud/user/routers/test_devices.py
@@ -51,15 +51,15 @@ def _get_model():
         "id": "SVSim",
         "device_type": "simulator",
         "status": "available",
-        "available_at": datetime(2023, 1, 2, 12, 34, 56),
+        "available_at": datetime(2023, 1, 2, 12, 34, 56, tzinfo=pytz.utc),
         "pending_jobs": 8,
         "n_qubits": 39,
         "basis_gates": '["x", "sx", "rz", "cx"]',
         "instructions": '["measure", "barrier", "reset"]',
         "device_info": "{}",
-        "calibrated_at": datetime(2024, 3, 4, 12, 34, 56),
+        "calibrated_at": datetime(2024, 3, 4, 12, 34, 56, tzinfo=pytz.utc),
         "description": "State vector-based quantum circuit simulator",
-        "created_at": datetime(2024, 3, 4, 12, 34, 56),
+        "created_at": datetime(2024, 3, 4, 12, 34, 56, tzinfo=pytz.utc),
     }
     return Device(**mode_dict)
 
@@ -102,14 +102,14 @@ def test_model_to_shema():
         device_id="SVSim",
         device_type=DeviceType.simulator,
         status=Status.available,
-        available_at=pytz.utc.localize(datetime(2023, 1, 2, 12, 34, 56)),
+        available_at=datetime(2023, 1, 2, 12, 34, 56, tzinfo=pytz.utc),
         n_pending_jobs=8,
         n_qubits=39,
         basis_gates=["x", "sx", "rz", "cx"],
         supported_instructions=["measure", "barrier", "reset"],
         # calibrationData=CalibrationData(**_get_calibration_dict()),
         device_info="{}",
-        calibrated_at=pytz.utc.localize(datetime(2024, 3, 4, 12, 34, 56)),
+        calibrated_at=datetime(2024, 3, 4, 12, 34, 56, tzinfo=pytz.utc),
         description="State vector-based quantum circuit simulator",
     )
     assert actual == expected


### PR DESCRIPTION
# 📃 Ticket
This PR fixes #229 

## ✍ Description
Currently, Provider API's `PATCH /devices/:device_id/device_info` endpoint does not respect the timezone in the requet's `calibrated_at` parameter. This is due to the behavior of the MySQL DATETIME column, which does not support timezone. 

To fix this, I added:
  - TypeDecorator `DatetimeTz` to automatically change the timezone during communicating with DB
 
Note: I did not add any change to the User API, for it should be concerned along with the issue [#221](https://github.com/oqtopus-team/oqtopus-cloud/issues/221).
 
## 📸 Test Result
<!--- Paste `make test result` -->

## 🔗 Related PRs
<!--- Paste related PRs -->
