### PR TITLE
add support to filtering jobs by id

### DIFF
--- a/backend/oas/user/openapi.yaml
+++ b/backend/oas/user/openapi.yaml
@@ -127,7 +127,7 @@ paths:
             example: '2022-10-19T11:45:34+09:00'
         - name: q
           in: query
-          description: Allows to filter the list of jobs to fetch by job's name and description. If specified only jobs which name or description contains specified search string are returned.
+          description: Allows to filter the list of jobs to fetch by job's id, name and description. If specified only jobs which id, name or description contains specified search string are returned.
           required: false
           schema:
             type: string

--- a/backend/oas/user/paths/jobs.yaml
+++ b/backend/oas/user/paths/jobs.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: q
         in: query
         description: |-
-          Allows to filter the list of jobs to fetch by job's name and description. If specified only jobs which name or description contains specified search string are returned.
+          Allows to filter the list of jobs to fetch by job's id, name and description. If specified only jobs which id, name or description contains specified search string are returned.
         required: false
         schema:
           type: string

--- a/backend/oqtopus_cloud/user/routers/jobs.py
+++ b/backend/oqtopus_cloud/user/routers/jobs.py
@@ -131,7 +131,13 @@ def get_jobs(
             etime = datetime.fromisoformat(end_time).astimezone(jst)
             stmt = stmt.filter(Job.created_at <= etime)
         if q is not None:
-            stmt = stmt.filter(or_(Job.name.contains(q), Job.description.contains(q)))
+            stmt = stmt.filter(
+                or_(
+                    Job.id.contains(q),
+                    Job.name.contains(q),
+                    Job.description.contains(q),
+                )
+            )
 
         set_params(
             Params(

--- a/docs/oas/user/openapi.yaml
+++ b/docs/oas/user/openapi.yaml
@@ -127,7 +127,7 @@ paths:
             example: '2022-10-19T11:45:34+09:00'
         - name: q
           in: query
-          description: Allows to filter the list of jobs to fetch by job's name and description. If specified only jobs which name or description contains specified search string are returned.
+          description: Allows to filter the list of jobs to fetch by job's id, name and description. If specified only jobs which id, name or description contains specified search string are returned.
           required: false
           schema:
             type: string


### PR DESCRIPTION
# 📃 Ticket

## ✍ Description
As it was requested to unify input for filtering jobs by id, name and description, I've added filtering by id via "q" URL query parameter

## 📸 Test Result

## 🔗 Related PRs
oqtopus-frontend pull request which unifies the mentioned input for filtering jobs
https://github.com/oqtopus-team/oqtopus-frontend/pull/84
