### PR TITLE
Add configurable overrides for AWS managed WAF size restriction rules

### DIFF
--- a/terraform/example/oqtopus-dev/service/terraform.tfvars.txt
+++ b/terraform/example/oqtopus-dev/service/terraform.tfvars.txt
@@ -15,6 +15,12 @@ api_gateway_log_retention_days = 14
 lambda_log_retention_days = 14
 
 waf_enable_common_rules        = false
+waf_common_rules_excluded_rules = [
+  "SizeRestrictions_QUERYSTRING",
+  "SizeRestrictions_Cookie_HEADER",
+  "SizeRestrictions_BODY",
+  "SizeRestrictions_URIPATH",
+]
 waf_enable_rate_limiting       = false
 waf_rate_limit                 = 1000
 waf_cloudwatch_metrics_enabled = false

--- a/terraform/service/modules/waf/README.md
+++ b/terraform/service/modules/waf/README.md
@@ -48,6 +48,7 @@ module "aws_waf" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cloudwatch_metrics_enabled"></a> [cloudwatch\_metrics\_enabled](#input\_cloudwatch\_metrics\_enabled) | flag for enabling/disabling sending WAF metrics to cloudwatch | `bool` | `false` | no |
+| <a name="input_common_rules_excluded_rules"></a> [common\_rules\_excluded\_rules](#input\_common\_rules\_excluded\_rules) | list of rule names in AWSManagedRulesCommonRuleSet to override to Count | `list(string)` | `[]` | no |
 | <a name="input_enable_common_rules"></a> [enable\_common\_rules](#input\_enable\_common\_rules) | flag for enabling/disabling common rules WAF rule | `bool` | `false` | no |
 | <a name="input_enable_rate_limiting"></a> [enable\_rate\_limiting](#input\_enable\_rate\_limiting) | flag for enabling/disabling rate limiting WAF rule | `bool` | `false` | no |
 | <a name="input_env"></a> [env](#input\_env) | environment name | `string` | n/a | yes |

--- a/terraform/service/modules/waf/main.tf
+++ b/terraform/service/modules/waf/main.tf
@@ -26,7 +26,7 @@
 */
 
 resource "aws_wafv2_web_acl" "this" {
-  name = "${var.product}-${var.org}-${var.env}-waf"
+  name  = "${var.product}-${var.org}-${var.env}-waf"
   scope = "REGIONAL"
 
   default_action {
@@ -35,14 +35,14 @@ resource "aws_wafv2_web_acl" "this" {
 
   visibility_config {
     cloudwatch_metrics_enabled = var.cloudwatch_metrics_enabled
-    metric_name = "${var.product}-${var.org}-${var.env}-waf-metric"
-    sampled_requests_enabled = var.sampled_requests_enabled
+    metric_name                = "${var.product}-${var.org}-${var.env}-waf-metric"
+    sampled_requests_enabled   = var.sampled_requests_enabled
   }
 
   dynamic "rule" {
     for_each = var.enable_common_rules ? [1] : []
     content {
-      name = "AWSManagedRulesCommonRuleSet"
+      name     = "AWSManagedRulesCommonRuleSet"
       priority = 1
 
       override_action {
@@ -51,15 +51,26 @@ resource "aws_wafv2_web_acl" "this" {
 
       statement {
         managed_rule_group_statement {
-          name = "AWSManagedRulesCommonRuleSet"
+          name        = "AWSManagedRulesCommonRuleSet"
           vendor_name = "AWS"
+
+          dynamic "rule_action_override" {
+            for_each = toset(var.common_rules_excluded_rules)
+            content {
+              name = rule_action_override.value
+
+              action_to_use {
+                count {}
+              }
+            }
+          }
         }
       }
 
       visibility_config {
         cloudwatch_metrics_enabled = var.cloudwatch_metrics_enabled
-        metric_name = "${var.product}-${var.org}-${var.env}-waf-metric-common-rules"
-        sampled_requests_enabled = var.sampled_requests_enabled
+        metric_name                = "${var.product}-${var.org}-${var.env}-waf-metric-common-rules"
+        sampled_requests_enabled   = var.sampled_requests_enabled
       }
     }
   }
@@ -67,7 +78,7 @@ resource "aws_wafv2_web_acl" "this" {
   dynamic "rule" {
     for_each = var.enable_rate_limiting ? [1] : []
     content {
-      name = "RateLimiting"
+      name     = "RateLimiting"
       priority = 2
 
       action {
@@ -76,22 +87,22 @@ resource "aws_wafv2_web_acl" "this" {
 
       statement {
         rate_based_statement {
-          limit = var.rate_limit
+          limit              = var.rate_limit
           aggregate_key_type = "IP"
         }
       }
 
       visibility_config {
         cloudwatch_metrics_enabled = var.cloudwatch_metrics_enabled
-        metric_name = "${var.product}-${var.org}-${var.env}-waf-metric-rate-limit"
-        sampled_requests_enabled = var.sampled_requests_enabled
+        metric_name                = "${var.product}-${var.org}-${var.env}-waf-metric-rate-limit"
+        sampled_requests_enabled   = var.sampled_requests_enabled
       }
     }
   }
 }
 
 resource "aws_wafv2_web_acl_association" "api_association" {
-  for_each = toset(var.resource_arn_list)
+  for_each     = toset(var.resource_arn_list)
   resource_arn = each.value
-  web_acl_arn = aws_wafv2_web_acl.this.arn
+  web_acl_arn  = aws_wafv2_web_acl.this.arn
 }

--- a/terraform/service/modules/waf/outputs.tf
+++ b/terraform/service/modules/waf/outputs.tf
@@ -1,9 +1,9 @@
 output "web_acl_arn" {
   description = "ARN of web ACL"
-  value = aws_wafv2_web_acl.this.arn
+  value       = aws_wafv2_web_acl.this.arn
 }
 
 output "web_acl_id" {
   description = "web ACL ID"
-  value = aws_wafv2_web_acl.this.id
+  value       = aws_wafv2_web_acl.this.id
 }

--- a/terraform/service/modules/waf/variables.tf
+++ b/terraform/service/modules/waf/variables.tf
@@ -15,35 +15,41 @@ variable "env" {
 
 variable "resource_arn_list" {
   description = "list of ARN of the resources to associate WAF with (like API Gateway)"
-  type = list(string)
+  type        = list(string)
 }
 
 variable "enable_common_rules" {
   description = "flag for enabling/disabling common rules WAF rule"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
+}
+
+variable "common_rules_excluded_rules" {
+  description = "list of rule names in AWSManagedRulesCommonRuleSet to override to Count"
+  type        = list(string)
+  default     = []
 }
 
 variable "enable_rate_limiting" {
   description = "flag for enabling/disabling rate limiting WAF rule"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 variable "rate_limit" {
   description = "maximum number of requests, which have an identical value in the field specified by the RateKey, allowed in a five-minute period. Minimum value is 100"
-  type = number
-  default = 1000
+  type        = number
+  default     = 1000
 }
 
 variable "cloudwatch_metrics_enabled" {
   description = "flag for enabling/disabling sending WAF metrics to cloudwatch"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 variable "sampled_requests_enabled" {
   description = "flag for enabling/disabling storing sample requests in WAF for analysis"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }

--- a/terraform/service/oqtopus-dev/main.tf
+++ b/terraform/service/oqtopus-dev/main.tf
@@ -215,16 +215,16 @@ module "vpc_endpoint" {
   lambda_subnet_ids                 = data.terraform_remote_state.infrastructure.outputs.network.private_subnet_ids
   secret_manager_security_group_ids = data.terraform_remote_state.infrastructure.outputs.security_group.secret_manager_security_group_ids
   cognito_security_group_ids        = data.terraform_remote_state.infrastructure.outputs.security_group.cognito_security_group_ids
-  cloudtrail_security_group_ids      = data.terraform_remote_state.infrastructure.outputs.security_group.cloudtrail_security_group_ids
+  cloudtrail_security_group_ids     = data.terraform_remote_state.infrastructure.outputs.security_group.cloudtrail_security_group_ids
   s3_bucket_name                    = data.terraform_remote_state.infrastructure.outputs.s3.s3_bucket_name
 
   identifiers = {
-    user_api = module.user_api.iam_role_arn,
-    provider_api = module.provider_api.iam_role_arn,
-    admin_api = module.admin_api.iam_role_arn,
-    user_signup_api = module.user_signup_api.iam_role_arn,
+    user_api             = module.user_api.iam_role_arn,
+    provider_api         = module.provider_api.iam_role_arn,
+    admin_api            = module.admin_api.iam_role_arn,
+    user_signup_api      = module.user_signup_api.iam_role_arn,
     pending_jobs_updater = module.pending_jobs_updater.iam_role_arn,
-    lambda_auth = module.lambda_auth.iam_role_arn,
+    lambda_auth          = module.lambda_auth.iam_role_arn,
   }
 
   depends_on = [
@@ -253,20 +253,21 @@ module "deployment_roles" {
 module "waf" {
   source = "../modules/waf"
 
-  product              = var.product
-  org                  = var.org
-  env                  = var.env
-  resource_arn_list    = [
+  product = var.product
+  org     = var.org
+  env     = var.env
+  resource_arn_list = [
     module.user_api.api_gateway_stage_arn,
     module.provider_api.api_gateway_stage_arn,
     module.admin_api.api_gateway_stage_arn,
     module.user_signup_api.api_gateway_stage_arn,
   ]
-  enable_common_rules        = var.waf_enable_common_rules
-  enable_rate_limiting       = var.waf_enable_rate_limiting
-  rate_limit                 = var.waf_rate_limit
-  cloudwatch_metrics_enabled = var.waf_cloudwatch_metrics_enabled
-  sampled_requests_enabled   = var.waf_sampled_requests_enabled
+  common_rules_excluded_rules = var.waf_common_rules_excluded_rules
+  enable_common_rules         = var.waf_enable_common_rules
+  enable_rate_limiting        = var.waf_enable_rate_limiting
+  rate_limit                  = var.waf_rate_limit
+  cloudwatch_metrics_enabled  = var.waf_cloudwatch_metrics_enabled
+  sampled_requests_enabled    = var.waf_sampled_requests_enabled
 
   depends_on = [
     module.user_api,

--- a/terraform/service/oqtopus-dev/variables.tf
+++ b/terraform/service/oqtopus-dev/variables.tf
@@ -95,6 +95,12 @@ variable "waf_enable_common_rules" {
   default     = false
 }
 
+variable "waf_common_rules_excluded_rules" {
+  description = "list of rule names in AWSManagedRulesCommonRuleSet to override to Count"
+  type        = list(string)
+  default     = []
+}
+
 variable "waf_enable_rate_limiting" {
   description = "flag for enabling/disabling rate limiting WAF rule"
   type        = bool

--- a/terraform/service/oqtopus-prod/main.tf
+++ b/terraform/service/oqtopus-prod/main.tf
@@ -70,7 +70,7 @@ module "user_api" {
   login_history_enabled                  = var.login_history_enabled
   api_gateway_log_retention_days         = var.api_gateway_log_retention_days
 
-  storage_driver      = "s3"
+  storage_driver = "s3"
   storage_env_vars_s3 = {
     "STORAGE_S3_REGION"      = var.region
     "STORAGE_S3_BUCKET_NAME" = data.terraform_remote_state.infrastructure.outputs.s3.s3_bucket_name
@@ -218,16 +218,16 @@ module "vpc_endpoint" {
   lambda_subnet_ids                 = data.terraform_remote_state.infrastructure.outputs.network.private_subnet_ids
   secret_manager_security_group_ids = data.terraform_remote_state.infrastructure.outputs.security_group.secret_manager_security_group_ids
   cognito_security_group_ids        = data.terraform_remote_state.infrastructure.outputs.security_group.cognito_security_group_ids
-  cloudtrail_security_group_ids      = data.terraform_remote_state.infrastructure.outputs.security_group.cloudtrail_security_group_ids
+  cloudtrail_security_group_ids     = data.terraform_remote_state.infrastructure.outputs.security_group.cloudtrail_security_group_ids
   s3_bucket_name                    = data.terraform_remote_state.infrastructure.outputs.s3.s3_bucket_name
 
   identifiers = {
-    user_api = module.user_api.iam_role_arn,
-    provider_api = module.provider_api.iam_role_arn,
-    admin_api = module.admin_api.iam_role_arn,
-    user_signup_api = module.user_signup_api.iam_role_arn,
+    user_api             = module.user_api.iam_role_arn,
+    provider_api         = module.provider_api.iam_role_arn,
+    admin_api            = module.admin_api.iam_role_arn,
+    user_signup_api      = module.user_signup_api.iam_role_arn,
     pending_jobs_updater = module.pending_jobs_updater.iam_role_arn,
-    lambda_auth = module.lambda_auth.iam_role_arn,
+    lambda_auth          = module.lambda_auth.iam_role_arn,
   }
 
   depends_on = [
@@ -242,20 +242,21 @@ module "vpc_endpoint" {
 module "waf" {
   source = "../modules/waf"
 
-  product              = var.product
-  org                  = var.org
-  env                  = var.env
-  resource_arn_list    = [
+  product = var.product
+  org     = var.org
+  env     = var.env
+  resource_arn_list = [
     module.user_api.api_gateway_stage_arn,
     module.provider_api.api_gateway_stage_arn,
     module.admin_api.api_gateway_stage_arn,
     module.user_signup_api.api_gateway_stage_arn,
   ]
-  enable_common_rules        = var.waf_enable_common_rules
-  enable_rate_limiting       = var.waf_enable_rate_limiting
-  rate_limit                 = var.waf_rate_limit
-  cloudwatch_metrics_enabled = var.waf_cloudwatch_metrics_enabled
-  sampled_requests_enabled   = var.waf_sampled_requests_enabled
+  common_rules_excluded_rules = var.waf_common_rules_excluded_rules
+  enable_common_rules         = var.waf_enable_common_rules
+  enable_rate_limiting        = var.waf_enable_rate_limiting
+  rate_limit                  = var.waf_rate_limit
+  cloudwatch_metrics_enabled  = var.waf_cloudwatch_metrics_enabled
+  sampled_requests_enabled    = var.waf_sampled_requests_enabled
 
   depends_on = [
     module.user_api,

--- a/terraform/service/oqtopus-prod/variables.tf
+++ b/terraform/service/oqtopus-prod/variables.tf
@@ -75,6 +75,12 @@ variable "waf_enable_common_rules" {
   default     = true
 }
 
+variable "waf_common_rules_excluded_rules" {
+  description = "list of rule names in AWSManagedRulesCommonRuleSet to override to Count"
+  type        = list(string)
+  default     = []
+}
+
 variable "waf_enable_rate_limiting" {
   description = "flag for enabling/disabling rate limiting WAF rule"
   type        = bool


### PR DESCRIPTION
This PR adds support for overriding specific rules in `AWSManagedRulesCommonRuleSet` from `Block` to `Count`.

Why:
- Valid large requests to `POST /jobs/{job_id}/submit` can be blocked by AWS managed WAF size restriction rules
- We want to relax only the size-based rules while keeping other protections enabled

What changed:
- Added `common_rules_excluded_rules` to the WAF Terraform module
- Wired the new variable through service-level Terraform
- Updated the example tfvars to include the size restriction rules by default
- Regenerated Terraform docs for the WAF module

Targeted rules:
- `SizeRestrictions_BODY`
- `SizeRestrictions_QUERYSTRING`
- `SizeRestrictions_URIPATH`
- `SizeRestrictions_Cookie_HEADER`

Validation:
- `terraform validate`
- Confirmed the Terraform plan updates the WAF configuration to apply per-rule overrides
- Verified that a previously blocked large submit request succeeds, while `GenericLFI_BODY` remains blocked
