### PR TITLE
feat : Make OpenAPI server configurable

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -5,6 +5,7 @@ on:
       - develop
     paths:
       - 'backend/oqtopus_cloud/**'
+      - 'backend/oas/**'
   workflow_dispatch:
 
 jobs:
@@ -55,6 +56,15 @@ jobs:
         run: |
           sudo -E env PATH="$PATH" make deploy-${{ matrix.deploy-target }}-via-actions
 
+      - name: Publish user OpenAPI spec to S3
+        if: matrix.deploy-target == 'user'
+        working-directory: ./deployment/oqtopus-dev
+        env:
+          PUBLISH_OPENAPI_S3_BUCKET: ${{ vars.PUBLISH_OPENAPI_S3_BUCKET }}
+          USER_API_SERVER_URL: ${{ vars.USER_API_SERVER_URL }}
+          USER_API_SERVER_DESCRIPTION: ${{ vars.USER_API_SERVER_DESCRIPTION }}
+        run: |
+          sudo -E env PATH="$PATH" make publish-${{ matrix.deploy-target }}-schema-via-actions
 
       - name: On Success
         if: ${{ success() }}

--- a/backend/oas/Makefile
+++ b/backend/oas/Makefile
@@ -18,24 +18,42 @@ lint-user_signup: ## Lint user_signup openapi.yaml
 
 lint-all: lint-user lint-provider lint-admin lint-user_signup ## Lint user, provider, and admin
 
+# Substitute ${API_SERVER_URL} / ${API_SERVER_DESCRIPTION} placeholders in the
+# bundled openapi.yaml. Callers can override per-API via the *_API_SERVER_URL
+# / *_API_SERVER_DESCRIPTION env vars; defaults preserve previous behavior.
+# Args: $(1)=env-var prefix (USER/PROVIDER/ADMIN/USER_SIGNUP)
+#       $(2)=default URL  $(3)=spec directory
+define substitute-servers
+	@url="$${$(1)_API_SERVER_URL:-$(2)}"; \
+	 desc="$${$(1)_API_SERVER_DESCRIPTION:-Local server url}"; \
+	 sed -e 's|$${API_SERVER_URL}|'"$$url"'|g' \
+	     -e 's|$${API_SERVER_DESCRIPTION}|'"$$desc"'|g' \
+	     $(3)/openapi.yaml > $(3)/openapi.yaml.tmp \
+	 && mv $(3)/openapi.yaml.tmp $(3)/openapi.yaml
+endef
+
 generate-user: ## Generate user openapi.yaml
 	@docker pull redocly/cli
 	@docker run --rm -v $(PWD):/spec redocly/cli bundle /spec/user/root.yaml -o /spec/user/openapi.yaml
