### PR TITLE
feat: renamed provider APIs `GET /jobs` parameter max_results -> limit

### DIFF
--- a/backend/oas/provider/openapi.yaml
+++ b/backend/oas/provider/openapi.yaml
@@ -207,7 +207,7 @@ paths:
           schema:
             $ref: '#/components/schemas/jobs.JobStatus'
         - in: query
-          name: max_results
+          name: limit
           required: false
           description: Additional search parameter:<br/> Set max number of quantum jobs to return in single request
           schema:

--- a/backend/oas/provider/paths/jobs.yaml
+++ b/backend/oas/provider/paths/jobs.yaml
@@ -21,7 +21,7 @@ jobs:
         schema:
           $ref: "../schemas/jobs.yaml#/jobs.JobStatus"
       - in: query
-        name: max_results
+        name: limit
         required: false
         description: "Additional search parameter:<br/> Set max number of quantum jobs to return in single request"
         schema:

--- a/backend/oqtopus_cloud/provider/routers/jobs.py
+++ b/backend/oqtopus_cloud/provider/routers/jobs.py
@@ -57,7 +57,7 @@ def get_jobs(
     device_id: str,
     fields: Optional[str] = None,
     status: Optional[str] = None,
-    max_results: Optional[int] = None,
+    limit: Optional[int] = None,
     timestamp: Optional[str] = None,
     db: Session = Depends(get_db),
 ) -> list[JobDef] | ErrorResponse:
@@ -99,8 +99,8 @@ def get_jobs(
         if timestamp is not None:
             time = datetime.fromisoformat(timestamp).astimezone(jst)
             select_stmt = select_stmt.filter(Job.created_at > time)
-        if max_results is not None:
-            select_stmt = select_stmt.limit(max_results)
+        if limit is not None:
+            select_stmt = select_stmt.limit(limit)
 
         models = db.scalars(select_stmt).all()
 

--- a/backend/tests/oqtopus_cloud/provider/routers/test_jobs.py
+++ b/backend/tests/oqtopus_cloud/provider/routers/test_jobs.py
@@ -210,7 +210,7 @@ def test_get_jobs_timestamp(test_db: Session):
         assert act.job_id == exp_job_id
 
 
-def test_get_jobs_max_results(test_db: Session):
+def test_get_jobs_limit(test_db: Session):
     # Arrange
     test_db.flush()
     for i in range(1, 10):
@@ -218,7 +218,7 @@ def test_get_jobs_max_results(test_db: Session):
     test_db.add(_get_device_model())
     test_db.commit()
 
-    response = client.get("/jobs?device_id=SC2&max_results=3")
+    response = client.get("/jobs?device_id=SC2&limit=3")
     adapter = TypeAdapter(List[JobDef])
     actual = adapter.validate_python(response.json())
     expect_job_ids = [

--- a/docs/oas/provider/openapi.yaml
+++ b/docs/oas/provider/openapi.yaml
@@ -207,7 +207,7 @@ paths:
           schema:
             $ref: '#/components/schemas/jobs.JobStatus'
         - in: query
-          name: max_results
+          name: limit
           required: false
           description: Additional search parameter:<br/> Set max number of quantum jobs to return in single request
           schema:


### PR DESCRIPTION
# 📃 Ticket
#220 

## ✍ Description
renamed provider APIs `GET /jobs` parameter: max_results -> limit

## 📸 Test Result
<!--- Paste `make test result` -->

## 🔗 Related PRs
<!--- Paste related PRs -->
