### PR TITLE
Fix : list pending jobs limit

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -198,6 +198,7 @@ test-provider: fmt-provider lint-provider ## Run Provider tests
 test-worker: fmt-worker lint-worker ## Run worker tests
 	@export POWERTOOLS_METRICS_NAMESPACE=worker && \
 	export POWERTOOLS_SERVICE_NAME=worker && \
+	export COUNT_PENDING_JOBS_SINCE=10d && \
 	uv run pytest tests/oqtopus_cloud/worker/ -vv --cov=oqtopus_cloud/worker --cov-report=xml:coverage-worker.xml --cov-report=html:htmlcov-worker
 	@mv .coverage .coverage-worker
 

--- a/backend/oqtopus_cloud/worker/pending_jobs_updater/lambda_function.py
+++ b/backend/oqtopus_cloud/worker/pending_jobs_updater/lambda_function.py
@@ -68,11 +68,11 @@ def lambda_handler(event: EventBridgeEvent, context):
         return Response.error(str(e))
 
 
-def update_pending_jobs(db):
+def update_pending_jobs(db, current=datetime.now(tz=timezone.utc)):
     logger.info("invoked update_pending_jobs")
     devices = db.scalars(select(Device)).all()
     device_ids = [device.id for device in devices]
-    since = parse_since(os.environ["COUNT_PENDING_JOBS_SINCE"])
+    since = parse_since(os.environ["COUNT_PENDING_JOBS_SINCE"], current)
     logger.info(f"device list is {device_ids}")
     for device_id in device_ids:
         n_pending_jobs = db.execute(
@@ -101,7 +101,7 @@ def update_pending_jobs(db):
     return Response.success(body)
 
 
-def parse_since(since_str: str) -> datetime:
+def parse_since(since_str: str, current: datetime) -> datetime:
     units = {
         "second": "seconds",
         "seconds": "seconds",
@@ -130,6 +130,5 @@ def parse_since(since_str: str) -> datetime:
     amount, unit = int(m.group(1)), m.group(2).lower()
     if unit not in units:
         raise ValueError(f"Unknown unit: {unit!r}")
-
-    delta = relativedelta(**{units[unit]: amount})
-    return datetime.now(tz=timezone.utc) - delta
+    delta = relativedelta(**{units[unit]: amount})  # type: ignore[arg-type]
+    return current - delta

--- a/backend/oqtopus_cloud/worker/pending_jobs_updater/lambda_function.py
+++ b/backend/oqtopus_cloud/worker/pending_jobs_updater/lambda_function.py
@@ -1,11 +1,11 @@
 import json
+import os
+import re
+from datetime import datetime, timezone
 from typing import Any
 
 from aws_lambda_powertools.utilities.data_classes import EventBridgeEvent, event_source
-from oqtopus_cloud.common.models.device import Device
-from oqtopus_cloud.common.models.job import Job
-from oqtopus_cloud.common.session import get_db
-from oqtopus_cloud.worker.pending_jobs_updater.conf import logger
+from dateutil.relativedelta import relativedelta
 from pydantic import BaseModel
 from sqlalchemy import (
     and_,
@@ -13,6 +13,11 @@ from sqlalchemy import (
     or_,
     select,
 )
+
+from oqtopus_cloud.common.models.device import Device
+from oqtopus_cloud.common.models.job import Job
+from oqtopus_cloud.common.session import get_db
+from oqtopus_cloud.worker.pending_jobs_updater.conf import logger
 
 
 class BaseResponse(BaseModel):
@@ -67,6 +72,7 @@ def update_pending_jobs(db):
     logger.info("invoked update_pending_jobs")
     devices = db.scalars(select(Device)).all()
     device_ids = [device.id for device in devices]
+    since = parse_since(os.environ["COUNT_PENDING_JOBS_SINCE"])
     logger.info(f"device list is {device_ids}")
     for device_id in device_ids:
         n_pending_jobs = db.execute(
@@ -78,6 +84,7 @@ def update_pending_jobs(db):
                         Job.status == "running",
                     ),
                     Job.device_id == device_id,
+                    Job.submitted_at >= since,
                 )
             )
         ).scalar_one()
@@ -92,3 +99,37 @@ def update_pending_jobs(db):
     logger.info("finish update_pending_jobs")
     body = json.dumps({"message": "update_pending_jobs process is succeeded"})
     return Response.success(body)
