### PR TITLE
bugfix: fix typo in endpoint from /whitelist to /whitelist_users for …

### DIFF
--- a/backend/oas/admin/openapi.yaml
+++ b/backend/oas/admin/openapi.yaml
@@ -217,7 +217,7 @@ paths:
                 $ref: '#/components/schemas/error.InternalServerError'
               example:
                 message: Internal Server Error
-  /whitelist:
+  /whitelist_users:
     get:
       tags:
         - WhitelistUsers

--- a/backend/oas/admin/root.yaml
+++ b/backend/oas/admin/root.yaml
@@ -17,7 +17,7 @@ paths:
     $ref: ./paths/users.yaml#/users
   /users/{user_id}:
     $ref: ./paths/users.yaml#/users.user_id
-  /whitelist:
+  /whitelist_users:
     $ref: ./paths/whitelist_users.yaml#/whitelist_users
   /devices:
     $ref: ./paths/devices.yaml#/devices

--- a/backend/oqtopus_cloud/admin/lambda_function.py
+++ b/backend/oqtopus_cloud/admin/lambda_function.py
@@ -16,6 +16,9 @@ from starlette.middleware.cors import CORSMiddleware
 from oqtopus_cloud.admin.conf import logger, metrics, tracer
 from oqtopus_cloud.admin.middleware import CustomMiddleware
 from oqtopus_cloud.admin.routers import (
+    announcements as announcements_router,
+)
+from oqtopus_cloud.admin.routers import (
     devices as devices_router,
 )
 from oqtopus_cloud.admin.routers import (
@@ -23,9 +26,6 @@ from oqtopus_cloud.admin.routers import (
 )
 from oqtopus_cloud.admin.routers import (
     whitelist_users as whitelist_router,
-)
-from oqtopus_cloud.admin.routers import (
-    announcements as announcements_router,
 )
 
 app: FastAPI = add_pagination(FastAPI())
@@ -54,7 +54,7 @@ app.include_router(
 
 app.include_router(
     whitelist_router.router,
-    tags=["whitelist"],
+    tags=["whitelist_users"],
 )
 
 app.include_router(


### PR DESCRIPTION
…consistency

# 📃 Ticket
* https://github.com/oqtopus-team/oqtopus-cloud/issues/298

## ✍ Description
Fix typo in root.yaml (from whitelist to whitelist_users), which would not affect current behavior.
