### PR TITLE
MySQL upgrade from 8.0 to 8.4

### DIFF
--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mysql:8.0
+    image: mysql:8.4
     platform: linux/x86_64
     environment:
       - MYSQL_DATABASE=main

--- a/backend/db/conf.d/my.cnf
+++ b/backend/db/conf.d/my.cnf
@@ -1,7 +1,7 @@
 [mysqld]
 character-set-server=utf8mb4
 collation-server=utf8mb4_unicode_ci
-default_authentication_plugin= mysql_native_password
+authentication_policy=caching_sha2_password
 sql_mode=NO_ENGINE_SUBSTITUTION
 [client]
 default-character-set=utf8mb4

--- a/terraform/infrastructure/modules/db/main.tf
+++ b/terraform/infrastructure/modules/db/main.tf
@@ -36,7 +36,7 @@ resource "aws_db_instance" "this" {
   db_subnet_group_name                  = aws_db_subnet_group.this.name
   deletion_protection                   = "true"
   engine                                = "mysql"
-  engine_version                        = "8.0.40"
+  engine_version                        = "8.4.8"
   iam_database_authentication_enabled   = "true"
   instance_class                        = var.db_performance_insights_enabled == true ? "db.t3.medium" : "db.t3.micro"
   iops                                  = "0"
@@ -48,7 +48,7 @@ resource "aws_db_instance" "this" {
   monitoring_interval                   = "0"
   multi_az                              = "true"
   network_type                          = "IPV4"
-  option_group_name                     = "default:mysql-8-0"
+  option_group_name                     = "default:mysql-8-4"
   parameter_group_name                  = aws_db_parameter_group.this.name
   performance_insights_enabled          = var.db_performance_insights_enabled
   performance_insights_kms_key_id       = var.db_performance_insights_enabled == true ? aws_kms_key.db_performance_insights[0].arn : null
@@ -94,8 +94,8 @@ resource "aws_db_subnet_group" "this" {
 
 resource "aws_db_parameter_group" "this" {
   name        = "${var.product}-${var.org}-${var.env}"
-  description = "default mysql8.0 with log_bin_trust_function_creators enabled"
-  family      = "mysql8.0"
+  description = "default mysql8.4 with log_bin_trust_function_creators enabled"
+  family      = "mysql8.4"
 
   parameter {
     apply_method = "immediate"
@@ -107,7 +107,7 @@ resource "aws_db_parameter_group" "this" {
 resource "aws_db_proxy" "this" {
   auth {
     auth_scheme               = "SECRETS"
-    client_password_auth_type = "MYSQL_NATIVE_PASSWORD"
+    client_password_auth_type = "MYSQL_CACHING_SHA2_PASSWORD"
     iam_auth                  = "DISABLED"
     secret_arn                = aws_db_instance.this.master_user_secret[0].secret_arn
   }
@@ -115,7 +115,7 @@ resource "aws_db_proxy" "this" {
   engine_family          = "MYSQL"
   idle_client_timeout    = "5400"
   name                   = "${var.product}-${var.org}-${var.env}"
-  require_tls            = "false"
+  require_tls            = "true"
   role_arn               = aws_iam_role.db_proxy.arn
   vpc_security_group_ids = var.db_proxy_security_group_ids
   vpc_subnet_ids         = var.subnet_ids


### PR DESCRIPTION
# 📃 Ticket
https://github.com/oqtopus-team/oqtopus-cloud/issues/360

## ✍ Description
This pull request contains changes required for upgrading MySQL from version 8.0 to 8.4.

Due to the fact, that default_authentication_plugin and mysql_native_password authentication method are both deprecated in the 8.4 version, they were replaced with default authentication_policy, which is caching_sha2_password. Therefore, BEFORE the upgrade of MySQL is performed, it is necessary to update every user in **mysql.user** table that has "plugin" column with value equal to "mysql_native_password" (it is important to do it before the upgrade at least for the root user, so that we are able to log into database from terminal). In order to do update the given user following SQL statement may be used:
`ALTER USER <user>@<host>
  IDENTIFIED WITH caching_sha2_password
  BY '<password-of-user>';` 
The plugin currently used by the given user may be checked as follows:
`SELECT user, host, plugin 
FROM USER;`

After updating user with the alter user statement, the value of plugin column should be equal to "caching_sha2_password".

Moreover, for this upgrade the authentication method for database proxy has also been changed to "MYSQL_CACHING_SHA2_PASSWORD". This method requires TLS enabled, therefore the "require_tls" flag has been set to true.


## **2026.7.3 Added:* Rollout order (must be followed at apply time)
1. Migrate DB users to `caching_sha2_password` (incl. `root` **and the RDS-managed
   master user** the proxy authenticates with) — see ALTER USER above.
2. Upgrade the engine 8.0 → 8.4 **out-of-band** (manual in-place / Blue-Green).
   Terraform does NOT perform this: `engine_version` is intentionally kept in
   `lifecycle.ignore_changes`.
3. `terraform apply` — this attaches the `mysql8.4` parameter/option group and flips
   the proxy to `caching_sha2` / `require_tls = true`. It will FAIL if run while the
   instance is still 8.0.
4. Prerequisite: the app-side TLS change (#478) must already be deployed (done), so
   `require_tls = true` does not break Lambda→DB connectivity.