+
+
+def parse_since(since_str: str) -> datetime:
+    units = {
+        "second": "seconds",
+        "seconds": "seconds",
+        "sec": "seconds",
+        "minute": "minutes",
+        "minutes": "minutes",
+        "min": "minutes",
+        "hour": "hours",
+        "hours": "hours",
+        "h": "hours",
+        "day": "days",
+        "days": "days",
+        "d": "days",
+        "week": "weeks",
+        "weeks": "weeks",
+        "month": "months",
+        "months": "months",
+        "year": "years",
+        "years": "years",
+    }
+
+    m = re.fullmatch(r"(\d+)\s*([a-zA-Z]+)", since_str.strip())
+    if not m:
+        raise ValueError(f"Invalid since format: {since_str!r}")
+
+    amount, unit = int(m.group(1)), m.group(2).lower()
+    if unit not in units:
+        raise ValueError(f"Unknown unit: {unit!r}")
+
+    delta = relativedelta(**{units[unit]: amount})
+    return datetime.now(tz=timezone.utc) - delta

--- a/backend/oqtopus_cloud/worker/pending_jobs_updater/lambda_function.py
+++ b/backend/oqtopus_cloud/worker/pending_jobs_updater/lambda_function.py
@@ -61,14 +61,14 @@ def lambda_handler(event: EventBridgeEvent, context):
     logger.info("invoke worker lambda_handler")
     try:
         db = next(get_db())
-        response = update_pending_jobs(db)
+        response = update_pending_jobs(db, datetime.now(tz=timezone.utc))
         return response
     except Exception as e:
         logger.exception("Error occurred")
         return Response.error(str(e))
 
 
-def update_pending_jobs(db, current=datetime.now(tz=timezone.utc)):
+def update_pending_jobs(db, current: datetime):
     logger.info("invoked update_pending_jobs")
     devices = db.scalars(select(Device)).all()
     device_ids = [device.id for device in devices]

--- a/backend/tests/oqtopus_cloud/worker/pending_jobs_updater/test_pending_jobs_updater.py
+++ b/backend/tests/oqtopus_cloud/worker/pending_jobs_updater/test_pending_jobs_updater.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 from oqtopus_cloud.common.models.device import Device
 from oqtopus_cloud.common.models.job import Job
@@ -9,8 +9,14 @@ from oqtopus_cloud.worker.pending_jobs_updater.lambda_function import (
 )
 from sqlalchemy import select
 
+# Reference "now" used by the tests. Job submitted_at values and the `current`
+# argument passed to update_pending_jobs are anchored to this so the
+# COUNT_PENDING_JOBS_SINCE filter behaves deterministically regardless of when
+# the test suite is executed.
+FIXED_NOW = datetime(2024, 3, 12, 12, 34, 56, tzinfo=timezone.utc)
 
-def _get_device(id: int) -> Device:
+
+def _get_device(id: str) -> Device:
     mode_dict = {
         "id": id,
         "device_type": "simulator",
@@ -28,7 +34,14 @@ def _get_device(id: int) -> Device:
     return Device(**mode_dict)
 
 
-def _get_job(n: int, device_id: str, status: str) -> Job:
+def _get_job(
+    n: int,
+    device_id: str,
+    status: str,
+    submitted_at: datetime | None = None,
+) -> Job:
+    if submitted_at is None:
+        submitted_at = datetime(2024, 3, 3 + n, 12, 34, 56)
     model_dict = {
         "id": f"testjob{n}id",
         "owner": "admin",
@@ -44,8 +57,8 @@ def _get_job(n: int, device_id: str, status: str) -> Job:
         ),
         "status": status,
         "shots": 1000,
-        "submitted_at": datetime(2024, 3, 3 + n, 12, 34, 56),
-        "created_at": datetime(2024, 3, 3 + n, 12, 34, 56),
+        "submitted_at": submitted_at,
+        "created_at": submitted_at,
     }
     return Job(**model_dict)
 
