### PR TITLE
Fix/terraform ignore changes on db engine version

### DIFF
--- a/terraform/infrastructure/modules/db/main.tf
+++ b/terraform/infrastructure/modules/db/main.tf
@@ -36,7 +36,7 @@ resource "aws_db_instance" "this" {
   db_subnet_group_name                  = aws_db_subnet_group.this.name
   deletion_protection                   = "true"
   engine                                = "mysql"
-  engine_version                        = "8.0.35"
+  engine_version                        = "8.0.40"
   iam_database_authentication_enabled   = "true"
   instance_class                        = var.db_performance_insights_enabled == true ? "db.t3.medium" : "db.t3.micro"
   iops                                  = "0"
@@ -59,6 +59,10 @@ resource "aws_db_instance" "this" {
   storage_type                          = "gp2"
   username                              = var.user_name
   vpc_security_group_ids                = var.db_security_group_ids
+
+  lifecycle {
+    ignore_changes = [engine_version]
+  }
 }
 
 

--- a/terraform/infrastructure/oqtopus-dev/outputs.tf
+++ b/terraform/infrastructure/oqtopus-dev/outputs.tf
@@ -16,11 +16,6 @@ output "user_cognito" {
   description = "The user cognito information"
 }
 
-output "provider_cognito" {
-  value       = module.provider_cognito
-  description = "The provider cognito information"
-}
-
 output "admin_cognito" {
   value       = module.admin_cognito
   description = "The admin cognito information"

--- a/terraform/infrastructure/oqtopus-prod/outputs.tf
+++ b/terraform/infrastructure/oqtopus-prod/outputs.tf
@@ -16,11 +16,6 @@ output "user_cognito" {
   description = "The user cognito information"
 }
 
-output "provider_cognito" {
-  value       = module.provider_cognito
-  description = "The provider cognito information"
-}
-
 output "admin_cognito" {
   value       = module.admin_cognito
   description = "The admin cognito information"

--- a/terraform/service/modules/deployment-roles/provider.tf
+++ b/terraform/service/modules/deployment-roles/provider.tf
@@ -5,5 +5,5 @@ terraform {
       version = "~> 5.57.0"
     }
   }
-  required_version = "~> 1.9.0"
+  required_version = ">= 1.9.0, < 2.0"
 }


### PR DESCRIPTION
# 📃 Ticket
<!--- Paste related ticket -->

## ✍ Description
Currently, the RDS engine_version is hardcoded in the terraform, and after the engine_version upgrade,
terraform detect the difference to downgrade the actual version to the version specified in the terraform.
Unfortunately, the AWS API does not allow to downgrade the engine_version of running db instance, so applying 
this diffs will end up with error. 
   
## 📸 Test Result
<!--- Paste `make test result` -->

## 🔗 Related PRs
<!--- Paste related PRs -->
