### PR TITLE
ci: auto detect OAS breaking changes

### DIFF
--- a/.github/workflows/openapi-check.yaml
+++ b/.github/workflows/openapi-check.yaml
@@ -2,10 +2,7 @@ name: OpenAPI check
 
 on:
   pull_request:
-    branches:
-      - 'test/#335-auto-detect-oas-breaking-changes'
     paths:
-      - '.github/workflows/**'
       - 'backend/oas/admin/**'
       - 'backend/oas/provider/**'
       - 'backend/oas/user/**'


### PR DESCRIPTION
# 📃 Ticket
#335 

## ✍ Description
I've added `OpenAPI check` Github action. This is on pull_request action. It uses oasdiff tool to detect OAS braking changes. This action for each API (user, provider etc.) analyses openapi.yaml changes and posts a PR comment if potential braking changes are detected.

## 📸 Test Result
Test PR used for OpenAPI check` Github action: [#341 ](https://github.com/oqtopus-team/oqtopus-cloud/pull/341)
I will remove test PR and test branches later on.