### PR TITLE
Duplicate job display bug

### DIFF
--- a/backend/oqtopus_cloud/admin/routers/announcements.py
+++ b/backend/oqtopus_cloud/admin/routers/announcements.py
@@ -56,7 +56,12 @@ def get_announcements_list(
             else asc(Announcement.start_time)
         )
 
-        stmt = select(Announcement).offset(offset).limit(limit).order_by(arg_order)
+        stmt = (
+            select(Announcement)
+            .offset(offset)
+            .limit(limit)
+            .order_by(arg_order, Announcement.id)
+        )
 
         if current_time is not None:
             ctime = datetime.fromisoformat(current_time).astimezone(utc)

--- a/backend/oqtopus_cloud/user/routers/announcements.py
+++ b/backend/oqtopus_cloud/user/routers/announcements.py
@@ -50,7 +50,12 @@ def get_announcements_list(
             else asc(Announcement.start_time)
         )
 
-        stmt = select(Announcement).offset(offset).limit(limit).order_by(arg_order)
+        stmt = (
+            select(Announcement)
+            .offset(offset)
+            .limit(limit)
+            .order_by(arg_order, Announcement.id)
+        )
 
         if current_time is not None:
             ctime = datetime.fromisoformat(current_time).astimezone(utc)

--- a/backend/oqtopus_cloud/user/routers/jobs.py
+++ b/backend/oqtopus_cloud/user/routers/jobs.py
@@ -111,7 +111,7 @@ def get_jobs(
                 stmt = (
                     select(Job)
                     .filter(Job.owner == owner)
-                    .order_by(arg_order)
+                    .order_by(arg_order, Job.id)
                     .options(load_only(*arg_select))
                 )
             else:
@@ -123,7 +123,7 @@ def get_jobs(
                     message=f"fields {invalid_fields_list} is invalid"
                 )
         else:
-            stmt = select(Job).filter(Job.owner == owner).order_by(arg_order)
+            stmt = select(Job).filter(Job.owner == owner).order_by(arg_order, Job.id)
 
         # Filtering Jobs
         if start_time is not None:


### PR DESCRIPTION
# 📃 Ticket
https://github.com/oqtopus-team/oqtopus-frontend/issues/112

## ✍ Description
In APIs that use pagination, when the value of the column we sort entities by is the same, then the order of retrieved entities cannot be guaranteed. Thus, we may encounter duplicates on the frontend from retrieving the same entities in different pages in pagination. To fix that, we have to add second sorting parameter (id), so that the database will always be able to determine the order the same way.

## 📸 Test Result

## 🔗 Related PRs
