### PR TITLE
fix: add auto deployment policy by adding Lambda alias management per…

### DIFF
--- a/terraform/service/modules/deployment-roles/main.tf
+++ b/terraform/service/modules/deployment-roles/main.tf
@@ -71,13 +71,21 @@ resource "aws_iam_role" "github_actions_role" {
 }
 
 resource "aws_iam_role_policy" "auto_deployment_policy" {
-  name   = "${var.product}-${var.org}-${var.env}-auto-deployment-policy"
-  role   = aws_iam_role.github_actions_role.id
+  name = "${var.product}-${var.org}-${var.env}-auto-deployment-policy"
+  role = aws_iam_role.github_actions_role.id
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
-      Effect   = "Allow"
-      Action   = ["iam:ListAccountAliases", "lambda:UpdateFunctionCode", "lambda:TagResource"]
+      Effect = "Allow"
+      Action = [
+        "iam:ListAccountAliases",
+        "lambda:UpdateFunctionCode",
+        "lambda:TagResource",
+        "lambda:CreateAlias",
+        "lambda:UpdateAlias",
+        "lambda:GetAlias",
+        "lambda:PublishVersion"
+      ]
       Resource = "*"
     }]
   })


### PR DESCRIPTION
## Root Cause
The IAM role `oqtopus-oqtopus-dev-deploy-lambda` used by GitHub Actions lacked the necessary permissions to manage Lambda aliases and versions during deployment.

## Solution
Added the following Lambda permissions to the deployment IAM role:
- `lambda:CreateAlias` - Create Lambda function aliases
- `lambda:UpdateAlias` - Update existing aliases
- `lambda:GetAlias` - Retrieve alias information
- `lambda:PublishVersion` - Publish new Lambda versions

## Changes

Updated `terraform/service/modules/deployment-roles/main.tf` to include Lambda alias management permissions in the `auto_deployment_policy`.