### PR TITLE
docs: add local backend and frontend startup procedures

### DIFF
--- a/docs/en/developer_guidelines/setup.md
+++ b/docs/en/developer_guidelines/setup.md
@@ -93,7 +93,9 @@ This command is required to use the Python version installed with Pyenv, to set 
 
 ## Running the Backend Locally
 
-### 1. Start DB and MinIO
+The following steps each run in a separate terminal. In every terminal, `cd backend` first before running the make commands.
+
+### 1. Start DB and MinIO (Terminal 1)
 
 ```bash
 cd backend
@@ -103,24 +105,40 @@ make up
 MySQL (port 3306) and MinIO (port 9000/9001) will start.
 On the first run, DB initialization (table creation and test data insertion) is performed automatically.
 
+`make up` runs in the foreground, so keep this terminal open (press Ctrl+C to stop).
+
 ### 2. Start the APIs
 
-Open two terminals and start each API:
+> [!NOTE]
+> When the frontend is served from `http://localhost:5173`, you must include that origin in `ALLOW_ORIGINS` to satisfy CORS. The Makefile default (`http://127.0.0.1:8000`) alone will be blocked by the browser.
+
+Open additional terminals and start the User / Provider APIs. Override `ALLOW_ORIGINS` so the local frontend can reach them:
 
 ```bash
-# Terminal 1: User API (for job submission)
-make run-user
+# Terminal 2: User API (for job submission)
+cd backend
+ALLOW_ORIGINS=http://127.0.0.1:8000,http://localhost:5173 make run-user
 ```
 
 ```bash
-# Terminal 2: Provider API (for backend instance communication)
-make run-provider
+# Terminal 3: Provider API (for backend instance communication)
+cd backend
+ALLOW_ORIGINS=http://127.0.0.1:8000,http://localhost:5173 make run-provider
+```
+
+If you want to exercise the signup flow, also start the User Signup API:
+
+```bash
+# Terminal 4 (optional): User Signup API
+cd backend
+ALLOW_ORIGINS=http://127.0.0.1:8000,http://localhost:5173 make run-user_signup
 ```
 
 | API | Port | Purpose |
 |-----|------|---------|
 | User API | 8080 | Job submission and result retrieval |
 | Provider API | 8888 | Communication with backend instances |
+| User Signup API | 8890 | Sign-up and user registration (optional) |
 
 ### 3. Verify
 
