### PR TITLE
feat: make editorconfig-checker ignore markdown

### DIFF
--- a/.github/workflows/editorconfig-review.yaml
+++ b/.github/workflows/editorconfig-review.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run editorconfig-checker with reviewdog
         run: |
-          bin/ec-${{ env.OS }}-${{ env.ARCH }} > output_ecc.txt || true
+          bin/ec-${{ env.OS }}-${{ env.ARCH }} -exclude '.*\.md$' > output_ecc.txt || true
           python3 scripts/ecc_converter.py < output_ecc.txt > result_py.txt
           reviewdog -efm="%f:%l:%c: %m" -name="editorconfig-checker" -reporter=github-pr-review < result_py.txt
         env:


### PR DESCRIPTION
# 📃 Ticket
https://github.com/oqtopus-team/oqtopus-cloud/issues/242

## ✍ Description
I only added `-exclude '.*\.md$'` to make editorconfig-checker ignore md files.

