### PR TITLE
feat(cognito): notify Slack on every sign-up confirmation

### DIFF
--- a/terraform/infrastructure/modules/cognito-signup-notifier/README.md
+++ b/terraform/infrastructure/modules/cognito-signup-notifier/README.md
@@ -1,0 +1,55 @@
+# Cognito Signup Notifier Module
+
+## What
+
+Lambda function attached as a Cognito User Pool **PostConfirmation** trigger. On every successful sign-up confirmation it:
+
+1. Posts a notification to Slack containing the sender's email domain only (no PII)
+2. Publishes a CloudWatch metric `<env-label>/cognito` with dimension `domain` for time-series visibility (Grafana CloudWatch datasource etc.)
+
+## Why
+
+After the 2026-05-26 incident in `qiqb-prod` / `riken-prod` where a misconfigured whitelist-bypass environment variable allowed 207 unauthorized sign-ups, we want a low-noise channel that surfaces every sign-up to operators. With small whitelist-based user bases, per-event Slack posts are tolerable and let humans notice anomalous patterns (unfamiliar domain bursts) early.
+
+The Lambda lives in `infrastructure/modules/` rather than `service/modules/` because attaching as a Cognito trigger creates a Lambda ↔ Cognito user pool dependency that is simplest to express when both resources are in the same Terraform layer.
+
+## How to wire
+
+In an env-level entry under `infrastructure/<env>/main.tf`:
+
+```hcl
+module "user_cognito_signup_notifier" {
+  source  = "../modules/cognito-signup-notifier"
+  product = var.product
+  org     = var.org
+  env     = var.env
+  region  = var.region
+}
+
+module "user_cognito" {
+  source                       = "../modules/cognito"
+  product                      = var.product
+  org                          = var.org
+  env                          = var.env
+  identifier                   = "user"
+  post_confirmation_lambda_arn = module.user_cognito_signup_notifier.lambda_arn
+}
+```
+
+## Required out-of-band step: Slack webhook URL
+
+The Slack webhook URL is held in Secrets Manager. The secret is created empty by Terraform; the value must be set manually after the first apply (or before the trigger fires):
+
+```bash
+aws secretsmanager put-secret-value \
+  --secret-id "<product>-<org>-<env>-cognito-signup-notifier-slack-webhook" \
+  --secret-string "https://hooks.slack.com/services/XXX/YYY/ZZZ"
+```
+
+The Lambda fetches the URL on cold start and caches it in memory. If the secret is rotated, the Lambda must be re-deployed or its containers will hold the old value until they recycle.
+
+## qiqb-dev experiment history
+
+Originally prototyped on 2026-06-01 in `qiqb-dev` via AWS Console GUI (function `cognito-signup-notifier`, Python 3.14, plain env var for the webhook). Verified end-to-end with a Cognito post-confirmation test event reaching Slack. This module is the IaC version that supersedes the GUI deployment.
+
+The `qiqb-dev` environment has no Terraform entry in this repository (managed separately), so this module applies cleanly to `oqtopus-dev` / `oqtopus-prod` only.