@@ -128,6 +146,7 @@ Check the API documentation (Swagger UI):
 
 - User API: [http://localhost:8080/docs](http://localhost:8080/docs)
 - Provider API: [http://localhost:8888/docs](http://localhost:8888/docs)
+- User Signup API: [http://localhost:8890/docs](http://localhost:8890/docs) (if started)
 
 ## Running the Frontend Locally
 
@@ -140,8 +159,9 @@ You can run the [OQTOPUS Frontend](https://github.com/oqtopus-team/oqtopus-front
 ### Prerequisites
 
 - [bun](https://bun.sh/) installed
-- The User API (port 8080) running, as described in "Running the Backend Locally"
+- The User API (port 8080) running, as described in "Running the Backend Locally", with `ALLOW_ORIGINS` including `http://localhost:5173`
 - An accessible Cognito User Pool ID / Web Client ID and a registered account
+- The User Signup API (port 8890) running if you want to exercise the signup flow
 
 ### 1. Clone the Repository
 
@@ -162,10 +182,13 @@ Edit the `.env` file to point to the local backend and configure Cognito for aut
 
 ```env
 VITE_APP_API_ENDPOINT=http://localhost:8080
+VITE_APP_API_SIGNUP_ENDPOINT=http://localhost:8890
 VITE_APP_AUTH_REGION=ap-northeast-1
 VITE_APP_AUTH_USER_POOL_ID=<your Cognito User Pool ID>
 VITE_APP_AUTH_USER_POOL_WEB_CLIENT_ID=<corresponding Web Client ID>
 ```
+
+If `VITE_APP_API_ENDPOINT` or `VITE_APP_API_SIGNUP_ENDPOINT` is unset, the frontend will throw at startup. Set these even if you do not run the User Signup API (no traffic will be sent to it unless you trigger a signup action).
 
 If `VITE_APP_AUTH_USER_POOL_ID` and `VITE_APP_AUTH_USER_POOL_WEB_CLIENT_ID` are left empty, you will not be able to log in.
 

--- a/docs/en/developer_guidelines/setup.md
+++ b/docs/en/developer_guidelines/setup.md
@@ -91,6 +91,92 @@ make setup-uv
 
 This command is required to use the Python version installed with Pyenv, to set up the Python environment, and to install dependencies. This will create a `.venv` in the root directory.
 
+## Running the Backend Locally
+
+### 1. Start DB and MinIO
+
+```bash
+cd backend
+make up
+```
+
+MySQL (port 3306) and MinIO (port 9000/9001) will start.
+On the first run, DB initialization (table creation and test data insertion) is performed automatically.
+
+### 2. Start the APIs
+
+Open two terminals and start each API:
+
+```bash
+# Terminal 1: User API (for job submission)
+make run-user
+```
+
+```bash
+# Terminal 2: Provider API (for backend instance communication)
+make run-provider
+```
+
+| API | Port | Purpose |
+|-----|------|---------|
+| User API | 8080 | Job submission and result retrieval |
+| Provider API | 8888 | Communication with backend instances |
+
+### 3. Verify
+
+Check the API documentation (Swagger UI):
+
+- User API: [http://localhost:8080/docs](http://localhost:8080/docs)
+- Provider API: [http://localhost:8888/docs](http://localhost:8888/docs)
+
+## Running the Frontend Locally
+
+You can run the [OQTOPUS Frontend](https://github.com/oqtopus-team/oqtopus-frontend) locally and connect it to the local backend started above.
+
+> [!IMPORTANT]
+> The frontend uses AWS Cognito for authentication. Even when running locally, you need an account registered in an existing Cognito User Pool (e.g., the `oqtopus-dev` environment) to log in.
+> Without a registered account, you cannot proceed past the login screen. Please contact the operations team if you need an account.
+
+### Prerequisites
+
+- [bun](https://bun.sh/) installed
+- The User API (port 8080) running, as described in "Running the Backend Locally"
+- An accessible Cognito User Pool ID / Web Client ID and a registered account
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/oqtopus-team/oqtopus-frontend.git
+cd oqtopus-frontend
+```
+
+### 2. Install Dependencies
+
+```bash
+bun install
+```
+
+### 3. Configure Environment Variables
+
+Edit the `.env` file to point to the local backend and configure Cognito for authentication:
+
+```env
+VITE_APP_API_ENDPOINT=http://localhost:8080
+VITE_APP_AUTH_REGION=ap-northeast-1
+VITE_APP_AUTH_USER_POOL_ID=<your Cognito User Pool ID>
+VITE_APP_AUTH_USER_POOL_WEB_CLIENT_ID=<corresponding Web Client ID>
+```
+
+If `VITE_APP_AUTH_USER_POOL_ID` and `VITE_APP_AUTH_USER_POOL_WEB_CLIENT_ID` are left empty, you will not be able to log in.
+
+### 4. Start the Development Server
+
+```bash
+bun run dev
+```
+
+Open [http://localhost:5173](http://localhost:5173) and log in with an account registered in Cognito to access the frontend.
+
 ## Starting the Documentation Server
 
 To start the documentation server, run the following command:

--- a/docs/ja/developer_guidelines/setup.md
+++ b/docs/ja/developer_guidelines/setup.md
@@ -92,7 +92,9 @@ make setup-uv
 
 ## ローカルでのバックエンド起動
 
-### 1. DB・MinIOの起動
+以降のステップは別々のターミナルで実行します。各ターミナルで `cd backend` してから make コマンドを実行してください。
+
+### 1. DB・MinIOの起動（ターミナル1）
 
 ```bash
 cd backend
@@ -102,24 +104,40 @@ make up
 MySQL (ポート3306) と MinIO (ポート9000/9001) が起動します。
 初回起動時はDBの初期化（テーブル作成・テストデータ投入）が自動で行われます。
 
+`make up` は foreground で動作するため、このターミナルはそのまま開いておいてください（停止させたい場合は Ctrl+C）。
+
 ### 2. APIの起動
 
-ターミナルを2つ開いて、それぞれで起動します：
+> [!NOTE]
+> フロントエンドを `http://localhost:5173` から呼ぶ場合、CORS のため `ALLOW_ORIGINS` に当該オリジンを含める必要があります。Makefile の既定値 (`http://127.0.0.1:8000`) のままだとブラウザでブロックされます。
+
+別のターミナルで User API / Provider API を起動します。フロントエンドからアクセスする場合は `ALLOW_ORIGINS` を上書きしてください：
 
 ```bash
-# ターミナル1: User API（ジョブ投入用）
-make run-user
+# ターミナル2: User API（ジョブ投入用）
+cd backend
+ALLOW_ORIGINS=http://127.0.0.1:8000,http://localhost:5173 make run-user
 ```
 
 ```bash
-# ターミナル2: Provider API（バックエンドインスタンスとの通信用）
-make run-provider
+# ターミナル3: Provider API（バックエンドインスタンスとの通信用）
+cd backend
+ALLOW_ORIGINS=http://127.0.0.1:8000,http://localhost:5173 make run-provider
+```
+
+サインアップ機能を試す場合はさらに User Signup API を起動します：
+
+```bash
+# ターミナル4（必要な場合のみ）: User Signup API
+cd backend
+ALLOW_ORIGINS=http://127.0.0.1:8000,http://localhost:5173 make run-user_signup
 ```
 
 | API | ポート | 用途 |
 |-----|--------|------|
 | User API | 8080 | ジョブ投入・結果取得 |
 | Provider API | 8888 | バックエンドインスタンスとの通信 |
+| User Signup API | 8890 | サインアップ・ユーザー登録（任意） |
 
 ### 3. 動作確認
 
@@ -127,6 +145,7 @@ APIドキュメント（Swagger UI）で確認できます：
 
 - User API: [http://localhost:8080/docs](http://localhost:8080/docs)
 - Provider API: [http://localhost:8888/docs](http://localhost:8888/docs)
+- User Signup API: [http://localhost:8890/docs](http://localhost:8890/docs)（起動した場合）
 
 ## ローカルでのフロントエンド起動
 
@@ -139,8 +158,9 @@ APIドキュメント（Swagger UI）で確認できます：
 ### 前提条件
 
 - [bun](https://bun.sh/) がインストール済みであること
-- 上記の「ローカルでのバックエンド起動」で User API (ポート8080) が起動済みであること
+- 上記の「ローカルでのバックエンド起動」で User API (ポート8080) が起動済みで、`ALLOW_ORIGINS` に `http://localhost:5173` が含まれていること
 - 利用可能なCognito User PoolのID / Web Client ID / 登録済みアカウント
+- サインアップ機能を試す場合は User Signup API (ポート8890) も起動済みであること
 
 ### 1. リポジトリのクローン
 
@@ -161,10 +181,13 @@ bun install
 
 ```env
 VITE_APP_API_ENDPOINT=http://localhost:8080
+VITE_APP_API_SIGNUP_ENDPOINT=http://localhost:8890
 VITE_APP_AUTH_REGION=ap-northeast-1
 VITE_APP_AUTH_USER_POOL_ID=<利用するCognito User Pool ID>
 VITE_APP_AUTH_USER_POOL_WEB_CLIENT_ID=<対応するWeb Client ID>
 ```
+
+`VITE_APP_API_ENDPOINT` および `VITE_APP_API_SIGNUP_ENDPOINT` が未設定だとフロントエンドが起動時にエラーになります。User Signup API を起動しない場合でも、上記のように値を入れておく必要があります（サインアップ操作を行わなければ実際の通信は発生しません）。
 
 `VITE_APP_AUTH_USER_POOL_ID` と `VITE_APP_AUTH_USER_POOL_WEB_CLIENT_ID` を空のままにするとログインできません。
 

--- a/docs/ja/developer_guidelines/setup.md
+++ b/docs/ja/developer_guidelines/setup.md
@@ -90,6 +90,92 @@ make setup-uv
 
 このコマンドは、PyenvでインストールされたPythonバージョンの使用、Python環境のセットアップ、依存関係のインストールに必要です。これにより、ルートディレクトリに `.venv` が作成されます。
 
+## ローカルでのバックエンド起動
+
+### 1. DB・MinIOの起動
+
+```bash
+cd backend
+make up
+```
+
+MySQL (ポート3306) と MinIO (ポート9000/9001) が起動します。
+初回起動時はDBの初期化（テーブル作成・テストデータ投入）が自動で行われます。
+
+### 2. APIの起動
+
+ターミナルを2つ開いて、それぞれで起動します：
+
+```bash
+# ターミナル1: User API（ジョブ投入用）
+make run-user
+```
+
+```bash
+# ターミナル2: Provider API（バックエンドインスタンスとの通信用）
+make run-provider
+```
+
+| API | ポート | 用途 |
+|-----|--------|------|
+| User API | 8080 | ジョブ投入・結果取得 |
+| Provider API | 8888 | バックエンドインスタンスとの通信 |
+
+### 3. 動作確認
+
+APIドキュメント（Swagger UI）で確認できます：
+
+- User API: [http://localhost:8080/docs](http://localhost:8080/docs)
+- Provider API: [http://localhost:8888/docs](http://localhost:8888/docs)
+
+## ローカルでのフロントエンド起動
+
+[OQTOPUS Frontend](https://github.com/oqtopus-team/oqtopus-frontend) をローカルで起動し、上記のローカルバックエンドと組み合わせて動作確認ができます。
+
+> [!IMPORTANT]
+> フロントエンドの認証はAWS Cognitoを使用しています。ローカルで起動した場合でも、ログインには **既存のCognito User Pool（例: `oqtopus-dev` 環境）にアカウントが登録されている必要** があります。
+> アカウントを持っていない場合はログイン画面から先に進めません。アカウントが必要な場合は運用担当者に依頼してください。
+
+### 前提条件
+
+- [bun](https://bun.sh/) がインストール済みであること
+- 上記の「ローカルでのバックエンド起動」で User API (ポート8080) が起動済みであること
+- 利用可能なCognito User PoolのID / Web Client ID / 登録済みアカウント
+
+### 1. リポジトリのクローン
+
+```bash
+git clone https://github.com/oqtopus-team/oqtopus-frontend.git
+cd oqtopus-frontend
+```
+
+### 2. 依存関係のインストール
+
+```bash
+bun install
+```
+
+### 3. 環境変数の設定
+
+`.env` ファイルを編集し、ローカルバックエンドを参照する設定と、認証用のCognito設定を行います：
+
+```env
+VITE_APP_API_ENDPOINT=http://localhost:8080
+VITE_APP_AUTH_REGION=ap-northeast-1
+VITE_APP_AUTH_USER_POOL_ID=<利用するCognito User Pool ID>
+VITE_APP_AUTH_USER_POOL_WEB_CLIENT_ID=<対応するWeb Client ID>
+```
+
+`VITE_APP_AUTH_USER_POOL_ID` と `VITE_APP_AUTH_USER_POOL_WEB_CLIENT_ID` を空のままにするとログインできません。
+
+### 4. 開発サーバーの起動
+
+```bash
+bun run dev
+```
+
+[http://localhost:5173](http://localhost:5173) にアクセスし、Cognitoに登録済みのアカウントでログインするとフロントエンドが表示されます。
+
 ## ドキュメンテーションサーバーの起動
 
 ドキュメンテーションサーバーを起動するには、以下のコマンドを実行します：


### PR DESCRIPTION
## Summary
- Add **Local Backend Startup** and **Local Frontend Startup** sections to the developer documentation `Setup Development Environment`
- Document steps for bringing up DB / MinIO / User API / Provider API locally
- Document steps for running OQTOPUS Frontend locally (auth uses AWS Cognito, so an account already registered in the Cognito User Pool is required — explicitly noted)
- Update both `ja` and `en` symmetrically

## Test plan
- [ ] Following the steps, start the backend and access Swagger UI for User API (8080) / Provider API (8888)
- [ ] Following the steps, start the frontend and access `http://localhost:5173`
- [ ] Confirm login fails when Cognito settings are left blank (matches the IMPORTANT note)
- [ ] No layout issues on readthedocs (ja: `/ja/latest/developer_guidelines/setup/`, en: `/latest/developer_guidelines/setup/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
