### PR TITLE
add filtering announcements by optional current_time query parameter

### DIFF
--- a/backend/oas/admin/openapi.yaml
+++ b/backend/oas/admin/openapi.yaml
@@ -529,6 +529,14 @@ paths:
               - DESC
               - ASC
             default: ASC
+        - name: current_time
+          in: query
+          description: Allows to filter the list of announcements to fetch by provided time. If specified only announcements with start_time <= current_time and end_time >= current_time are returned.
+          required: false
+          schema:
+            type: string
+            format: date-time
+            example: '2022-10-19T11:45:34Z'
       responses:
         '200':
           description: Return announcements

--- a/backend/oas/admin/paths/announcements.yaml
+++ b/backend/oas/admin/paths/announcements.yaml
@@ -35,7 +35,7 @@ announcements:
         schema:
           type: string
           format: date-time
-          example: '2022-10-19T11:45:34Z'      
+          example: '2022-10-19T11:45:34Z'
     responses:
       "200":
         description: "Return announcements"

--- a/backend/oas/admin/paths/announcements.yaml
+++ b/backend/oas/admin/paths/announcements.yaml
@@ -28,6 +28,14 @@ announcements:
           enum:
             ["DESC", "ASC"]
           default: "ASC"
+      - name: current_time
+        in: query
+        description: Allows to filter the list of announcements to fetch by provided time. If specified only announcements with start_time <= current_time and end_time >= current_time are returned.
+        required: false
+        schema:
+          type: string
+          format: date-time
+          example: '2022-10-19T11:45:34Z'      
     responses:
       "200":
         description: "Return announcements"

--- a/backend/oas/user/openapi.yaml
+++ b/backend/oas/user/openapi.yaml
@@ -657,6 +657,14 @@ paths:
               - DESC
               - ASC
             default: ASC
+        - name: current_time
+          in: query
+          description: Allows to filter the list of announcements to fetch by provided time. If specified only announcements with start_time <= current_time and end_time >= current_time are returned.
+          required: false
+          schema:
+            type: string
+            format: date-time
+            example: '2022-10-19T11:45:34Z'
       responses:
         '200':
           description: Return announcements

--- a/backend/oas/user/paths/announcements.yaml
+++ b/backend/oas/user/paths/announcements.yaml
@@ -28,6 +28,14 @@ announcements:
           enum:
             ["DESC", "ASC"]
           default: "ASC"
+      - name: current_time
+        in: query
+        description: Allows to filter the list of announcements to fetch by provided time. If specified only announcements with start_time <= current_time and end_time >= current_time are returned.
+        required: false
+        schema:
+          type: string
+          format: date-time
+          example: '2022-10-19T11:45:34Z'
     responses:
       "200":
         description: "Return announcements"

--- a/backend/oqtopus_cloud/admin/routers/announcements.py
+++ b/backend/oqtopus_cloud/admin/routers/announcements.py
@@ -1,8 +1,8 @@
-from datetime import timedelta
+from datetime import timedelta, datetime
 from typing import Optional
 
 from fastapi import APIRouter, Depends, status
-from sqlalchemy import asc, desc, select
+from sqlalchemy import asc, desc, select, and_
 from sqlalchemy.orm import Session
 from zoneinfo import ZoneInfo
 
@@ -44,6 +44,7 @@ def get_announcements_list(
     offset: Optional[int] = 0,
     limit: Optional[int] = 10,
     order: Optional[str] = None,
+    current_time: Optional[str] = None,
     db: Session = Depends(get_db),
 ) -> GetAnnouncementsListResponse | ErrorResponse:
     try:
@@ -55,9 +56,15 @@ def get_announcements_list(
             else asc(Announcement.start_time)
         )
 
-        query_result = db.scalars(
-            select(Announcement).offset(offset).limit(limit).order_by(arg_order)
-        ).all()
+        stmt = select(Announcement).offset(offset).limit(limit).order_by(arg_order)
+
+        if current_time is not None:
+            ctime = datetime.fromisoformat(current_time).astimezone(utc)
+            stmt = stmt.filter(
+                and_(Announcement.start_time <= ctime, Announcement.end_time >= ctime)
+            )
+
+        query_result = db.scalars(stmt).all()
         announcements_list = [
             model_to_schema(announcement) for announcement in query_result
         ]