--- a/terraform/infrastructure/modules/cognito-signup-notifier/files/lambda_function.py
+++ b/terraform/infrastructure/modules/cognito-signup-notifier/files/lambda_function.py
@@ -1,0 +1,62 @@
+import json
+import os
+import urllib.request
+
+import boto3
+
+ENV_LABEL = os.environ.get("ENV_LABEL", "unknown")
+SLACK_WEBHOOK_SECRET_ARN = os.environ["SLACK_WEBHOOK_SECRET_ARN"]
+
+_secrets = boto3.client("secretsmanager")
+_cloudwatch = boto3.client("cloudwatch")
+_slack_webhook_url = None
+
+
+def _get_slack_webhook_url():
+    global _slack_webhook_url
+    if _slack_webhook_url is None:
+        resp = _secrets.get_secret_value(SecretId=SLACK_WEBHOOK_SECRET_ARN)
+        _slack_webhook_url = resp["SecretString"]
+    return _slack_webhook_url
+
+
+def lambda_handler(event, context):
+    if event.get("triggerSource") != "PostConfirmation_ConfirmSignUp":
+        return event
+
+    email = event["request"]["userAttributes"].get("email", "")
+    domain = email.split("@")[-1] if "@" in email else "unknown"
+
+    try:
+        _notify_slack(domain)
+    except Exception as e:
+        print(f"slack notify failed: {e}")
+
+    try:
+        _put_metric(domain)
+    except Exception as e:
+        print(f"cloudwatch put failed: {e}")
+
+    return event
+
+
+def _notify_slack(domain):
+    body = json.dumps({"text": f"[{ENV_LABEL}] new Cognito signup: @{domain}"}).encode()
+    req = urllib.request.Request(
+        _get_slack_webhook_url(),
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    urllib.request.urlopen(req, timeout=3)
+
+
+def _put_metric(domain):
+    _cloudwatch.put_metric_data(
+        Namespace=f"{ENV_LABEL}/cognito",
+        MetricData=[{
+            "MetricName": "Signup",
+            "Dimensions": [{"Name": "domain", "Value": domain}],
+            "Value": 1,
+            "Unit": "Count",
+        }],
+    )

--- a/terraform/infrastructure/modules/cognito-signup-notifier/main.tf
+++ b/terraform/infrastructure/modules/cognito-signup-notifier/main.tf
@@ -1,0 +1,135 @@
+/**
+*
+* # Cognito Signup Notifier Module
+*
+* ## Description
+*
+* Creates a Lambda function attached as a Cognito User Pool PostConfirmation trigger.
+* On every successful sign-up confirmation it posts a notification to Slack (sender
+* domain only, no PII) and publishes a CloudWatch metric for visibility.
+*
+* The Slack webhook URL is held in Secrets Manager; the secret value must be set
+* out-of-band (see README).
+*
+* ## Usage
+*
+* ```hcl
+* module "user_cognito_signup_notifier" {
+*   source  = "../modules/cognito-signup-notifier"
+*   product = "oqtopus"
+*   org     = "example"
+*   env     = "dev"
+*   region  = "ap-northeast-1"
+* }
+*
+* module "user_cognito" {
+*   source                       = "../modules/cognito"
+*   ...
+*   post_confirmation_lambda_arn = module.user_cognito_signup_notifier.lambda_arn
+* }
+* ```
+*
+*/
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_secretsmanager_secret" "slack_webhook" {
+  name        = "${var.product}-${var.org}-${var.env}-cognito-signup-notifier-slack-webhook"
+  description = "Slack webhook URL for Cognito sign-up notifications"
+}
+
+data "archive_file" "lambda" {
+  type        = "zip"
+  source_file = "${path.module}/files/lambda_function.py"
+  output_path = "${path.module}/build/lambda.zip"
+}
+
+resource "aws_lambda_function" "this" {
+  architectures = ["x86_64"]
+
+  environment {
+    variables = {
+      SLACK_WEBHOOK_SECRET_ARN = aws_secretsmanager_secret.slack_webhook.arn
+      ENV_LABEL                = "${var.product}-${var.org}-${var.env}"
+    }
+  }
+
+  filename                       = data.archive_file.lambda.output_path
+  source_code_hash               = data.archive_file.lambda.output_base64sha256
+  function_name                  = "${var.product}-${var.org}-${var.env}-cognito-signup-notifier"
+  handler                        = "lambda_function.lambda_handler"
+  memory_size                    = "128"
+  package_type                   = "Zip"
+  reserved_concurrent_executions = "-1"
+  role                           = aws_iam_role.lambda.arn
+  runtime                        = "python3.12"
+  skip_destroy                   = "false"
+  timeout                        = "10"
+
+  tracing_config {
+    mode = "Active"
+  }
+
+  lifecycle {
+    ignore_changes = [tags["github-sha"]]
+  }
+}
+
+resource "aws_iam_role" "lambda" {
+  assume_role_policy   = data.aws_iam_policy_document.lambda_assume_role.json
+  description          = "Execution role for Cognito signup notifier Lambda."
+  max_session_duration = "3600"
+  name                 = "${var.product}-${var.org}-${var.env}-cognito-signup-notifier-lambda"
+  path                 = "/"
+}
+
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "basic_execution" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "xray" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+}
+
+resource "aws_iam_role_policy" "extras" {
+  name   = "${var.product}-${var.org}-${var.env}-cognito-signup-notifier-extras"
+  role   = aws_iam_role.lambda.id
+  policy = data.aws_iam_policy_document.extras.json
+}
+
+data "aws_iam_policy_document" "extras" {
+  statement {
+    actions   = ["cloudwatch:PutMetricData"]
+    effect    = "Allow"
+    resources = ["*"]
+  }
+  statement {
+    actions   = ["secretsmanager:GetSecretValue"]
+    effect    = "Allow"
+    resources = [aws_secretsmanager_secret.slack_webhook.arn]
+  }
+}
+
+# Wildcard source_arn avoids the chicken-and-egg with cognito user pool ARN
+# (user pool's lambda_config requires the permission to exist first, and the
+# permission would otherwise require the user pool ARN).
+resource "aws_lambda_permission" "cognito_invoke" {
+  statement_id  = "AllowCognitoInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.this.function_name
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = "arn:aws:cognito-idp:${var.region}:${data.aws_caller_identity.current.account_id}:userpool/*"
+}

