### PR TITLE
bugfix: #369 fixed API gateway auth permissions definition in terraform

### DIFF
--- a/terraform/service/modules/api-server/main.tf
+++ b/terraform/service/modules/api-server/main.tf
@@ -491,7 +491,8 @@ resource "aws_lambda_permission" "apigw_lambda_auth_invoke" {
   count         = var.authorizer_type == "LAMBDA" ? 1 : 0
   statement_id  = "AllowAPIGatewayInvokeForLambdaAuth"
   action        = "lambda:InvokeFunction"
-  function_name = "${var.lambda_authorizer_arn}:${var.lambda_authorizer_alias}"
+  function_name = var.lambda_authorizer_arn
+  qualifier     = var.lambda_authorizer_alias
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
 }


### PR DESCRIPTION
# 📃 Ticket
#369 

## ✍ Description
I've reproduced the problem with the following terraform message:

```
Terraform will perform the following actions:
  # module.user_api.aws_lambda_permission.apigw_lambda_auth_invoke[0] must be replaced
-/+ resource "aws_lambda_permission" "apigw_lambda_auth_invoke" {
      ~ function_name       = "arn:aws:lambda:ap-northeast-1:741448931691:function:oqtopus-fjq-dev-lambda_auth" -> "arn:aws:lambda:ap-northeast-1:741448931691:function:oqtopus-fjq-dev-lambda_auth:snapstart" # forces replacement
      ~ id                  = "AllowAPIGatewayInvokeForLambdaAuth" -> (known after apply)
      - qualifier           = "snapstart" -> null # forces replacement
      + statement_id_prefix = (known after apply)
        # (4 unchanged attributes hidden)
    }
```

Solution is to specify "snapstart" alias not as a part of function name, but as a qualifier parameter. 