### PR TITLE
Fix : Defaults null json field to {}

### DIFF
--- a/backend/oqtopus_cloud/user/routers/jobs.py
+++ b/backend/oqtopus_cloud/user/routers/jobs.py
@@ -231,9 +231,15 @@ def submit_jobs(
             description=description,
             device_id=request.device_id,
             job_info=json.dumps(request.job_info.model_dump()),
-            transpiler_info=json.dumps(request.transpiler_info),
-            simulator_info=json.dumps(request.simulator_info),
-            mitigation_info=json.dumps(request.mitigation_info),
+            transpiler_info=json.dumps(
+                request.transpiler_info if request.transpiler_info is not None else {}
+            ),
+            simulator_info=json.dumps(
+                request.simulator_info if request.simulator_info is not None else {}
+            ),
+            mitigation_info=json.dumps(
+                request.mitigation_info if request.mitigation_info is not None else {}
+            ),
             job_type=request.job_type,
             shots=shots,
             submitted_at=datetime.now(utc),


### PR DESCRIPTION
The job failed to execute correctly when JSON fields such as `mitigation_info` were `null`.

This occurred because, although there was a convention on the cloud side to set these fields to `{}` instead of `null`, it was not being enforced.

This PR fixes the issue by ensuring that null values are replaced with `{}` as intended.