--- a/terraform/infrastructure/modules/cognito-signup-notifier/outputs.tf
+++ b/terraform/infrastructure/modules/cognito-signup-notifier/outputs.tf
@@ -1,0 +1,14 @@
+output "lambda_arn" {
+  value       = aws_lambda_function.this.arn
+  description = "ARN of the notifier Lambda function (pass to cognito module's post_confirmation_lambda_arn)"
+}
+
+output "lambda_function_name" {
+  value       = aws_lambda_function.this.function_name
+  description = "Name of the notifier Lambda function"
+}
+
+output "slack_webhook_secret_arn" {
+  value       = aws_secretsmanager_secret.slack_webhook.arn
+  description = "ARN of the Secrets Manager secret that must hold the Slack webhook URL"
+}

--- a/terraform/infrastructure/modules/cognito-signup-notifier/provider.tf
+++ b/terraform/infrastructure/modules/cognito-signup-notifier/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.57.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.0"
+    }
+  }
+  required_version = ">= 1.9.0, < 2.0.0"
+}

--- a/terraform/infrastructure/modules/cognito-signup-notifier/variables.tf
+++ b/terraform/infrastructure/modules/cognito-signup-notifier/variables.tf
@@ -1,0 +1,19 @@
+variable "product" {
+  description = "product name"
+  type        = string
+}
+
+variable "org" {
+  description = "organization name"
+  type        = string
+}
+
+variable "env" {
+  description = "environment name"
+  type        = string
+}
+
+variable "region" {
+  description = "region of the deployment"
+  type        = string
+}

--- a/terraform/infrastructure/modules/cognito/main.tf
+++ b/terraform/infrastructure/modules/cognito/main.tf
@@ -87,6 +87,13 @@ resource "aws_cognito_user_pool" "this" {
   }
 
   username_attributes = var.username_attributes