@@ -69,8 +82,9 @@ def test_update_pending_jobs(
     test_db.add(_get_job(6, "device1", "succeeded"))
     test_db.commit()
 
-    # call worker lambda
-    update_pending_jobs(test_db)
+    # call worker lambda with a fixed `current` so the COUNT_PENDING_JOBS_SINCE
+    # filter window covers the fixed submitted_at values of the test jobs.
+    update_pending_jobs(test_db, current=FIXED_NOW)
 
     # get pending_jobs from DB
     device1_pending_jobs = test_db.scalar(
@@ -89,7 +103,7 @@ def test_update_pending_jobs(
     test_db.commit()
 
     # call worker lambda
-    update_pending_jobs(test_db)
+    update_pending_jobs(test_db, current=FIXED_NOW)
     # get pending_jobs from DB
     device1_pending_jobs = test_db.scalar(
         select(Device.pending_jobs).where(Device.id == "device1")
@@ -101,3 +115,79 @@ def test_update_pending_jobs(
     # assertion
     assert device1_pending_jobs == 2
     assert device2_pending_jobs == 5
+
+
+def test_count_pending_jobs_since_respects_env_var(test_db, monkeypatch):
+    """COUNT_PENDING_JOBS_SINCE must control the cutoff applied to submitted_at.
+
+    Two jobs are inserted:
+      * job 1 submitted 1 day before FIXED_NOW
+      * job 2 submitted 5 days before FIXED_NOW
+
+    With COUNT_PENDING_JOBS_SINCE="2d" only the recent one falls inside the
+    window, so device1.pending_jobs must become 1.
+    With COUNT_PENDING_JOBS_SINCE="10d" both jobs fall inside the window, so
+    device1.pending_jobs must become 2.
+    """
+    test_db.flush()
+    test_db.add(_get_device("device1"))
+    test_db.add(
+        _get_job(
+            1,
+            "device1",
+            "submitted",
+            submitted_at=datetime(2024, 3, 11, 12, 34, 56),  # 1 day before FIXED_NOW
+        )
+    )
+    test_db.add(
+        _get_job(
+            2,
+            "device1",
+            "submitted",
+            submitted_at=datetime(2024, 3, 7, 12, 34, 56),  # 5 days before FIXED_NOW
+        )
+    )
+    test_db.commit()
+
+    # Narrow window: only the 1-day-old job should be counted.
+    monkeypatch.setenv("COUNT_PENDING_JOBS_SINCE", "2d")
+    update_pending_jobs(test_db, current=FIXED_NOW)
+    assert (
+        test_db.scalar(select(Device.pending_jobs).where(Device.id == "device1")) == 1
+    )
+
+    # Wide window: both jobs should be counted.
+    monkeypatch.setenv("COUNT_PENDING_JOBS_SINCE", "10d")
+    update_pending_jobs(test_db, current=FIXED_NOW)
+    assert (
+        test_db.scalar(select(Device.pending_jobs).where(Device.id == "device1")) == 2
+    )
+
+
+def test_count_pending_jobs_since_supports_hour_unit(test_db, monkeypatch):
+    """The since string must accept non-day units such as hours."""
+    test_db.flush()
+    test_db.add(_get_device("device1"))
+    test_db.add(
+        _get_job(
+            1,
+            "device1",
+            "submitted",
+            submitted_at=datetime(2024, 3, 12, 10, 34, 56),  # 2 hours before FIXED_NOW
+        )
+    )
+    test_db.add(
+        _get_job(
+            2,
+            "device1",
+            "submitted",
+            submitted_at=datetime(2024, 3, 12, 6, 34, 56),  # 6 hours before FIXED_NOW
+        )
+    )
+    test_db.commit()
+
+    monkeypatch.setenv("COUNT_PENDING_JOBS_SINCE", "3h")
+    update_pending_jobs(test_db, current=FIXED_NOW)
+    assert (
+        test_db.scalar(select(Device.pending_jobs).where(Device.id == "device1")) == 1
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
   "python-multipart>=0.0.20",
   "fsspec>=2025.5.1",
   "s3fs>=2025.5.1",
+  "python-dateutil>=2.9.0.post0",
+  "types-python-dateutil>=2.9.0.20260508",
 ]
 
 [build-system]

--- a/terraform/service/modules/worker/main.tf
+++ b/terraform/service/modules/worker/main.tf
@@ -43,6 +43,7 @@ resource "aws_lambda_function" "this" {
       ALLOW_METHODS                = var.allow_methods
       ALLOW_HEADERS                = var.allow_headers
       LOG_LEVEL                    = var.log_level
+      COUNT_PENDING_JOBS_SINCE     = var.count_pending_jobs_since
     }
   }
 

--- a/terraform/service/modules/worker/variables.tf
+++ b/terraform/service/modules/worker/variables.tf
@@ -76,3 +76,8 @@ variable "log_level" {
   description = "The log level for the Lambda function"
   type        = string
 }
+
+variable "count_pending_jobs_since" {
+  description = "Time window for counting pending jobs (e.g. '10days', '1month', '2weeks'). Used to filter jobs submitted within the specified duration from the current time."
+  type        = string
+}

--- a/terraform/service/oqtopus-dev/main.tf
+++ b/terraform/service/oqtopus-dev/main.tf
@@ -189,6 +189,7 @@ module "pending_jobs_updater" {
   allow_methods                 = "*"
   allow_headers                 = "*"
   log_level                     = "INFO"
+  count_pending_jobs_since      = "10 days"
 }
 
 module "lambda_version_cleaner" {
@@ -215,16 +216,16 @@ module "vpc_endpoint" {
   lambda_subnet_ids                 = data.terraform_remote_state.infrastructure.outputs.network.private_subnet_ids
   secret_manager_security_group_ids = data.terraform_remote_state.infrastructure.outputs.security_group.secret_manager_security_group_ids
   cognito_security_group_ids        = data.terraform_remote_state.infrastructure.outputs.security_group.cognito_security_group_ids
-  cloudtrail_security_group_ids      = data.terraform_remote_state.infrastructure.outputs.security_group.cloudtrail_security_group_ids
+  cloudtrail_security_group_ids     = data.terraform_remote_state.infrastructure.outputs.security_group.cloudtrail_security_group_ids
   s3_bucket_name                    = data.terraform_remote_state.infrastructure.outputs.s3.s3_bucket_name
 
   identifiers = {
-    user_api = module.user_api.iam_role_arn,
-    provider_api = module.provider_api.iam_role_arn,
-    admin_api = module.admin_api.iam_role_arn,
-    user_signup_api = module.user_signup_api.iam_role_arn,
+    user_api             = module.user_api.iam_role_arn,
+    provider_api         = module.provider_api.iam_role_arn,
+    admin_api            = module.admin_api.iam_role_arn,
+    user_signup_api      = module.user_signup_api.iam_role_arn,
     pending_jobs_updater = module.pending_jobs_updater.iam_role_arn,
-    lambda_auth = module.lambda_auth.iam_role_arn,
+    lambda_auth          = module.lambda_auth.iam_role_arn,
   }
 
   depends_on = [
@@ -253,10 +254,10 @@ module "deployment_roles" {
 module "waf" {
   source = "../modules/waf"
 
-  product              = var.product
-  org                  = var.org
-  env                  = var.env
-  resource_arn_list    = [
+  product = var.product
+  org     = var.org
+  env     = var.env
+  resource_arn_list = [
     module.user_api.api_gateway_stage_arn,
     module.provider_api.api_gateway_stage_arn,
     module.admin_api.api_gateway_stage_arn,

--- a/terraform/service/oqtopus-prod/main.tf
+++ b/terraform/service/oqtopus-prod/main.tf
@@ -70,7 +70,7 @@ module "user_api" {
   login_history_enabled                  = var.login_history_enabled
   api_gateway_log_retention_days         = var.api_gateway_log_retention_days
 
-  storage_driver      = "s3"
+  storage_driver = "s3"
   storage_env_vars_s3 = {
     "STORAGE_S3_REGION"      = var.region
     "STORAGE_S3_BUCKET_NAME" = data.terraform_remote_state.infrastructure.outputs.s3.s3_bucket_name
@@ -192,6 +192,7 @@ module "pending_jobs_updater" {
   allow_methods                 = "*"
   allow_headers                 = "*"
   log_level                     = "INFO"
+  count_pending_jobs_since      = "10 days"
 }
 
 module "lambda_version_cleaner" {
@@ -218,16 +219,16 @@ module "vpc_endpoint" {
   lambda_subnet_ids                 = data.terraform_remote_state.infrastructure.outputs.network.private_subnet_ids
   secret_manager_security_group_ids = data.terraform_remote_state.infrastructure.outputs.security_group.secret_manager_security_group_ids
   cognito_security_group_ids        = data.terraform_remote_state.infrastructure.outputs.security_group.cognito_security_group_ids
-  cloudtrail_security_group_ids      = data.terraform_remote_state.infrastructure.outputs.security_group.cloudtrail_security_group_ids
+  cloudtrail_security_group_ids     = data.terraform_remote_state.infrastructure.outputs.security_group.cloudtrail_security_group_ids
   s3_bucket_name                    = data.terraform_remote_state.infrastructure.outputs.s3.s3_bucket_name
 
   identifiers = {
-    user_api = module.user_api.iam_role_arn,
-    provider_api = module.provider_api.iam_role_arn,
-    admin_api = module.admin_api.iam_role_arn,
-    user_signup_api = module.user_signup_api.iam_role_arn,
+    user_api             = module.user_api.iam_role_arn,
+    provider_api         = module.provider_api.iam_role_arn,
+    admin_api            = module.admin_api.iam_role_arn,
+    user_signup_api      = module.user_signup_api.iam_role_arn,
     pending_jobs_updater = module.pending_jobs_updater.iam_role_arn,
-    lambda_auth = module.lambda_auth.iam_role_arn,
+    lambda_auth          = module.lambda_auth.iam_role_arn,
   }
 
   depends_on = [
@@ -242,10 +243,10 @@ module "vpc_endpoint" {
 module "waf" {
   source = "../modules/waf"
 
-  product              = var.product
-  org                  = var.org
-  env                  = var.env
-  resource_arn_list    = [
+  product = var.product
+  org     = var.org
+  env     = var.env
+  resource_arn_list = [
     module.user_api.api_gateway_stage_arn,
     module.provider_api.api_gateway_stage_arn,
     module.admin_api.api_gateway_stage_arn,

--- a/uv.lock
+++ b/uv.lock
@@ -254,11 +254,13 @@ dependencies = [
     { name = "pyjwt" },
     { name = "pymysql" },
     { name = "pytest-env" },
+    { name = "python-dateutil" },
     { name = "python-multipart" },
     { name = "pytz" },
     { name = "s3fs" },
     { name = "setuptools" },
     { name = "sqlalchemy" },
+    { name = "types-python-dateutil" },
     { name = "types-pytz" },
     { name = "types-setuptools" },
     { name = "uuid-v7" },
@@ -312,11 +314,13 @@ requires-dist = [
     { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "pymysql", specifier = ">=1.1.0" },
     { name = "pytest-env", specifier = ">=1.1.5" },
+    { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "pytz", specifier = ">=2025.1" },
     { name = "s3fs", specifier = ">=2025.5.1" },
     { name = "setuptools", specifier = ">=75.1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.28" },
+    { name = "types-python-dateutil", specifier = ">=2.9.0.20260508" },
     { name = "types-pytz", specifier = ">=2025.1.0.20250204" },
     { name = "types-setuptools", specifier = ">=75.1.0.20240917" },
     { name = "uuid-v7", specifier = ">=1.0.0" },
@@ -1883,6 +1887,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/36/6c/583522cfb3c330e92e726af517a91c13247e555e021791a60f1b03c6ff16/types_awscrt-0.27.2.tar.gz", hash = "sha256:acd04f57119eb15626ab0ba9157fc24672421de56e7bd7b9f61681fedee44e91", size = 16304, upload-time = "2025-05-16T03:10:08.712Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/82/1ee2e5c9d28deac086ab3a6ff07c8bc393ef013a083f546c623699881715/types_awscrt-0.27.2-py3-none-any.whl", hash = "sha256:49a045f25bbd5ad2865f314512afced933aed35ddbafc252e2268efa8a787e4e", size = 37761, upload-time = "2025-05-16T03:10:07.466Z" },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20260508"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/9b/ee1674cbe9ec50bb824f35a5dc0ce5fd1f1b6196ba1213e3fe6f33b4ce32/types_python_dateutil-2.9.0.20260508.tar.gz", hash = "sha256:596a6d63d81f587bf04c8254fb78df9d2344e915ce67948d7400512e3a6206d5", size = 17033, upload-time = "2026-05-08T04:47:08.248Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/7c/1788ff10edf56031d74ad3fba40947e0e8b82e3a529b30e6b7d71c191dec/types_python_dateutil-2.9.0.20260508-py3-none-any.whl", hash = "sha256:bfc6fd2d81aa86e5ac97206a64304f6bd247426eedbca9b98619bbc48c6a1c10", size = 18425, upload-time = "2026-05-08T04:47:07.207Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds the ability to filter pending jobs by `submitted_at` in the `pending-jobs-updater` worker Lambda, with the cutoff date configurable via an environment variable.

## Changes

- **pending-jobs-updater Lambda**: Added `submitted_at`-based filtering when counting pending jobs. Jobs submitted before the configured cutoff are excluded from the count.
- **Environment variable**: Introduced `COUNT_PENDING_JOBS_SINCE` to configure the cutoff as a human-readable duration string (e.g. `10days`, `1month`, `2weeks`).
- **Terraform**: Added the `count_pending_jobs_since` variable and wired it to the Lambda's environment variables.

## How to test

Set `COUNT_PENDING_JOBS_SINCE` to a value such as `30days` and verify that jobs submitted before that window are excluded from the pending job count.