### PR TITLE
chore: remove container_name from compose services

### DIFF
--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -46,7 +46,6 @@ services:
 
   minio:
     image: quay.io/minio/minio
-    container_name: minio
     ports:
       - "9000:9000"
       - "9001:9001"
@@ -65,7 +64,6 @@ services:
 
   mc:
     image: minio/mc
-    container_name: minio-client
     depends_on:
       minio:
         condition: service_healthy
@@ -77,7 +75,6 @@ services:
 
   user-api:
     <<: *api-common
-    container_name: oqtopus-user-api
     environment:
       <<: *api-env
       POWERTOOLS_METRICS_NAMESPACE: user-api
@@ -88,7 +85,6 @@ services:
 
   provider-api:
     <<: *api-common
-    container_name: oqtopus-provider-api
     environment:
       <<: *api-env
       POWERTOOLS_METRICS_NAMESPACE: provider-api


### PR DESCRIPTION
This pull request makes a small but important change to the `backend/compose.yaml` file by removing explicit `container_name` fields from several service definitions. This allows Docker Compose to use its default naming convention, which can help avoid naming conflicts and improve compatibility with certain Docker workflows.

Most important changes:

**Docker Compose configuration cleanup:**

* Removed the `container_name` field from the `minio` service definition.
* Removed the `container_name` field from the `mc` (MinIO client) service definition.
* Removed the `container_name` field from the `user-api` service definition.
* Removed the `container_name` field from the `provider-api` service definition.