+
+  dynamic "lambda_config" {
+    for_each = var.post_confirmation_lambda_arn != null ? [1] : []
+    content {
+      post_confirmation = var.post_confirmation_lambda_arn
+    }
+  }
 }
 
 resource "aws_cognito_user_pool_client" "this" {

--- a/terraform/infrastructure/modules/cognito/variables.tf
+++ b/terraform/infrastructure/modules/cognito/variables.tf
@@ -48,3 +48,9 @@ variable "password_minimum_length" {
   default     = 8
 }
 
+variable "post_confirmation_lambda_arn" {
+  description = "ARN of Lambda function to invoke after Cognito sign-up confirmation. When set, attaches as PostConfirmation trigger."
+  type        = string
+  default     = null
+}
+

--- a/terraform/infrastructure/oqtopus-dev/main.tf
+++ b/terraform/infrastructure/oqtopus-dev/main.tf
@@ -60,13 +60,23 @@ module "management" {
   eic_security_group_ids         = module.security_group.eic_security_group_ids
 }
 
+module "user_cognito_signup_notifier" {
+  source = "../modules/cognito-signup-notifier"
+
+  product = var.product
+  org     = var.org
+  env     = var.env
+  region  = var.region
+}
+
 module "user_cognito" {
   source = "../modules/cognito"
 
-  product    = var.product
-  org        = var.org
-  env        = var.env
-  identifier = "user"
+  product                      = var.product
+  org                          = var.org
+  env                          = var.env
+  identifier                   = "user"
+  post_confirmation_lambda_arn = module.user_cognito_signup_notifier.lambda_arn
 }
 
 module "admin_cognito" {


### PR DESCRIPTION
## Slack Image
<img width="598" height="132" alt="image" src="https://github.com/user-attachments/assets/5c94c149-a949-4403-80be-e526e528d888" />

## Summary

Adds a PostConfirmation Lambda trigger on the user Cognito user pool that posts a domain-only notification to Slack (no PII) and publishes a CloudWatch metric for every successful sign-up.

Motivated by the 2026-05-26 incident where a misconfigured whitelist-bypass flag in qiqb-prod / riken-prod allowed 207 unauthorized sign-ups to go unnoticed for several days. With small whitelist-based user bases, per-event Slack posts give operators a low-effort way to spot anomalous patterns (unfamiliar-domain bursts, etc.) early.

## What's in the change

- New module: `terraform/infrastructure/modules/cognito-signup-notifier/`
  - Lambda (Python 3.12, no VPC, x86_64)
  - IAM role with basic execution + X-Ray + CloudWatch PutMetricData + Secrets Manager read
  - Lambda permission for Cognito to invoke (wildcard `userpool/*` source_arn)
  - Empty Secrets Manager secret for the Slack webhook URL
- Extended `terraform/infrastructure/modules/cognito` with an optional `post_confirmation_lambda_arn` variable (defaults to null; existing callers unaffected)
- Wired the notifier into `oqtopus-dev` only. `oqtopus-prod` will be enabled in a follow-up once dev has validated the path.

## Design notes

- **Module placed in `infrastructure/` rather than `service/`**: attaching a Cognito trigger creates a Lambda ↔ user pool dependency that is simplest to express when both live in the same Terraform layer.
- **Slack URL in Secrets Manager, not in Terraform**: matches the existing pattern where Terraform only knows secret ARNs (e.g., DB master password via `manage_master_user_password`). The webhook URL never enters Terraform state or plan output.
- **Wildcard source_arn on the Lambda permission**: a strict ARN reference (user_pool_arn) would create a cycle with the user pool's `lambda_config`. The scope is still limited to Cognito as principal.

## Required out-of-band step (after first apply)

The Lambda fetches the webhook URL from Secrets Manager on cold start. Set the secret value before the trigger fires (or accept that signups before the value is set will only emit a CloudWatch metric — Slack post is wrapped in try/except so the signup itself is never blocked):

```bash
aws secretsmanager put-secret-value \
  --secret-id "oqtopus-oqtopus-dev-cognito-signup-notifier-slack-webhook" \
  --secret-string "https://hooks.slack.com/services/..."
```

## Test plan

- [x] Prototyped end-to-end in qiqb-dev via AWS Console (function `cognito-signup-notifier`, Python 3.14, env var for webhook). Cognito PostConfirmation test event reached the configured Slack channel.
- [ ] `terraform plan` against oqtopus-dev to confirm no unexpected drift on the existing cognito module
- [ ] After apply: `put-secret-value` the Slack webhook URL, then sign up a test user (whitelisted) and confirm the Slack notification arrives and CloudWatch `oqtopus-oqtopus-dev/cognito.Signup` metric increments

## Follow-ups

- Wire into `oqtopus-prod` once dev is validated
- Companion change: a whitelist-change notifier (polling Lambda on `whitelist_users` table) is planned as a separate PR
- Grafana panel (CloudWatch datasource) for the `Signup` metric is planned on the monitoring-prototype side