### PR TITLE
feat: setup S3 VPC Endpoint

### DIFF
--- a/terraform/infrastructure/modules/network/main.tf
+++ b/terraform/infrastructure/modules/network/main.tf
@@ -243,3 +243,19 @@ resource "aws_route_table_association" "private" {
   subnet_id      = aws_subnet.private[each.key].id
   route_table_id = aws_route_table.private[each.key].id
 }
+
+## S3 VPC Endpoint (Gateway)
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = aws_vpc.this.id
+  service_name      = "com.amazonaws.${var.region}.s3"
+  vpc_endpoint_type = "Gateway"
+  tags = {
+    Name = "${var.product}-${var.org}-${var.env}-s3-vpc-endpoint"
+  }
+}
+
+resource "aws_vpc_endpoint_route_table_association" "private_s3" {
+  for_each        = aws_route_table.private
+  route_table_id  = each.value.id
+  vpc_endpoint_id = aws_vpc_endpoint.s3.id
+}


### PR DESCRIPTION
# 📃 Ticket
[Issue #347](https://github.com/oqtopus-team/oqtopus-cloud/issues/347)

## ✍ Description
Implemented S3 VPC Endpoint (Gateway type) in the shared network module to optimize costs and enhance security.

### Changes
- Added `aws_vpc_endpoint` resource to `terraform/infrastructure/modules/network/main.tf`
- Configured as Gateway type with dynamic service name (`com.amazonaws.${var.region}.s3`)
- Associated the endpoint with private route tables to bypass NAT Gateway for S3 traffic

## 📸 Test Result
Running `terraform validate` or `tflint` (if available) is recommended.
(Paste output of `terraform fmt -recursive` or validation here)