+	$(call substitute-servers,USER,http://localhost:8080,user)
 	@$(MAKE) lint-user
 
 generate-provider: ## Generate provider openapi.yaml
 	@docker pull redocly/cli
 	@docker run --rm -v $(PWD):/spec redocly/cli bundle /spec/provider/root.yaml -o /spec/provider/openapi.yaml
+	$(call substitute-servers,PROVIDER,http://localhost:8888,provider)
 	@$(MAKE) lint-provider
 
 generate-admin: ## Generate admin openapi.yaml
 	@docker pull redocly/cli
 	@docker run --rm -v $(PWD):/spec redocly/cli bundle /spec/admin/root.yaml -o /spec/admin/openapi.yaml
+	$(call substitute-servers,ADMIN,http://localhost:8080,admin)
 	@$(MAKE) lint-admin
 
 generate-user_signup: ## Generate user_signup openapi.yaml
 	@docker pull redocly/cli
 	@docker run --rm -v $(PWD):/spec redocly/cli bundle /spec/user_signup/root.yaml -o /spec/user_signup/openapi.yaml
+	$(call substitute-servers,USER_SIGNUP,http://localhost:8080,user_signup)
 	@$(MAKE) lint-user_signup
 
 generate-all: generate-user generate-provider generate-admin generate-user_signup ## Generate user, provider, admin openapi.yaml

--- a/backend/oas/admin/root.yaml
+++ b/backend/oas/admin/root.yaml
@@ -10,8 +10,8 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 servers:
-  - url: http://localhost:8080
-    description: Local server url
+  - url: ${API_SERVER_URL}
+    description: ${API_SERVER_DESCRIPTION}
 paths:
   /users:
     $ref: ./paths/users.yaml#/users

--- a/backend/oas/provider/root.yaml
+++ b/backend/oas/provider/root.yaml
@@ -10,8 +10,8 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 servers:
-  - url: http://localhost:8888
-    description: Local server url
+  - url: ${API_SERVER_URL}
+    description: ${API_SERVER_DESCRIPTION}
 security:
   - ApiKeyAuth: []
 paths:

--- a/backend/oas/user/openapi.yaml
+++ b/backend/oas/user/openapi.yaml
@@ -10,7 +10,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 servers:
-  - url: http://localhost:8080
+  - url: https://api.qiqb-cloud.jp
     description: Local server url
 paths:
   /devices:

--- a/backend/oas/user/root.yaml
+++ b/backend/oas/user/root.yaml
@@ -10,8 +10,8 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 servers:
-  - url: http://localhost:8080
-    description: Local server url
+  - url: ${API_SERVER_URL}
+    description: ${API_SERVER_DESCRIPTION}
 paths:
   /devices:
     $ref: ./paths/devices.yaml#/devices

--- a/backend/oas/user_signup/root.yaml
+++ b/backend/oas/user_signup/root.yaml
@@ -10,8 +10,8 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 servers:
-  - url: http://localhost:8080
-    description: Local server url
+  - url: ${API_SERVER_URL}
+    description: ${API_SERVER_DESCRIPTION}
 paths:
   /signup:
     $ref: ./paths/signup.yaml#/signup

--- a/deployment/oqtopus-dev/Makefile
+++ b/deployment/oqtopus-dev/Makefile
@@ -134,12 +134,13 @@ OAS_DIR := $(abspath ../../backend/oas)
 .PHONY: publish-user-schema publish-schema publish-user-schema-via-actions publish-schema-via-actions
 
 publish-user-schema: ## Publish user OpenAPI spec to S3
-	@$(MAKE) publish-schema API=user API_VAR_PREFIX=USER OPENAPI_S3_OBJECT_KEY=openapi.yaml DEFAULT_URL=http://localhost:8080
+	@if [ -z "$(PUBLISH_OPENAPI_S3_BUCKET)" ]; then \
+		echo "⏭  PUBLISH_OPENAPI_S3_BUCKET is not set — skipping publish-user-schema"; \
+	else \
+		$(MAKE) publish-schema API=user API_VAR_PREFIX=USER OPENAPI_S3_OBJECT_KEY=openapi.yaml DEFAULT_URL=http://localhost:8080; \
+	fi
 
 publish-schema:
-	@if [ -z "$(PUBLISH_OPENAPI_S3_BUCKET)" ]; then \
-		echo "❌ PUBLISH_OPENAPI_S3_BUCKET is not set (define it in .env)"; exit 1; \
-	fi
 	@docker pull -q redocly/cli >/dev/null
 	@TMPDIR=$$(mktemp -d); \
 	 trap 'rm -rf "$$TMPDIR"' EXIT; \
@@ -166,12 +167,13 @@ publish-schema:
 # Github Actions variants — same as the targets above but without --profile
 # (AWS credentials come from configure-aws-credentials via env vars).
 publish-user-schema-via-actions: ## Publish user OpenAPI spec to S3 via Github Actions
-	@$(MAKE) publish-schema-via-actions API=user API_VAR_PREFIX=USER OPENAPI_S3_OBJECT_KEY=openapi.yaml DEFAULT_URL=http://localhost:8080
+	@if [ -z "$(PUBLISH_OPENAPI_S3_BUCKET)" ]; then \
+		echo "⏭  PUBLISH_OPENAPI_S3_BUCKET is not set — skipping publish-user-schema-via-actions"; \
+	else \
+		$(MAKE) publish-schema-via-actions API=user API_VAR_PREFIX=USER OPENAPI_S3_OBJECT_KEY=openapi.yaml DEFAULT_URL=http://localhost:8080; \
+	fi
 
 publish-schema-via-actions:
-	@if [ -z "$(PUBLISH_OPENAPI_S3_BUCKET)" ]; then \
-		echo "❌ PUBLISH_OPENAPI_S3_BUCKET is not set"; exit 1; \
-	fi
 	@docker pull -q redocly/cli >/dev/null
 	@TMPDIR=$$(mktemp -d); \
 	 trap 'rm -rf "$$TMPDIR"' EXIT; \

--- a/deployment/oqtopus-dev/Makefile
+++ b/deployment/oqtopus-dev/Makefile
@@ -129,6 +129,71 @@ deploy-lambda-version-cleaner: zip-lambda-version-cleaner	## Deploy lambda-versi
 
 deploy-all: deploy-user deploy-provider deploy-admin deploy-lambda_auth deploy-user_signup deploy-pending-jobs-updater-worker deploy-lambda-version-cleaner ## Deploy All Lambda Packages
 
+OAS_DIR := $(abspath ../../backend/oas)
+
+.PHONY: publish-user-schema publish-schema publish-user-schema-via-actions publish-schema-via-actions
+
+publish-user-schema: ## Publish user OpenAPI spec to S3
+	@$(MAKE) publish-schema API=user API_VAR_PREFIX=USER OPENAPI_S3_OBJECT_KEY=openapi.yaml DEFAULT_URL=http://localhost:8080
+
+publish-schema:
+	@if [ -z "$(PUBLISH_OPENAPI_S3_BUCKET)" ]; then \
+		echo "❌ PUBLISH_OPENAPI_S3_BUCKET is not set (define it in .env)"; exit 1; \
+	fi
+	@docker pull -q redocly/cli >/dev/null
+	@TMPDIR=$$(mktemp -d); \
+	 trap 'rm -rf "$$TMPDIR"' EXIT; \
+	 echo "📄 Bundling $(API) OpenAPI spec ..."; \
+	 docker run --rm \
+	   -v $(OAS_DIR):/spec \
+	   -v $$TMPDIR:/out \
+	   redocly/cli bundle /spec/$(API)/root.yaml -o /out/openapi.yaml; \
+	 var_url="$(API_VAR_PREFIX)_API_SERVER_URL"; \
+	 var_desc="$(API_VAR_PREFIX)_API_SERVER_DESCRIPTION"; \
+	 url="$${!var_url:-$(DEFAULT_URL)}"; \
+	 desc="$${!var_desc:-Local server url}"; \
+	 echo "🔧 servers: url=$$url, description=$$desc"; \
+	 sed -e 's|$${API_SERVER_URL}|'"$$url"'|g' \
+	     -e 's|$${API_SERVER_DESCRIPTION}|'"$$desc"'|g' \
+	     $$TMPDIR/openapi.yaml > $$TMPDIR/openapi.final.yaml; \
+	 echo "☁️  Uploading to s3://$(PUBLISH_OPENAPI_S3_BUCKET)/$(OPENAPI_S3_OBJECT_KEY) ..."; \
+	 aws s3 cp $$TMPDIR/openapi.final.yaml \
+	   "s3://$(PUBLISH_OPENAPI_S3_BUCKET)/$(OPENAPI_S3_OBJECT_KEY)" \
+	   --content-type application/yaml \
+	   --profile $(PROFILE); \
+	 echo "✅ Published $(API) OpenAPI spec"
+
+# Github Actions variants — same as the targets above but without --profile
+# (AWS credentials come from configure-aws-credentials via env vars).
+publish-user-schema-via-actions: ## Publish user OpenAPI spec to S3 via Github Actions
+	@$(MAKE) publish-schema-via-actions API=user API_VAR_PREFIX=USER OPENAPI_S3_OBJECT_KEY=openapi.yaml DEFAULT_URL=http://localhost:8080
+
+publish-schema-via-actions:
+	@if [ -z "$(PUBLISH_OPENAPI_S3_BUCKET)" ]; then \
+		echo "❌ PUBLISH_OPENAPI_S3_BUCKET is not set"; exit 1; \
+	fi
+	@docker pull -q redocly/cli >/dev/null
+	@TMPDIR=$$(mktemp -d); \
+	 trap 'rm -rf "$$TMPDIR"' EXIT; \
+	 echo "📄 Bundling $(API) OpenAPI spec ..."; \
+	 docker run --rm \
+	   -v $(OAS_DIR):/spec \
+	   -v $$TMPDIR:/out \
+	   redocly/cli bundle /spec/$(API)/root.yaml -o /out/openapi.yaml; \
+	 var_url="$(API_VAR_PREFIX)_API_SERVER_URL"; \
+	 var_desc="$(API_VAR_PREFIX)_API_SERVER_DESCRIPTION"; \
+	 url="$${!var_url:-$(DEFAULT_URL)}"; \
+	 desc="$${!var_desc:-Local server url}"; \
+	 echo "🔧 servers: url=$$url, description=$$desc"; \
+	 sed -e 's|$${API_SERVER_URL}|'"$$url"'|g' \
+	     -e 's|$${API_SERVER_DESCRIPTION}|'"$$desc"'|g' \
+	     $$TMPDIR/openapi.yaml > $$TMPDIR/openapi.final.yaml; \
+	 echo "☁️  Uploading to s3://$(PUBLISH_OPENAPI_S3_BUCKET)/$(OPENAPI_S3_OBJECT_KEY) ..."; \
+	 aws s3 cp $$TMPDIR/openapi.final.yaml \
+	   "s3://$(PUBLISH_OPENAPI_S3_BUCKET)/$(OPENAPI_S3_OBJECT_KEY)" \
+	   --content-type application/yaml; \
+	 echo "✅ Published $(API) OpenAPI spec"
+
 deploy: generate-tag
 	@echo "Deploy ${FUNCTION_NAME} ..."
 	@export AWS_PAGER="" && \

--- a/deployment/oqtopus-prod/Makefile
+++ b/deployment/oqtopus-prod/Makefile
@@ -130,12 +130,13 @@ OAS_DIR := $(abspath ../../backend/oas)
 .PHONY: publish-user-schema publish-schema publish-user-schema-via-actions publish-schema-via-actions
 
 publish-user-schema: ## Publish user OpenAPI spec to S3
-	@$(MAKE) publish-schema API=user API_VAR_PREFIX=USER OPENAPI_S3_OBJECT_KEY=openapi.yaml DEFAULT_URL=http://localhost:8080
+	@if [ -z "$(PUBLISH_OPENAPI_S3_BUCKET)" ]; then \
+		echo "⏭  PUBLISH_OPENAPI_S3_BUCKET is not set — skipping publish-user-schema"; \
+	else \
+		$(MAKE) publish-schema API=user API_VAR_PREFIX=USER OPENAPI_S3_OBJECT_KEY=openapi.yaml DEFAULT_URL=http://localhost:8080; \
+	fi
 
 publish-schema:
-	@if [ -z "$(PUBLISH_OPENAPI_S3_BUCKET)" ]; then \
-		echo "❌ PUBLISH_OPENAPI_S3_BUCKET is not set (define it in .env)"; exit 1; \
-	fi
 	@docker pull -q redocly/cli >/dev/null
 	@TMPDIR=$$(mktemp -d); \
 	 trap 'rm -rf "$$TMPDIR"' EXIT; \
@@ -162,12 +163,13 @@ publish-schema:
 # Github Actions variants — same as the targets above but without --profile
 # (AWS credentials come from configure-aws-credentials via env vars).
 publish-user-schema-via-actions: ## Publish user OpenAPI spec to S3 via Github Actions
-	@$(MAKE) publish-schema-via-actions API=user API_VAR_PREFIX=USER OPENAPI_S3_OBJECT_KEY=openapi.yaml DEFAULT_URL=http://localhost:8080
+	@if [ -z "$(PUBLISH_OPENAPI_S3_BUCKET)" ]; then \
+		echo "⏭  PUBLISH_OPENAPI_S3_BUCKET is not set — skipping publish-user-schema-via-actions"; \
+	else \
+		$(MAKE) publish-schema-via-actions API=user API_VAR_PREFIX=USER OPENAPI_S3_OBJECT_KEY=openapi.yaml DEFAULT_URL=http://localhost:8080; \
+	fi
 
 publish-schema-via-actions:
-	@if [ -z "$(PUBLISH_OPENAPI_S3_BUCKET)" ]; then \
-		echo "❌ PUBLISH_OPENAPI_S3_BUCKET is not set"; exit 1; \
-	fi
 	@docker pull -q redocly/cli >/dev/null
 	@TMPDIR=$$(mktemp -d); \
 	 trap 'rm -rf "$$TMPDIR"' EXIT; \

--- a/deployment/oqtopus-prod/Makefile
+++ b/deployment/oqtopus-prod/Makefile
@@ -125,6 +125,71 @@ deploy-lambda-version-cleaner: zip-lambda-version-cleaner	## Deploy lambda-versi
 
 deploy-all: deploy-user deploy-provider deploy-admin deploy-lambda_auth deploy-user_signup deploy-pending-jobs-updater-worker deploy-lambda-version-cleaner ## Deploy All Lambda Packages
 
+OAS_DIR := $(abspath ../../backend/oas)
+
+.PHONY: publish-user-schema publish-schema publish-user-schema-via-actions publish-schema-via-actions
+
+publish-user-schema: ## Publish user OpenAPI spec to S3
+	@$(MAKE) publish-schema API=user API_VAR_PREFIX=USER OPENAPI_S3_OBJECT_KEY=openapi.yaml DEFAULT_URL=http://localhost:8080
+
+publish-schema:
+	@if [ -z "$(PUBLISH_OPENAPI_S3_BUCKET)" ]; then \
+		echo "❌ PUBLISH_OPENAPI_S3_BUCKET is not set (define it in .env)"; exit 1; \
+	fi
+	@docker pull -q redocly/cli >/dev/null
+	@TMPDIR=$$(mktemp -d); \
+	 trap 'rm -rf "$$TMPDIR"' EXIT; \
+	 echo "📄 Bundling $(API) OpenAPI spec ..."; \
+	 docker run --rm \
+	   -v $(OAS_DIR):/spec \
+	   -v $$TMPDIR:/out \
+	   redocly/cli bundle /spec/$(API)/root.yaml -o /out/openapi.yaml; \
+	 var_url="$(API_VAR_PREFIX)_API_SERVER_URL"; \
+	 var_desc="$(API_VAR_PREFIX)_API_SERVER_DESCRIPTION"; \
+	 url="$${!var_url:-$(DEFAULT_URL)}"; \
+	 desc="$${!var_desc:-Local server url}"; \
+	 echo "🔧 servers: url=$$url, description=$$desc"; \
+	 sed -e 's|$${API_SERVER_URL}|'"$$url"'|g' \
+	     -e 's|$${API_SERVER_DESCRIPTION}|'"$$desc"'|g' \
+	     $$TMPDIR/openapi.yaml > $$TMPDIR/openapi.final.yaml; \
+	 echo "☁️  Uploading to s3://$(PUBLISH_OPENAPI_S3_BUCKET)/$(OPENAPI_S3_OBJECT_KEY) ..."; \
+	 aws s3 cp $$TMPDIR/openapi.final.yaml \
+	   "s3://$(PUBLISH_OPENAPI_S3_BUCKET)/$(OPENAPI_S3_OBJECT_KEY)" \
+	   --content-type application/yaml \
+	   --profile $(PROFILE); \
+	 echo "✅ Published $(API) OpenAPI spec"
+
+# Github Actions variants — same as the targets above but without --profile
+# (AWS credentials come from configure-aws-credentials via env vars).
+publish-user-schema-via-actions: ## Publish user OpenAPI spec to S3 via Github Actions
+	@$(MAKE) publish-schema-via-actions API=user API_VAR_PREFIX=USER OPENAPI_S3_OBJECT_KEY=openapi.yaml DEFAULT_URL=http://localhost:8080
+
+publish-schema-via-actions:
+	@if [ -z "$(PUBLISH_OPENAPI_S3_BUCKET)" ]; then \
+		echo "❌ PUBLISH_OPENAPI_S3_BUCKET is not set"; exit 1; \
+	fi
+	@docker pull -q redocly/cli >/dev/null
+	@TMPDIR=$$(mktemp -d); \
+	 trap 'rm -rf "$$TMPDIR"' EXIT; \
+	 echo "📄 Bundling $(API) OpenAPI spec ..."; \
+	 docker run --rm \
+	   -v $(OAS_DIR):/spec \
+	   -v $$TMPDIR:/out \
+	   redocly/cli bundle /spec/$(API)/root.yaml -o /out/openapi.yaml; \
+	 var_url="$(API_VAR_PREFIX)_API_SERVER_URL"; \
+	 var_desc="$(API_VAR_PREFIX)_API_SERVER_DESCRIPTION"; \
+	 url="$${!var_url:-$(DEFAULT_URL)}"; \
+	 desc="$${!var_desc:-Local server url}"; \
+	 echo "🔧 servers: url=$$url, description=$$desc"; \
+	 sed -e 's|$${API_SERVER_URL}|'"$$url"'|g' \
+	     -e 's|$${API_SERVER_DESCRIPTION}|'"$$desc"'|g' \
+	     $$TMPDIR/openapi.yaml > $$TMPDIR/openapi.final.yaml; \
+	 echo "☁️  Uploading to s3://$(PUBLISH_OPENAPI_S3_BUCKET)/$(OPENAPI_S3_OBJECT_KEY) ..."; \
+	 aws s3 cp $$TMPDIR/openapi.final.yaml \
+	   "s3://$(PUBLISH_OPENAPI_S3_BUCKET)/$(OPENAPI_S3_OBJECT_KEY)" \
+	   --content-type application/yaml; \
+	 echo "✅ Published $(API) OpenAPI spec"
+
 deploy: generate-tag
 	@echo "Deploy ${FUNCTION_NAME} ..."
 	@export AWS_PAGER="" && \


### PR DESCRIPTION
#  Summary

Makes OpenAPI servers URLs configurable per environment, and wires up 
an automated S3 publish step for the user API spec on every dev deploy.

#  Changes

This PR brings the following change:
-  `backend/oas/` : Each API's `root.yaml` now uses `${API_SERVER_URL}`
   / `${API_SERVER_DESCRIPTION}` placeholders, substituted by `sed`
  after redocly bundle in Makefile. Per-API env vars (e.g.
  `USER_API_SERVER_URL`) override; absence falls back to the
  previous localhost values, so existing behavior is preserved.

- `deployment/oqtopus-{dev,prod}/Makefile` : New
  `publish-user-schema` target bundles the user spec, substitutes
  env-specific server values into a tempdir copy (the
  repo-tracked openapi.yaml is not touched), and uploads to S3
  via aws s3 cp. `publish-user-schema-via-actions` is the CI
  variant without `--profile`, mirroring the existing
  deploy-*-via-actions convention.

-  `.github/workflows/deployment.yaml` — Added `backend/oas/**` to
  the trigger paths:, and a "Publish user OpenAPI spec to S3"
  step after the Lambda deploy, conditional on
  `matrix.deploy-target == 'user'.`

#  Configuration required before merging

  - GitHub repo Variables (Settings → Variables):
    - `PUBLISH_OPENAPI_S3_BUCKET`
    - `USER_API_SERVER_URL`
    - `USER_API_SERVER_DESCRIPTION`