--- a/backend/oqtopus_cloud/user/routers/announcements.py
+++ b/backend/oqtopus_cloud/user/routers/announcements.py
@@ -6,7 +6,7 @@ from oqtopus_cloud.common.models.announcements import Announcement
 from oqtopus_cloud.user.schemas.announcements import GetAnnouncementsListResponse
 import pytz
 from fastapi import APIRouter, Depends
-from sqlalchemy import asc, desc, select
+from sqlalchemy import asc, desc, select, and_
 from sqlalchemy.orm import Session
 from zoneinfo import ZoneInfo
 
@@ -38,6 +38,7 @@ def get_announcements_list(
     offset: Optional[int] = 0,
     limit: Optional[int] = 10,
     order: Optional[str] = None,
+    current_time: Optional[str] = None,
     db: Session = Depends(get_db),
 ) -> GetAnnouncementsListResponse | ErrorResponse:
     try:
@@ -49,10 +50,15 @@ def get_announcements_list(
             else asc(Announcement.start_time)
         )
 
-        announcements_list = db.scalars(
-            select(Announcement).offset(offset).limit(limit).order_by(arg_order)
-        ).all()
+        stmt = select(Announcement).offset(offset).limit(limit).order_by(arg_order)
 
+        if current_time is not None:
+            ctime = datetime.fromisoformat(current_time).astimezone(utc)
+            stmt = stmt.filter(
+                and_(Announcement.start_time <= ctime, Announcement.end_time >= ctime)
+            )
+
+        announcements_list = db.scalars(stmt).all()
         return GetAnnouncementsListResponse(
             announcements=[
                 model_to_schema(announcement) for announcement in announcements_list

--- a/backend/tests/oqtopus_cloud/admin/routers/test_announcements.py
+++ b/backend/tests/oqtopus_cloud/admin/routers/test_announcements.py
@@ -149,7 +149,7 @@ def test_get_announcements_list_with_current_time(test_db):
     actual = adapter.validate_python(response.json())
 
     expected = GetAnnouncementsListResponse(announcements=[
-         GetAnnouncementResponse(
+        GetAnnouncementResponse(
             id=2,
             title="title2",
             content="content2",

--- a/backend/tests/oqtopus_cloud/admin/routers/test_announcements.py
+++ b/backend/tests/oqtopus_cloud/admin/routers/test_announcements.py
@@ -116,6 +116,63 @@ def test_get_all_announcements_offset1_limit2_desc(
     assert actual == expect
 
 
+def test_get_announcements_list_with_current_time(test_db):
+    test_db.flush()
+    test_db.add(Announcement(
+        id=1, 
+        title="title1", 
+        content="content1", 
+        start_time=datetime(2025, 1, 5, 12, 34, 56, tzinfo=timezone.utc), 
+        end_time=datetime(2025, 1, 6, 12, 34, 56, tzinfo=timezone.utc), 
+        updated_at=datetime(2025, 1, 5, 12, 34, 56, tzinfo=timezone.utc)
+    ))
+    test_db.add(Announcement(
+        id=2, 
+        title="title2", 
+        content="content2", 
+        start_time=datetime(2025, 1, 4, 12, 34, 56, tzinfo=timezone.utc), 
+        end_time=datetime(2025, 1, 6, 12, 34, 56, tzinfo=timezone.utc), 
+        updated_at=datetime(2025, 1, 4, 12, 34, 56, tzinfo=timezone.utc)
+    ))
+    test_db.add(Announcement(
+        id=3, 
+        title="title3", 
+        content="content3", 
+        start_time=datetime(2025, 1, 4, 12, 34, 56, tzinfo=timezone.utc), 
+        end_time=datetime(2025, 1, 5, 11, 34, 56, tzinfo=timezone.utc), 
+        updated_at=datetime(2025, 1, 4, 12, 34, 56, tzinfo=timezone.utc)
+    ))
+    test_db.commit()
+
+    response = client.get("/announcements?current_time=2025-01-05T18:20:26Z")
+    adapter = TypeAdapter(GetAnnouncementsListResponse)
+    actual = adapter.validate_python(response.json())
+
+    expected = GetAnnouncementsListResponse(announcements=[
+         GetAnnouncementResponse(
+            id=2,
+            title="title2",
+            content="content2",
+            publishable=False,
+            start_time=datetime(2025, 1, 4, 12, 34, 56, tzinfo=timezone.utc),
+            end_time=datetime(2025, 1, 6, 12, 34, 56, tzinfo=timezone.utc),
+            updated_at=datetime(2025, 1, 4, 12, 34, 56, tzinfo=timezone.utc),
+        ),
+        GetAnnouncementResponse(
+            id=1,
+            title="title1",
+            content="content1",
+            publishable=False,
+            start_time=datetime(2025, 1, 5, 12, 34, 56, tzinfo=timezone.utc),
+            end_time=datetime(2025, 1, 6, 12, 34, 56, tzinfo=timezone.utc),
+            updated_at=datetime(2025, 1, 5, 12, 34, 56, tzinfo=timezone.utc),
+        ),
+    ])
+
+    assert response.status_code == 200
+    assert actual == expected
+
+
 def test_get_all_announcements_500():
     """_summary_
     GET /announcements tests 500 error

--- a/backend/tests/oqtopus_cloud/admin/routers/test_announcements.py
+++ b/backend/tests/oqtopus_cloud/admin/routers/test_announcements.py
@@ -124,7 +124,7 @@ def test_get_announcements_list_with_current_time(test_db):
         content="content1", 
         start_time=datetime(2025, 1, 5, 12, 34, 56, tzinfo=timezone.utc), 
         end_time=datetime(2025, 1, 6, 12, 34, 56, tzinfo=timezone.utc), 
-        updated_at=datetime(2025, 1, 5, 12, 34, 56, tzinfo=timezone.utc)
+        updated_at=datetime(2025, 1, 5, 12, 34, 56, tzinfo=timezone.utc),
     ))
     test_db.add(Announcement(
         id=2, 
@@ -132,7 +132,7 @@ def test_get_announcements_list_with_current_time(test_db):
         content="content2", 
         start_time=datetime(2025, 1, 4, 12, 34, 56, tzinfo=timezone.utc), 
         end_time=datetime(2025, 1, 6, 12, 34, 56, tzinfo=timezone.utc), 
-        updated_at=datetime(2025, 1, 4, 12, 34, 56, tzinfo=timezone.utc)
+        updated_at=datetime(2025, 1, 4, 12, 34, 56, tzinfo=timezone.utc),
     ))
     test_db.add(Announcement(
         id=3, 
@@ -140,7 +140,7 @@ def test_get_announcements_list_with_current_time(test_db):
         content="content3", 
         start_time=datetime(2025, 1, 4, 12, 34, 56, tzinfo=timezone.utc), 
         end_time=datetime(2025, 1, 5, 11, 34, 56, tzinfo=timezone.utc), 
-        updated_at=datetime(2025, 1, 4, 12, 34, 56, tzinfo=timezone.utc)
+        updated_at=datetime(2025, 1, 4, 12, 34, 56, tzinfo=timezone.utc),
     ))
     test_db.commit()
 

--- a/backend/tests/oqtopus_cloud/user/routers/test_announcements.py
+++ b/backend/tests/oqtopus_cloud/user/routers/test_announcements.py
@@ -198,7 +198,7 @@ def test_get_announcements_list_with_current_time(test_db):
     actual = adapter.validate_python(response.json())
 
     expected = GetAnnouncementsListResponse(announcements=[
-         GetAnnouncementResponse(
+        GetAnnouncementResponse(
             id=2,
             title="title2",
             content="content2",

--- a/backend/tests/oqtopus_cloud/user/routers/test_announcements.py
+++ b/backend/tests/oqtopus_cloud/user/routers/test_announcements.py
@@ -175,21 +175,21 @@ def test_get_announcements_list_with_current_time(test_db):
         title="title1", 
         content="content1", 
         start_time=datetime(2025, 1, 5, 12, 34, 56, tzinfo=utc), 
-        end_time=datetime(2025, 1, 6, 12, 34, 56, tzinfo=utc)
+        end_time=datetime(2025, 1, 6, 12, 34, 56, tzinfo=utc),
     ))
     test_db.add(Announcement(
         id=2, 
         title="title2", 
         content="content2", 
         start_time=datetime(2025, 1, 4, 12, 34, 56, tzinfo=utc), 
-        end_time=datetime(2025, 1, 6, 12, 34, 56, tzinfo=utc)
+        end_time=datetime(2025, 1, 6, 12, 34, 56, tzinfo=utc),
     ))
     test_db.add(Announcement(
         id=3, 
         title="title3", 
         content="content3", 
         start_time=datetime(2025, 1, 4, 12, 34, 56, tzinfo=utc), 
-        end_time=datetime(2025, 1, 5, 11, 34, 56, tzinfo=utc)
+        end_time=datetime(2025, 1, 5, 11, 34, 56, tzinfo=utc),
     ))
     test_db.commit()
 

--- a/backend/tests/oqtopus_cloud/user/routers/test_announcements.py
+++ b/backend/tests/oqtopus_cloud/user/routers/test_announcements.py
@@ -168,6 +168,58 @@ def test_get_announcements_list_with_order(test_db):
     assert actual == expected
 
 
+def test_get_announcements_list_with_current_time(test_db):
+    test_db.flush()
+    test_db.add(Announcement(
+        id=1, 
+        title="title1", 
+        content="content1", 
+        start_time=datetime(2025, 1, 5, 12, 34, 56, tzinfo=utc), 
+        end_time=datetime(2025, 1, 6, 12, 34, 56, tzinfo=utc)
+    ))
+    test_db.add(Announcement(
+        id=2, 
+        title="title2", 
+        content="content2", 
+        start_time=datetime(2025, 1, 4, 12, 34, 56, tzinfo=utc), 
+        end_time=datetime(2025, 1, 6, 12, 34, 56, tzinfo=utc)
+    ))
+    test_db.add(Announcement(
+        id=3, 
+        title="title3", 
+        content="content3", 
+        start_time=datetime(2025, 1, 4, 12, 34, 56, tzinfo=utc), 
+        end_time=datetime(2025, 1, 5, 11, 34, 56, tzinfo=utc)
+    ))
+    test_db.commit()
+
+    response = client.get("/announcements?current_time=2025-01-05T18:20:26Z")
+    adapter = TypeAdapter(GetAnnouncementsListResponse)
+    actual = adapter.validate_python(response.json())
+
+    expected = GetAnnouncementsListResponse(announcements=[
+         GetAnnouncementResponse(
+            id=2,
+            title="title2",
+            content="content2",
+            publishable=False,
+            start_time=datetime(2025, 1, 4, 12, 34, 56, tzinfo=utc),
+            end_time=datetime(2025, 1, 6, 12, 34, 56, tzinfo=utc),
+        ),
+        GetAnnouncementResponse(
+            id=1,
+            title="title1",
+            content="content1",
+            publishable=False,
+            start_time=datetime(2025, 1, 5, 12, 34, 56, tzinfo=utc),
+            end_time=datetime(2025, 1, 6, 12, 34, 56, tzinfo=utc),
+        ),
+    ])
+
+    assert response.status_code == 200
+    assert actual == expected
+
+
 def test_get_announcements_list_all_params(test_db):
     test_db.flush()
     test_db.add(_get_model(id=1, title="title1", content="content1", publishable=True))

--- a/docs/oas/admin/openapi.yaml
+++ b/docs/oas/admin/openapi.yaml
@@ -529,6 +529,14 @@ paths:
               - DESC
               - ASC
             default: ASC
+        - name: current_time
+          in: query
+          description: Allows to filter the list of announcements to fetch by provided time. If specified only announcements with start_time <= current_time and end_time >= current_time are returned.
+          required: false
+          schema:
+            type: string
+            format: date-time
+            example: '2022-10-19T11:45:34Z'
       responses:
         '200':
           description: Return announcements

--- a/docs/oas/user/openapi.yaml
+++ b/docs/oas/user/openapi.yaml
@@ -657,6 +657,14 @@ paths:
               - DESC
               - ASC
             default: ASC
+        - name: current_time
+          in: query
+          description: Allows to filter the list of announcements to fetch by provided time. If specified only announcements with start_time <= current_time and end_time >= current_time are returned.
+          required: false
+          schema:
+            type: string
+            format: date-time
+            example: '2022-10-19T11:45:34Z'
       responses:
         '200':
           description: Return announcements


### PR DESCRIPTION
# 📃 Ticket

## ✍ Description
As discussed, updated Announcements API to enable filtering announcements by current_time query parameter. If it is provided, then the GET announcements request will return only those announcements which start_time is before current_time and end_time is after current_time

## 📸 Test Result

## 🔗 Related PRs
