### PR TITLE
Fix : Set default value for `COUNT_PENDING_JOBS_SINCE` in Makefile ta…

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -105,9 +105,12 @@ run-user_signup: ## Start the user_signup API
 	export POWERTOOLS_SERVICE_NAME=user_signup-api && \
 	uv run uvicorn oqtopus_cloud.user_signup.lambda_function:app --host 0.0.0.0 --port ${USER_SIGNUP_API_PORT} --reload --log-level debug
 
+COUNT_PENDING_JOBS_SINCE ?= 10d
+
 run-worker:
 	@export POWERTOOLS_METRICS_NAMESPACE=pending-jobs-updater && \
 	export POWERTOOLS_SERVICE_NAME=pending-jobs-updater && \
+	export COUNT_PENDING_JOBS_SINCE=$(COUNT_PENDING_JOBS_SINCE) && \
 	uv run python oqtopus_cloud/worker/pending_jobs_updater/local_scheduler.py
 
 up: ## Start the DB


### PR DESCRIPTION
# Summary
  - Make environment variable `COUNT_PENDING_JOBS_SINCE` visible to the Makefile target `run-worker`
  - Overridable by introducing a `?=` default (`10d`) and expanding the Make variable into the exported env var.

 # Test plan
  - [ ] `make run-worker` runs with the default `10d`.
  - [x] `make run-worker COUNT_PENDING_JOBS_SINCE=1h` exports
  `COUNT_PENDING_JOBS_SINCE=1h` to the worker process.
  - [x] `COUNT_PENDING_JOBS_SINCE=1h make run-worker` behaves the
  same as above.
