### PR TITLE
docs: clarify S3-based job storage flow and artifact format

### DIFF
--- a/docs/en/architecture/quantum_jobs_in_detail.md
+++ b/docs/en/architecture/quantum_jobs_in_detail.md
@@ -17,27 +17,17 @@ Each job owns a storage prefix named by its job ID:
 <job_id>/sse_log.zip
 ```
 
-The supported object names are fixed by the backend:
+The supported object names are fixed by the backend, and each zip is expected to contain a single payload file:
 
-| Object | Producer | Consumer | Notes |
-| --- | --- | --- | --- |
-| `input.zip` | User | Provider, User | Required before submission can be completed. The file content follows `jobs.S3SubmitJobInfo`. |
-| `combined_program.zip` | Provider | User | Only accepted for `multi_manual` jobs. |
-| `transpile_result.zip` | Provider | User | Transpilation output. |
-| `result.zip` | Provider | User | Job result. The file content follows `jobs.S3JobResult`. |
-| `sse_log.zip` | Provider | User | Only accepted for `sse` jobs. |
+| Object | Archive entry name | Producer | Consumer | Payload format | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `input.zip` | `input.json` | User | Provider, User | JSON matching `jobs.S3SubmitJobInfo` | Required before submission can be completed. |
+| `combined_program.zip` | `combined_program.json` | Provider | User | JSON payload for the combined program | Only accepted for `multi_manual` jobs. |
+| `transpile_result.zip` | `transpile_result.json` | Provider | User | JSON matching `jobs.S3TranspileResult` | Transpilation output. |
+| `result.zip` | `result.json` | Provider | User | JSON matching `jobs.S3JobResult` | Job result. |
+| `sse_log.zip` | `sse_log.log` | Provider | User | JSON string payload containing the SSE log text | Only accepted for `sse` jobs. |
 
 The default storage driver is S3. Local development can use `local` or `local:minio`, but the API contract is the same: the API returns upload presigned URL data or download presigned URLs, and the client transfers files directly to the storage backend.
-
-Each zip file is expected to contain a single payload file. The current implementation convention is:
-
-| Object | Archive entry name | Payload format |
-| --- | --- | --- |
-| `input.zip` | `input.json` | JSON matching `jobs.S3SubmitJobInfo` |
-| `combined_program.zip` | `combined_program.json` | JSON payload for the combined program |
-| `transpile_result.zip` | `transpile_result.json` | JSON matching `jobs.S3TranspileResult` |
-| `result.zip` | `result.json` | JSON matching `jobs.S3JobResult` |
-| `sse_log.zip` | `sse_log.log` | JSON string payload containing the SSE log text |
 
 For the current storage-backed format, the zip entry naming rule is effectively `<object-stem>.json`, except `sse_log.zip`, which uses `sse_log.log`.
 
@@ -46,7 +36,7 @@ For the current storage-backed format, the zip entry naming rule is effectively 
 1. Register a job with `POST /jobs`.
    The backend creates a DB row in `registered` status with a generated `job_id` and returns an upload presigned URL for `<job_id>/input.zip`.
 2. Upload `input.zip` to the returned presigned URL.
-   The uploaded file contains the job input described by `jobs.S3SubmitJobInfo`.
+   The uploaded zip contains the job input as `input.json`, described by `jobs.S3SubmitJobInfo`.
 3. Complete submission with `POST /jobs/{job_id}/submit`.
    The request body contains DB metadata such as `device_id`, `job_type`, `shots`, and optional transpiler, simulator, mitigation, name, and description fields. The backend verifies that `<job_id>/input.zip` exists before moving the job to `submitted`.
 4. Read job details with `GET /jobs` or `GET /jobs/{job_id}`.
@@ -89,7 +79,7 @@ The `ready -> failed` transition is supported so that provider-side preprocessin
 
 ## Job Input and Output Schemas
 
-`input.zip` contains a payload matching `jobs.S3SubmitJobInfo`.
+`input.zip` contains `input.json`, and that payload matches `jobs.S3SubmitJobInfo`.
 
 | Field | Required for | Notes |
 | --- | --- | --- |
@@ -97,14 +87,7 @@ The `ready -> failed` transition is supported so that provider-side preprocessin
 | `operator` | `estimation` | Array of Pauli operator items. |
 | `sse_program` | `sse` | User program for SSE jobs. |
 
-Provider outputs are stored as separate zip files:
-
-| File | Schema |
-| --- | --- |
-| `result.zip` | `jobs.S3JobResult` |
-| `transpile_result.zip` | `jobs.S3TranspileResult` |
-| `combined_program.zip` | Combined program for `multi_manual` jobs |
-| `sse_log.zip` | SSE log for `sse` jobs |
+For provider output zip files and the payload names/schema inside them, refer to the storage-model table above.
 
 Example archive layouts:
 

--- a/docs/en/architecture/quantum_jobs_in_detail.md
+++ b/docs/en/architecture/quantum_jobs_in_detail.md
@@ -1,38 +1,130 @@
 # Quantum Jobs in Detail
 
-## The Definition of Quantum Job
+OQTOPUS stores large quantum-job payloads in object storage and keeps only job metadata in the database.
+The User API, Provider API, and storage service are connected by presigned URLs, so clients upload and download job files directly without sending large payloads through the API server.
 
-The quantum job in OQTOPUS is a structure consisting of several fields, some of which also include subfields.
-In this section, we describe how quantum jobs are structured.
+This page describes the current implementation contract. It intentionally follows the running backend implementation and OpenAPI files under `backend/oas`.
 
-### Job Info
+## Storage Model
 
-`JobInfo` is a structure that holds data related to the execution of individual quantum jobs and is composed of the following fields
+Each job owns a storage prefix named by its job ID:
 
-- **`desc`**  
-  The quantum job descriptor, detailed below.
-- **`transpiled_code`**  
-  The transpiled quantum program which is actually executed on a device.
-- **`result`**  
-  The computation result. For failed jobs, this field is empty.
-- **`reason`**  
-  The description of failure. For successful jobs, this field is empty.
+```text
+<job_id>/input.zip
+<job_id>/combined_program.zip
+<job_id>/transpile_result.zip
+<job_id>/result.zip
+<job_id>/sse_log.zip
+```
 
-The job info descriptor is also a structure with fields varying depending on the job type. All job types have a `job_type` field in common, and its value determines the type of quantum job. 
+The supported object names are fixed by the backend:
 
-Currently, the following types of jobs are supported. The structure of the job info descriptor for each job type is as follows:
+| Object | Producer | Consumer | Notes |
+| --- | --- | --- | --- |
+| `input.zip` | User | Provider, User | Required before submission can be completed. The file content follows `jobs.S3SubmitJobInfo`. |
+| `combined_program.zip` | Provider | User | Only accepted for `multi_manual` jobs. |
+| `transpile_result.zip` | Provider | User | Transpilation output. |
+| `result.zip` | Provider | User | Job result. The file content follows `jobs.S3JobResult`. |
+| `sse_log.zip` | Provider | User | Only accepted for `sse` jobs. |
 
-- **Sampling Job**  
-    - `job_type`: `sampling`
-    - `code`: The quantum program of the job, written in OpenQASM3.
+The default storage driver is S3. Local development can use `local` or `local:minio`, but the API contract is the same: the API returns upload presigned URL data or download presigned URLs, and the client transfers files directly to the storage backend.
 
-- **Estimation Job**  
-    - `job_type`: `estimation`.
-    - `code`: The quantum program of the job, written in OpenQASM3.
-    - `operators`:  
+Each zip file is expected to contain a single payload file. The current implementation convention is:
 
-### Transpiler Info
+| Object | Archive entry name | Payload format |
+| --- | --- | --- |
+| `input.zip` | `input.json` | JSON matching `jobs.S3SubmitJobInfo` |
+| `combined_program.zip` | `combined_program.json` | JSON payload for the combined program |
+| `transpile_result.zip` | `transpile_result.json` | JSON matching `jobs.S3TranspileResult` |
+| `result.zip` | `result.json` | JSON matching `jobs.S3JobResult` |
+| `sse_log.zip` | `sse_log.log` | JSON string payload containing the SSE log text |
 
-### Mitigation Info
+For the current storage-backed format, the zip entry naming rule is effectively `<object-stem>.json`, except `sse_log.zip`, which uses `sse_log.log`.
 
-### Simulator Info
+## User API Flow
+
+1. Register a job with `POST /jobs`.
+   The backend creates a DB row in `registered` status with a generated `job_id` and returns an upload presigned URL for `<job_id>/input.zip`.
+2. Upload `input.zip` to the returned presigned URL.
+   The uploaded file contains the job input described by `jobs.S3SubmitJobInfo`.
+3. Complete submission with `POST /jobs/{job_id}/submit`.
+   The request body contains DB metadata such as `device_id`, `job_type`, `shots`, and optional transpiler, simulator, mitigation, name, and description fields. The backend verifies that `<job_id>/input.zip` exists before moving the job to `submitted`.
+4. Read job details with `GET /jobs` or `GET /jobs/{job_id}`.
+   For submitted and later jobs, `job_info.input` is a download presigned URL. Uploaded provider outputs appear in `job_info` after the provider reports them through `PATCH /jobs/{job_id}/status`.
+5. Delete a terminal job with `DELETE /jobs/{job_id}`.
+   Deletion is allowed only for `succeeded`, `failed`, and `cancelled` jobs. The backend deletes the DB row and all objects under `<job_id>/`.
+
+`registered` jobs are visible to the owner, but their DB row contains placeholder values for fields that are not known until submission. User responses therefore expose only `job_id` and `status` for registered jobs unless a filtered field is explicitly requested, in which case undefined fields are returned as `null`.
+
+## Provider API Flow
+
+1. Poll jobs with `GET /jobs?device_id=<device_id>`.
+   Registered jobs are excluded. When the provider fetches a `submitted` job, the backend advances it to `ready` and returns `input`, a download presigned URL for `<job_id>/input.zip`.
+2. Optionally request output upload URLs with `GET /jobs/{job_id}/upload?items=...`.
+   `items` is a comma-separated list from `combined_program`, `transpile_result`, `result`, and `sse_log`. The backend rejects `combined_program` for non-`multi_manual` jobs and rejects `sse_log` for non-`sse` jobs.
+3. Mark execution as started with `PATCH /jobs/{job_id}/status` and body `{ "status": "running" }`.
+   This transition is allowed only from `ready`.
+4. Upload output files directly to storage using the presigned URL data.
+5. Complete the job with `PATCH /jobs/{job_id}/status`.
+   Final statuses are `succeeded`, `failed`, and `cancelled`. The request can include `execution_time`, `message`, and `output_files`.
+
+`output_files` must contain full storage keys such as `<job_id>/result.zip`. The backend validates that each key belongs to the patched job, has one of the supported file names, and exists in storage. The database stores the normalized object names without the job ID or `.zip` suffix, and the User API later expands them into `job_info` download URLs.
+
+## Status Transitions
+
+The current provider status transitions are:
+
+| From | To | Actor |
+| --- | --- | --- |
+| `registered` | `submitted` | User API `POST /jobs/{job_id}/submit` |
+| `submitted` | `ready` | Provider API `GET /jobs` |
+| `ready` | `running` | Provider API `PATCH /jobs/{job_id}/status` |
+| `ready` | `failed` | Provider API `PATCH /jobs/{job_id}/status` |
+| `running` | `succeeded` | Provider API `PATCH /jobs/{job_id}/status` |
+| `running` | `failed` | Provider API `PATCH /jobs/{job_id}/status` |
+| `running` | `cancelled` | Provider API `PATCH /jobs/{job_id}/status` |
+| `registered`, `submitted`, `ready`, `running` | `cancelled` | User API `POST /jobs/{job_id}/cancel` |
+
+The `ready -> failed` transition is supported so that provider-side preprocessing failures can be reported before execution starts.
+
+## Job Input and Output Schemas
+
+`input.zip` contains a payload matching `jobs.S3SubmitJobInfo`.
+
+| Field | Required for | Notes |
+| --- | --- | --- |
+| `program` | `sampling`, `estimation`, `multi_manual` | Array of OpenQASM 3 programs. Non-multiprogramming jobs normally contain one program. |
+| `operator` | `estimation` | Array of Pauli operator items. |
+| `sse_program` | `sse` | User program for SSE jobs. |
+
+Provider outputs are stored as separate zip files:
+
+| File | Schema |
+| --- | --- |
+| `result.zip` | `jobs.S3JobResult` |
+| `transpile_result.zip` | `jobs.S3TranspileResult` |
+| `combined_program.zip` | Combined program for `multi_manual` jobs |
+| `sse_log.zip` | SSE log for `sse` jobs |
+
+Example archive layouts:
+
+```text
+<job_id>/input.zip
+  input.json
+
+<job_id>/result.zip
+  result.json
+
+<job_id>/transpile_result.zip
+  transpile_result.json
+
+<job_id>/sse_log.zip
+  sse_log.log
+```
+
+## Implementation Notes
+
+- `jobs.job_info` is no longer a DB column. The `jobs` table stores metadata, `output_files`, and `message`.
+- User-facing `job_info` is a response object containing presigned download URLs and the provider message, not an inline serialized JSON payload.
+- Upload presigned URLs expire according to the storage strategy; the current default in `FSSpecStorage` is one hour.
+- S3 object cleanup is best-effort after the DB row is deleted. If storage cleanup fails, the API returns an internal server error.

--- a/docs/en/architecture/quantum_jobs_in_detail.md
+++ b/docs/en/architecture/quantum_jobs_in_detail.md
@@ -3,7 +3,7 @@
 OQTOPUS stores large quantum-job payloads in object storage and keeps only job metadata in the database.
 The User API, Provider API, and storage service are connected by presigned URLs, so clients upload and download job files directly without sending large payloads through the API server.
 
-This page describes the current implementation contract. It intentionally follows the running backend implementation and OpenAPI files under `backend/oas`.
+This page describes the current backend behavior and the storage conventions used by the surrounding clients. It intentionally follows the running backend implementation and OpenAPI files under `backend/oas`.
 
 ## Storage Model
 
@@ -17,11 +17,11 @@ Each job owns a storage prefix named by its job ID:
 <job_id>/sse_log.zip
 ```
 
-The supported object names are fixed by the backend, and each zip is expected to contain a single payload file:
+The supported `.zip` object names are fixed by the backend. Each zip conventionally contains a single payload file, but the backend validates the object key, not the filename inside the archive:
 
-| Object | Archive entry name | Producer | Consumer | Payload format | Notes |
+| Object | Conventional archive entry name | Producer | Consumer | Payload format | Notes |
 | --- | --- | --- | --- | --- | --- |
-| `input.zip` | `input.json` | User | Provider, User | JSON matching `jobs.S3SubmitJobInfo` | Required before submission can be completed. |
+| `input.zip` | `input.json` | User | Provider, User | JSON matching the User API `jobs.S3SubmitJobInfo` | Required before submission can be completed. |
 | `combined_program.zip` | `combined_program.json` | Provider | User | JSON payload for the combined program | Only accepted for `multi_manual` jobs. |
 | `transpile_result.zip` | `transpile_result.json` | Provider | User | JSON matching `jobs.S3TranspileResult` | Transpilation output. |
 | `result.zip` | `result.json` | Provider | User | JSON matching `jobs.S3JobResult` | Job result. |
@@ -29,14 +29,14 @@ The supported object names are fixed by the backend, and each zip is expected to
 
 The default storage driver is S3. Local development can use `local` or `local:minio`, but the API contract is the same: the API returns upload presigned URL data or download presigned URLs, and the client transfers files directly to the storage backend.
 
-For the current storage-backed format, the zip entry naming rule is effectively `<object-stem>.json`, except `sse_log.zip`, which uses `sse_log.log`.
+For the current storage-backed format, client-side archive entries conventionally use `<object-stem>.json`, except SSE logs, which conventionally use a `.log` entry.
 
 ## User API Flow
 
 1. Register a job with `POST /jobs`.
    The backend creates a DB row in `registered` status with a generated `job_id` and returns an upload presigned URL for `<job_id>/input.zip`.
 2. Upload `input.zip` to the returned presigned URL.
-   The uploaded zip contains the job input as `input.json`, described by `jobs.S3SubmitJobInfo`.
+   The uploaded zip conventionally contains the job input as `input.json`, described by the User API `jobs.S3SubmitJobInfo`.
 3. Complete submission with `POST /jobs/{job_id}/submit`.
    The request body contains DB metadata such as `device_id`, `job_type`, `shots`, and optional transpiler, simulator, mitigation, name, and description fields. The backend verifies that `<job_id>/input.zip` exists before moving the job to `submitted`.
 4. Read job details with `GET /jobs` or `GET /jobs/{job_id}`.
@@ -79,15 +79,16 @@ The `ready -> failed` transition is supported so that provider-side preprocessin
 
 ## Job Input and Output Schemas
 
-`input.zip` contains `input.json`, and that payload matches `jobs.S3SubmitJobInfo`.
+`input.zip` conventionally contains `input.json`, and that payload matches the User API `jobs.S3SubmitJobInfo`.
 
 | Field | Required for | Notes |
 | --- | --- | --- |
 | `program` | `sampling`, `estimation`, `multi_manual` | Array of OpenQASM 3 programs. Non-multiprogramming jobs normally contain one program. |
 | `operator` | `estimation` | Array of Pauli operator items. |
-| `sse_program` | `sse` | User program for SSE jobs. |
 
-For provider output zip files and the payload names/schema inside them, refer to the storage-model table above.
+The Provider API has a separate generated `jobs.S3SubmitJobInfo` schema that includes `sse_program` for SSE jobs. That field is not part of the User API input-upload schema described here.
+
+For provider output zip files and the conventional payload names/schema inside them, refer to the storage-model table above.
 
 Example archive layouts:
 

--- a/docs/en/architecture/sequence_diagram.md
+++ b/docs/en/architecture/sequence_diagram.md
@@ -1,191 +1,127 @@
 # Sequences of Job Operations
 
-This page shows behavioral sequences of task operations.
-Each sequence shows a series of steps from sending a request of job execution or cancellation to the completion of the operations.
+This page shows the current job-operation sequences.
+Large job inputs and outputs are transferred through object storage with presigned URLs, while the Cloud API stores and updates job metadata.
 
 ## Sequence of Job Execution (Success Case)
 
-The following shows a sequence of successful job execution.
-It shows the steps of job submission by User, job execution by Provider, and retrieval of the execution result by User.
-
 ```mermaid
 sequenceDiagram
     autonumber
-    participant User as User (alice)
-    participant Cloud as Cloud (Backend)
-    participant Provider as Provider (Device ID is 'SC')
+    participant User as User
+    participant Cloud as Cloud API
+    participant Storage as Object Storage
+    participant Provider as Provider
 
-    User->>Cloud: POST /jobs { "job_info": "{ \"code\": \"OPENQASM ...\", ... }", ... }
-    Note right of User: User submits a job
-    Note over Cloud: A new job is created.
-    Cloud-->>User: HTTP 200 OK { "job_id": <job ID-1> }
+    User->>Cloud: POST /jobs
+    Note over Cloud: Create job row in registered status
+    Cloud-->>User: 200 { job_id, presigned_url for input.zip }
 
-    User->>Cloud: GET /jobs/<job ID-1>/status
-    Cloud-->>User: HTTP 200 OK { "job_id": <job ID-1>, "status": "submitted" }
+    User->>Storage: Upload <job_id>/input.zip with presigned URL
+    Storage-->>User: Upload accepted
 
-    Note over Provider: Provider starts getting jobs.
-    Provider->>Cloud: GET /jobs
-    Note over Cloud: The job status is updated to `ready`.
-    Cloud-->>Provider: HTTP 200 OK
+    User->>Cloud: POST /jobs/<job_id>/submit { device_id, job_type, shots, ... }
+    Note over Cloud: Verify input.zip exists and set status to submitted
+    Cloud-->>User: 200 { message: "job submitted" }
 
-    Note over Provider: Provider starts execution of the jobs and sends <br/>  requests to update their statuses to `running`.
-    Provider->>Cloud: PATCH /jobs/<job ID-1> { "status": "running" }
-    Note over Cloud: The job status is updated to `running`.
-    Cloud-->>Provider: HTTP 200 OK
+    Provider->>Cloud: GET /jobs?device_id=<device_id>
+    Note over Cloud: submitted jobs returned to the provider are advanced to ready
+    Cloud-->>Provider: 200 [{ job_id, status: ready, input: download URL, ... }]
 
-    Provider->>Cloud: PATCH /jobs/<job ID-N> { "status": "running" }
-    Note over Cloud: The job status is updated to `running`.
-    Cloud-->>Provider: HTTP 200 OK
+    Provider->>Storage: Download <job_id>/input.zip
+    Storage-->>Provider: input.zip
 
-    User->>Cloud: GET /jobs/<job ID-1>/status
-    Cloud-->>User: HTTP 200 OK { "job_id": <job ID-1>, "status": "running" }
+    Provider->>Cloud: PATCH /jobs/<job_id>/status { status: "running" }
+    Note over Cloud: Set status to running
+    Cloud-->>Provider: 200
 
-    Note over Provider: The execution of the job <job ID-1> is successfully completed.
-    Provider->>Cloud: PATCH /jobs/<job ID-N>/job_info { "result": ... }
+    Provider->>Cloud: GET /jobs/<job_id>/upload?items=transpile_result,result
+    Cloud-->>Provider: 200 [upload URL data for output files]
 
-    Note over Cloud: The result of the job is stored in the `job_info` JSON field<br /> in the database, and the job status is updated to `success`.
-    Cloud-->>Provider: HTTP 200 OK
+    Provider->>Storage: Upload transpile_result.zip and result.zip
+    Storage-->>Provider: Upload accepted
 
-    User->>Cloud: GET /jobs/<job ID-1>
-    Cloud-->>User: HTTP 200 OK <br>{ "job_id": <job ID-1>, "status": "succeeded", "job_info": "{ \"result\": ... }", ... } 
+    Provider->>Cloud: PATCH /jobs/<job_id>/status { status: "succeeded", output_files: ["<job_id>/transpile_result.zip", "<job_id>/result.zip"], execution_time, message }
+    Note over Cloud: Validate uploaded keys, store output file names, and set status to succeeded
+    Cloud-->>Provider: 200
+
+    User->>Cloud: GET /jobs/<job_id>
+    Cloud-->>User: 200 { status: "succeeded", job_info: { input, transpile_result, result, message }, ... }
+
+    User->>Storage: Download result files with job_info URLs
+    Storage-->>User: Result files
 ```
 
-Provider periodically repeats the process of executing the jobs and writting the results.
-The above diagram shows one iteration of the repeated process.
-
-Each sequence shows a series of steps from sending a request of task execution or cancellation to the completion of the operations.
-
-> [!NOTE]
-> The `job_info` field in the job is a JSON serialized string.
-
-### Data in the DB at Each Time Point
-
-The followings show sample data in the database at each point in the sequence diagram,
-where there is one job submission to each of the two endpoints, `/tasks/sampling` and `/tasks/estimation`.
-The numbers below correspond to the circled numbers in the sequence diagram.
-
-- (2)
-  - tasks table: [success-case-tasks-02.csv](../../sample/architecture/success-case-tasks-02.csv)
-  - results table: no data
-- (6)
-  - tasks table: [success-case-tasks-06.csv](../../sample/architecture/success-case-tasks-06.csv)
-  - results table: no data
-- (10)
-  - tasks table: [success-case-tasks-10.csv](../../sample/architecture/success-case-tasks-10.csv)
-  - results table: no data
-- (14)
-  - tasks table: [success-case-tasks-14.csv](../../sample/architecture/success-case-tasks-14.csv)
-  - results table: [success-case-results-14.csv](../../sample/architecture/success-case-results-14.csv)
+Provider polling advances jobs from `submitted` to `ready`. A provider then explicitly changes `ready` to `running`, uploads output files to storage, and reports the uploaded keys when setting a terminal status.
 
 ## Sequence of Job Execution (Failure Case)
 
-The following shows a sequence in which a job execution fails.
-Each step from the beginning until the job status is changed to `running` is the same as in the success case.
-The colored part shows steps specific to the failure case.
+The flow is the same as the success case until the provider reports failure.
+The Provider API accepts failure from either `ready` or `running`, which allows preprocessing failures to be reported before execution starts.
 
 ```mermaid
 sequenceDiagram
     autonumber
-    participant User as User (alice)
-    participant Cloud as Cloud (Backend)
-    participant Provider as Provider (Device ID is 'SVSim')
+    participant User as User
+    participant Cloud as Cloud API
+    participant Storage as Object Storage
+    participant Provider as Provider
 
-    User->>Cloud: POST /jobs { "job_info": "{ \"code\": \"OPENQASM ...\", ... }", ... }
+    User->>Cloud: POST /jobs
+    Cloud-->>User: 200 { job_id, presigned_url for input.zip }
+    User->>Storage: Upload <job_id>/input.zip
+    User->>Cloud: POST /jobs/<job_id>/submit { device_id, job_type, shots, ... }
+    Cloud-->>User: 200
 
-    Note right of User: User submits a job
-    Note over Cloud: A new job is created.
-    Cloud-->>User: HTTP 200 OK { "job_id": <job ID-1> }
+    Provider->>Cloud: GET /jobs?device_id=<device_id>
+    Note over Cloud: Set status to ready
+    Cloud-->>Provider: 200 [{ job_id, status: ready, input: download URL, ... }]
 
-    User->>Cloud: GET /jobs/<job ID-1>/status
-    Cloud-->>User: HTTP 200 OK { "job_id": <job ID-1>, "status": "submitted" }
-
-    Note over Provider: Provider starts getting jobs.
-    Provider->>Cloud: GET /jobs
-    Note over Cloud: Suppose that the job status is set to `ready`.
-    Cloud-->>Provider: HTTP 200 OK
-
-    Note over Provider: Provider starts execution of the jobs and sends <br/>  requests to update their statuses to `running`.
-    Provider->>Cloud: PATCH /jobs/<job ID-1> { "status": "running" }
-    Note over Cloud: The job status is updated to `running`.
-    Cloud-->>Provider: HTTP 200 OK
-
-    Provider->>Cloud: PATCH /jobs/<job ID-N> { "status": "running" }
-    Note over Cloud: The job status is updated to `running`.
-    Cloud-->>Provider: HTTP 200 OK
-
-    User->>Cloud: GET /jobs/<job ID-1>/status
-    Cloud-->>User: HTTP 200 OK { "job_id": <job ID-1>, "status": "running" }
-
-    rect rgb(255, 240, 240)
-        Note over Provider: The execution of the task <job ID-1> is failed.
-        Provider->>Cloud: PATCH /jobs/{job ID-1}/job_info { "reason": "The reason of failure", ... }
-        Note over Cloud: The error description is stored in the `job_info` JSON <br />field in database, and the job status is set to `failed`.
-        Cloud-->>Provider: HTTP 200 OK
-  
-        User->>Cloud: GET /jobs/<job ID-1>
-        Cloud-->>User: HTTP 200 OK <br />{ "job_id": <job ID-1>, "status": "failed", "job_info": "{ \"reason\": \"The reason of failure\", ... }" }
+    alt failure before execution starts
+        Provider->>Cloud: PATCH /jobs/<job_id>/status { status: "failed", message }
+        Note over Cloud: Set status to failed
+        Cloud-->>Provider: 200
+    else failure after execution starts
+        Provider->>Cloud: PATCH /jobs/<job_id>/status { status: "running" }
+        Cloud-->>Provider: 200
+        Provider->>Cloud: GET /jobs/<job_id>/upload?items=result
+        Cloud-->>Provider: 200 [upload URL data]
+        Provider->>Storage: Upload result.zip
+        Provider->>Cloud: PATCH /jobs/<job_id>/status { status: "failed", output_files: ["<job_id>/result.zip"], message }
+        Note over Cloud: Validate uploaded keys and set status to failed
+        Cloud-->>Provider: 200
     end
+
+    User->>Cloud: GET /jobs/<job_id>
+    Cloud-->>User: 200 { status: "failed", job_info: { input, result, message }, ... }
 ```
 
-### Data in the DB at Each Time Point
-
-The followings show sample data in the DB at each point in the sequence diagram,
-where there is one task submission to the endpoint `/tasks/estimation`.
-The numbers below correspond to the circled numbers in the sequence diagram.
-
-- (2), (6), (10)
-  - Omitted, as they are the same as in the successful case.
-- (14)
-  - tasks table: [failure-case-tasks-14.csv](../../sample/architecture/failure-case-tasks-14.csv)
-  - results table: [failure-case-tasks-14.csv](../../sample/architecture/failure-case-results-14.csv)
+Failure details are returned through `job_info.message`. If the provider uploads diagnostic output files and includes them in `output_files`, the User API exposes download presigned URLs for those files.
 
 ## Sequence of Job Cancellation
 
-The following shows a sequence of job cancellation,
-where User tries to cancel a job.
-
 ```mermaid
 sequenceDiagram
     autonumber
-    participant User as User (alice)
-    participant Cloud as Cloud (Backend)
-    participant Provider as Provider (Device ID is 'SVSim')
+    participant User as User
+    participant Cloud as Cloud API
+    participant Storage as Object Storage
 
-    User->>Cloud: POST /jobs/<Job ID-1>/cancel
-    Note right of User: User sends a cancel requests for the job <job ID-1>.
-    Note over Cloud: The job status is updated to `cancelled`
-    Cloud-->>User: HTTP 200 OK
+    User->>Cloud: POST /jobs/<job_id>/cancel
+    Note over Cloud: registered, submitted, ready, or running jobs are marked cancelled
+    Cloud-->>User: 200 { message: "cancel request accepted" }
 
-    User->>Cloud: GET /jobs/<job ID-1>/status
-    Cloud-->>User: HTTP 200 OK { "job_id": <job ID-1>, "status": "cancelled" }
+    User->>Cloud: GET /jobs/<job_id>/status
+    Cloud-->>User: 200 { job_id, status: "cancelled" }
 
-    Note over Provider: Provider tries to cancel the executions of the tasks.
-    Note over Provider: The execution of the job  <Job ID-1> is successfully cancelled.
-    Provider->>Cloud: PATCH /jobs/<JOB ID-1>/job_info { "job_id": <Job ID-1>, "reason": ... }
+    User->>Cloud: GET /jobs/<job_id>
+    Cloud-->>User: 200 { status: "cancelled", job_info: { input, message, ... }, ... }
 
-    Note over Cloud: The received result is stored in the `job_info` JSON field of the job.
-    Cloud-->>Provider: HTTP 200 OK
-
-    User->>Cloud: GET /jobs/<Job ID-1>/status
-    Cloud-->>User: HTTP 200 OK { "job_id": <Job ID-1>, "status": "cancelled", "job_info": "{ \"reason\": ... }", ... }
+    User->>Cloud: DELETE /jobs/<job_id>
+    Note over Cloud: Delete DB row and all storage objects under <job_id>/
+    Cloud->>Storage: Delete <job_id>/*
+    Cloud-->>User: 200 { message: "job deleted" }
 ```
 
-Provider periodically repeats the process of cancelling job executions and sending the cancellation results.
-The above diagram shows one iteration of the repeated process.
-
-### Data in the DB at Each Time Point
-
-The followings show sample data in the DB at each point in the sequence diagram,
-where there is one cancellation request to the endpoint `/jobs/{job ID}/cancel`.
-The numbers below correspond to the circled numbers in the sequence diagram.
-
-- (1)
-  - tasks table: [cancel-case-jobs-01.csv](../../sample/architecture/cancel-case-tasks-01.csv)
-  - results table: no data
-- (2)
-  - tasks table: [cancel-case-jobs-02.csv](../../sample/architecture/cancel-case-tasks-02.csv)
-  - results table: no data
-- (6)
-  - tasks table: [cancel-case-jobs-08.csv](../../sample/architecture/cancel-case-tasks-08.csv)
-  - results table: [cancel-case-results-08.csv](../../sample/architecture/cancel-case-results-08.csv)
-
+Users can request cancellation while the job is `registered`, `submitted`, `ready`, or `running`.
+Deletion is allowed only after a job reaches `succeeded`, `failed`, or `cancelled`.

--- a/docs/en/architecture/task_state_transition_diagram.md
+++ b/docs/en/architecture/task_state_transition_diagram.md
@@ -2,7 +2,8 @@
 
 ```mermaid
 stateDiagram-v2
-    [*] --> submitted :job submitted
+    [*] --> registered :job registered
+    registered --> submitted :job submitted
 
     submitted --> ready : job readying
     ready --> running : execution started
@@ -17,6 +18,7 @@ stateDiagram-v2
 
     succeeded --> [*] :deleted
     failed --> [*] :deleted
+    registered --> cancelled :cancel requested
     submitted --> cancelled :cancel requested (cancelled in the cloud PF)
     ready --> cancelled :cancel requested
     cancelled --> [*] :deleted

--- a/docs/ja/architecture/quantum_jobs_in_detail.md
+++ b/docs/ja/architecture/quantum_jobs_in_detail.md
@@ -17,28 +17,18 @@ User API、Provider API、ストレージは presigned URL で接続され、ク
 <job_id>/sse_log.zip
 ```
 
-バックエンドが扱うオブジェクト名は固定です。
+バックエンドが扱うオブジェクト名は固定で、各 zip には単一の payload ファイルを入れます。
 
-| Object | 作成者 | 利用者 | 備考 |
-| --- | --- | --- | --- |
-| `input.zip` | User | Provider, User | submission 完了前に必須です。ファイル内容は `jobs.S3SubmitJobInfo` に従います。 |
-| `combined_program.zip` | Provider | User | `multi_manual` ジョブでのみ受け付けます。 |
-| `transpile_result.zip` | Provider | User | transpile 結果です。 |
-| `result.zip` | Provider | User | ジョブ結果です。ファイル内容は `jobs.S3JobResult` に従います。 |
-| `sse_log.zip` | Provider | User | `sse` ジョブでのみ受け付けます。 |
+| Object | zip 内エントリ名 | 作成者 | 利用者 | payload format | 備考 |
+| --- | --- | --- | --- | --- | --- |
+| `input.zip` | `input.json` | User | Provider, User | `jobs.S3SubmitJobInfo` に一致する JSON | submission 完了前に必須です。 |
+| `combined_program.zip` | `combined_program.json` | Provider | User | combined program 用 JSON payload | `multi_manual` ジョブでのみ受け付けます。 |
+| `transpile_result.zip` | `transpile_result.json` | Provider | User | `jobs.S3TranspileResult` に一致する JSON | transpile 結果です。 |
+| `result.zip` | `result.json` | Provider | User | `jobs.S3JobResult` に一致する JSON | ジョブ結果です。 |
+| `sse_log.zip` | `sse_log.log` | Provider | User | SSE ログ文字列を入れた JSON string payload | `sse` ジョブでのみ受け付けます。 |
 
 デフォルトのストレージドライバーは S3 です。
 ローカル開発では `local` や `local:minio` も使えますが、API 契約は同じです。API は upload presigned URL data または download presigned URL を返し、クライアントはストレージバックエンドへ直接ファイルを転送します。
-
-各 zip ファイルには、単一の payload ファイルを入れる想定です。現在の実装上の取り決めは次の通りです。
-
-| Object | zip 内エントリ名 | payload format |
-| --- | --- | --- |
-| `input.zip` | `input.json` | `jobs.S3SubmitJobInfo` に一致する JSON |
-| `combined_program.zip` | `combined_program.json` | combined program 用 JSON payload |
-| `transpile_result.zip` | `transpile_result.json` | `jobs.S3TranspileResult` に一致する JSON |
-| `result.zip` | `result.json` | `jobs.S3JobResult` に一致する JSON |
-| `sse_log.zip` | `sse_log.log` | SSE ログ文字列を入れた JSON string payload |
 
 現在の storage-backed 形式では、zip 内エントリ名の規則は基本的に `<object-stem>.json` で、`sse_log.zip` だけ `sse_log.log` を使います。
 
@@ -47,7 +37,7 @@ User API、Provider API、ストレージは presigned URL で接続され、ク
 1. `POST /jobs` でジョブを登録します。
    バックエンドは `registered` 状態の DB 行を作成し、生成した `job_id` と `<job_id>/input.zip` 用の upload presigned URL を返します。
 2. 返された presigned URL に `input.zip` をアップロードします。
-   アップロードするファイルには、`jobs.S3SubmitJobInfo` で表現されるジョブ入力を入れます。
+   アップロードする zip には、`jobs.S3SubmitJobInfo` で表現されるジョブ入力を `input.json` として入れます。
 3. `POST /jobs/{job_id}/submit` で submission を完了します。
    request body には `device_id`, `job_type`, `shots` と、任意の transpiler, simulator, mitigation, name, description を含めます。バックエンドは `<job_id>/input.zip` が存在することを確認してから status を `submitted` に変更します。
 4. `GET /jobs` または `GET /jobs/{job_id}` でジョブ詳細を取得します。
@@ -92,7 +82,7 @@ DB にはジョブ ID と `.zip` suffix を除いた正規化済みオブジェ�
 
 ## ジョブ入出力スキーマ
 
-`input.zip` には `jobs.S3SubmitJobInfo` に従う payload を入れます。
+`input.zip` の中には、`jobs.S3SubmitJobInfo` に従う `input.json` を入れます。
 
 | Field | Required for | 備考 |
 | --- | --- | --- |
@@ -100,14 +90,7 @@ DB にはジョブ ID と `.zip` suffix を除いた正規化済みオブジェ�
 | `operator` | `estimation` | Pauli operator item の配列です。 |
 | `sse_program` | `sse` | SSE job 用の user program です。 |
 
-Provider の出力は別々の zip ファイルとして保存します。
-
-| File | Schema |
-| --- | --- |
-| `result.zip` | `jobs.S3JobResult` |
-| `transpile_result.zip` | `jobs.S3TranspileResult` |
-| `combined_program.zip` | `multi_manual` ジョブ用の combined program |
-| `sse_log.zip` | `sse` ジョブ用の SSE log |
+Provider の出力 zip とその中の payload 名、schema/format の対応は上のストレージモデル表を参照してください。
 
 アーカイブ構成の例:
 

--- a/docs/ja/architecture/quantum_jobs_in_detail.md
+++ b/docs/ja/architecture/quantum_jobs_in_detail.md
@@ -3,7 +3,7 @@
 OQTOPUS は、大きな量子ジョブのペイロードをオブジェクトストレージに保存し、データベースにはジョブのメタデータだけを保存します。
 User API、Provider API、ストレージは presigned URL で接続され、クライアントは大きなファイルを API サーバー経由ではなくストレージへ直接アップロードまたはダウンロードします。
 
-このページでは、現在動作しているバックエンド実装と `backend/oas` 配下の OpenAPI を正として仕様を説明します。
+このページでは、現在動作しているバックエンドの挙動と、周辺クライアントで使われているストレージ上の慣例を説明します。内容は `backend/oas` 配下の OpenAPI と実装に沿っています。
 
 ## ストレージモデル
 
@@ -17,11 +17,11 @@ User API、Provider API、ストレージは presigned URL で接続され、ク
 <job_id>/sse_log.zip
 ```
 
-バックエンドが扱うオブジェクト名は固定で、各 zip には単一の payload ファイルを入れます。
+バックエンドが扱う `.zip` オブジェクト名は固定です。各 zip には慣例として単一の payload ファイルを入れますが、バックエンドが検証するのはオブジェクトキーであり、archive 内のファイル名ではありません。
 
-| Object | zip 内エントリ名 | 作成者 | 利用者 | payload format | 備考 |
+| Object | 慣例上の zip 内エントリ名 | 作成者 | 利用者 | payload format | 備考 |
 | --- | --- | --- | --- | --- | --- |
-| `input.zip` | `input.json` | User | Provider, User | `jobs.S3SubmitJobInfo` に一致する JSON | submission 完了前に必須です。 |
+| `input.zip` | `input.json` | User | Provider, User | User API の `jobs.S3SubmitJobInfo` に一致する JSON | submission 完了前に必須です。 |
 | `combined_program.zip` | `combined_program.json` | Provider | User | combined program 用 JSON payload | `multi_manual` ジョブでのみ受け付けます。 |
 | `transpile_result.zip` | `transpile_result.json` | Provider | User | `jobs.S3TranspileResult` に一致する JSON | transpile 結果です。 |
 | `result.zip` | `result.json` | Provider | User | `jobs.S3JobResult` に一致する JSON | ジョブ結果です。 |
@@ -30,14 +30,14 @@ User API、Provider API、ストレージは presigned URL で接続され、ク
 デフォルトのストレージドライバーは S3 です。
 ローカル開発では `local` や `local:minio` も使えますが、API 契約は同じです。API は upload presigned URL data または download presigned URL を返し、クライアントはストレージバックエンドへ直接ファイルを転送します。
 
-現在の storage-backed 形式では、zip 内エントリ名の規則は基本的に `<object-stem>.json` で、`sse_log.zip` だけ `sse_log.log` を使います。
+現在の storage-backed 形式では、クライアント側の archive entry は慣例として `<object-stem>.json` を使い、SSE ログでは慣例として `.log` entry を使います。
 
 ## User API の流れ
 
 1. `POST /jobs` でジョブを登録します。
    バックエンドは `registered` 状態の DB 行を作成し、生成した `job_id` と `<job_id>/input.zip` 用の upload presigned URL を返します。
 2. 返された presigned URL に `input.zip` をアップロードします。
-   アップロードする zip には、`jobs.S3SubmitJobInfo` で表現されるジョブ入力を `input.json` として入れます。
+   アップロードする zip には、User API の `jobs.S3SubmitJobInfo` で表現されるジョブ入力を、慣例として `input.json` に入れます。
 3. `POST /jobs/{job_id}/submit` で submission を完了します。
    request body には `device_id`, `job_type`, `shots` と、任意の transpiler, simulator, mitigation, name, description を含めます。バックエンドは `<job_id>/input.zip` が存在することを確認してから status を `submitted` に変更します。
 4. `GET /jobs` または `GET /jobs/{job_id}` でジョブ詳細を取得します。
@@ -82,15 +82,16 @@ DB にはジョブ ID と `.zip` suffix を除いた正規化済みオブジェ�
 
 ## ジョブ入出力スキーマ
 
-`input.zip` の中には、`jobs.S3SubmitJobInfo` に従う `input.json` を入れます。
+`input.zip` の中には、User API の `jobs.S3SubmitJobInfo` に従う payload を、慣例として `input.json` に入れます。
 
 | Field | Required for | 備考 |
 | --- | --- | --- |
 | `program` | `sampling`, `estimation`, `multi_manual` | OpenQASM 3 program の配列です。非 multiprogramming job では通常 1 つの program を含みます。 |
 | `operator` | `estimation` | Pauli operator item の配列です。 |
-| `sse_program` | `sse` | SSE job 用の user program です。 |
 
-Provider の出力 zip とその中の payload 名、schema/format の対応は上のストレージモデル表を参照してください。
+Provider API には、SSE job 用の `sse_program` を含む別の generated `jobs.S3SubmitJobInfo` schema があります。このフィールドは、ここで説明している User API の input upload schema には含まれません。
+
+Provider の出力 zip とその中の慣例上の payload 名、schema/format の対応は上のストレージモデル表を参照してください。
 
 アーカイブ構成の例:
 

--- a/docs/ja/architecture/quantum_jobs_in_detail.md
+++ b/docs/ja/architecture/quantum_jobs_in_detail.md
@@ -1,0 +1,133 @@
+# 量子ジョブの詳細
+
+OQTOPUS は、大きな量子ジョブのペイロードをオブジェクトストレージに保存し、データベースにはジョブのメタデータだけを保存します。
+User API、Provider API、ストレージは presigned URL で接続され、クライアントは大きなファイルを API サーバー経由ではなくストレージへ直接アップロードまたはダウンロードします。
+
+このページでは、現在動作しているバックエンド実装と `backend/oas` 配下の OpenAPI を正として仕様を説明します。
+
+## ストレージモデル
+
+各ジョブは、ジョブ ID を名前にしたストレージ prefix を持ちます。
+
+```text
+<job_id>/input.zip
+<job_id>/combined_program.zip
+<job_id>/transpile_result.zip
+<job_id>/result.zip
+<job_id>/sse_log.zip
+```
+
+バックエンドが扱うオブジェクト名は固定です。
+
+| Object | 作成者 | 利用者 | 備考 |
+| --- | --- | --- | --- |
+| `input.zip` | User | Provider, User | submission 完了前に必須です。ファイル内容は `jobs.S3SubmitJobInfo` に従います。 |
+| `combined_program.zip` | Provider | User | `multi_manual` ジョブでのみ受け付けます。 |
+| `transpile_result.zip` | Provider | User | transpile 結果です。 |
+| `result.zip` | Provider | User | ジョブ結果です。ファイル内容は `jobs.S3JobResult` に従います。 |
+| `sse_log.zip` | Provider | User | `sse` ジョブでのみ受け付けます。 |
+
+デフォルトのストレージドライバーは S3 です。
+ローカル開発では `local` や `local:minio` も使えますが、API 契約は同じです。API は upload presigned URL data または download presigned URL を返し、クライアントはストレージバックエンドへ直接ファイルを転送します。
+
+各 zip ファイルには、単一の payload ファイルを入れる想定です。現在の実装上の取り決めは次の通りです。
+
+| Object | zip 内エントリ名 | payload format |
+| --- | --- | --- |
+| `input.zip` | `input.json` | `jobs.S3SubmitJobInfo` に一致する JSON |
+| `combined_program.zip` | `combined_program.json` | combined program 用 JSON payload |
+| `transpile_result.zip` | `transpile_result.json` | `jobs.S3TranspileResult` に一致する JSON |
+| `result.zip` | `result.json` | `jobs.S3JobResult` に一致する JSON |
+| `sse_log.zip` | `sse_log.log` | SSE ログ文字列を入れた JSON string payload |
+
+現在の storage-backed 形式では、zip 内エントリ名の規則は基本的に `<object-stem>.json` で、`sse_log.zip` だけ `sse_log.log` を使います。
+
+## User API の流れ
+
+1. `POST /jobs` でジョブを登録します。
+   バックエンドは `registered` 状態の DB 行を作成し、生成した `job_id` と `<job_id>/input.zip` 用の upload presigned URL を返します。
+2. 返された presigned URL に `input.zip` をアップロードします。
+   アップロードするファイルには、`jobs.S3SubmitJobInfo` で表現されるジョブ入力を入れます。
+3. `POST /jobs/{job_id}/submit` で submission を完了します。
+   request body には `device_id`, `job_type`, `shots` と、任意の transpiler, simulator, mitigation, name, description を含めます。バックエンドは `<job_id>/input.zip` が存在することを確認してから status を `submitted` に変更します。
+4. `GET /jobs` または `GET /jobs/{job_id}` でジョブ詳細を取得します。
+   submitted 以降のジョブでは、`job_info.input` が download presigned URL になります。Provider が `PATCH /jobs/{job_id}/status` で出力ファイルを報告すると、User API の `job_info` に出力ファイル用 URL が現れます。
+5. `DELETE /jobs/{job_id}` で終端状態のジョブを削除します。
+   削除できるのは `succeeded`, `failed`, `cancelled` のジョブだけです。バックエンドは DB 行と `<job_id>/` 配下のオブジェクトを削除します。
+
+`registered` ジョブは owner から参照できますが、submission が完了するまで DB 行には未確定フィールドの placeholder が入っています。そのため通常の User API response では `job_id` と `status` だけを返し、明示的に field 指定された未定義項目は `null` になります。
+
+## Provider API の流れ
+
+1. `GET /jobs?device_id=<device_id>` でジョブを poll します。
+   `registered` ジョブは返されません。Provider が `submitted` ジョブを取得すると、バックエンドは status を `ready` に進め、`<job_id>/input.zip` の download presigned URL である `input` を返します。
+2. 必要に応じて `GET /jobs/{job_id}/upload?items=...` で出力用 upload URL を取得します。
+   `items` は `combined_program`, `transpile_result`, `result`, `sse_log` の comma-separated list です。バックエンドは、`multi_manual` 以外の `combined_program` と、`sse` 以外の `sse_log` を拒否します。
+3. `{ "status": "running" }` を指定して `PATCH /jobs/{job_id}/status` を呼び、実行開始を反映します。
+   この遷移は `ready` からのみ許可されます。
+4. presigned URL data を使って出力ファイルをストレージへ直接アップロードします。
+5. `PATCH /jobs/{job_id}/status` でジョブを完了します。
+   終端状態は `succeeded`, `failed`, `cancelled` です。request body には `execution_time`, `message`, `output_files` を含められます。
+
+`output_files` には `<job_id>/result.zip` のような完全なストレージキーを指定します。
+バックエンドは、各キーが対象ジョブに属すること、サポート対象のファイル名であること、ストレージ上に存在することを検証します。
+DB にはジョブ ID と `.zip` suffix を除いた正規化済みオブジェクト名を保存し、User API は後でそれらを `job_info` の download URL に展開します。
+
+## 状態遷移
+
+現在の Provider を含む状態遷移は次の通りです。
+
+| From | To | Actor |
+| --- | --- | --- |
+| `registered` | `submitted` | User API `POST /jobs/{job_id}/submit` |
+| `submitted` | `ready` | Provider API `GET /jobs` |
+| `ready` | `running` | Provider API `PATCH /jobs/{job_id}/status` |
+| `ready` | `failed` | Provider API `PATCH /jobs/{job_id}/status` |
+| `running` | `succeeded` | Provider API `PATCH /jobs/{job_id}/status` |
+| `running` | `failed` | Provider API `PATCH /jobs/{job_id}/status` |
+| `running` | `cancelled` | Provider API `PATCH /jobs/{job_id}/status` |
+| `registered`, `submitted`, `ready`, `running` | `cancelled` | User API `POST /jobs/{job_id}/cancel` |
+
+`ready -> failed` は、Provider 側の前処理で失敗したジョブを `running` にする前に報告できるようサポートされています。
+
+## ジョブ入出力スキーマ
+
+`input.zip` には `jobs.S3SubmitJobInfo` に従う payload を入れます。
+
+| Field | Required for | 備考 |
+| --- | --- | --- |
+| `program` | `sampling`, `estimation`, `multi_manual` | OpenQASM 3 program の配列です。非 multiprogramming job では通常 1 つの program を含みます。 |
+| `operator` | `estimation` | Pauli operator item の配列です。 |
+| `sse_program` | `sse` | SSE job 用の user program です。 |
+
+Provider の出力は別々の zip ファイルとして保存します。
+
+| File | Schema |
+| --- | --- |
+| `result.zip` | `jobs.S3JobResult` |
+| `transpile_result.zip` | `jobs.S3TranspileResult` |
+| `combined_program.zip` | `multi_manual` ジョブ用の combined program |
+| `sse_log.zip` | `sse` ジョブ用の SSE log |
+
+アーカイブ構成の例:
+
+```text
+<job_id>/input.zip
+  input.json
+
+<job_id>/result.zip
+  result.json
+
+<job_id>/transpile_result.zip
+  transpile_result.json
+
+<job_id>/sse_log.zip
+  sse_log.log
+```
+
+## 実装メモ
+
+- `jobs.job_info` は DB column ではありません。`jobs` table は metadata, `output_files`, `message` を保存します。
+- User API の `job_info` は inline JSON 文字列ではなく、download presigned URL と Provider message を含む response object です。
+- upload presigned URL の有効期限は storage strategy に従います。現在の `FSSpecStorage` の default は 1 時間です。
+- DB 行の削除後、S3 オブジェクトの cleanup は best-effort で行われます。cleanup に失敗した場合、API は internal server error を返します。

--- a/docs/ja/architecture/sequence_diagram.md
+++ b/docs/ja/architecture/sequence_diagram.md
@@ -1,197 +1,129 @@
-# タスク操作時のシーケンス
+# ジョブ操作時のシーケンス
 
-タスク操作時のシーケンスを以下に示します。
-各シーケンスは、タスクの送信やキャンセルを行ってから操作が完了するまでの一連のステップを示しています。
+現在のジョブ操作シーケンスを示します。
+大きなジョブ入出力は presigned URL を使ってオブジェクトストレージへ直接アップロードまたはダウンロードし、Cloud API はジョブのメタデータと状態を管理します。
 
-> [!NOTE]
-> シーケンス図中に記載している `/tasks`, `/tasks/{taskId}/cancel`, `/results` エンドポイントは、実際には sampling タスク用と estimation タスク用の別々のエンドポイントに分かれています。
-> 例えば、`/tasks` であれば、`/tasks/sampling` と `/tasks/estimation` に分かれています。
-> sampling タスク用と estimation タスク用の両エンドポイントでのシーケンスは共通のため、シーケンス図上ではパス中の `/sampling`, `/estimation` の部分を省略して記載しています。
-
-## タスク実行のシーケンス (成功ケース)
-
-タスクの実行が成功した場合のシーケンスを以下に示します。
-User によるタスクの送信、Provider によるタスクの実行、User による結果の取得の一連の流れを示しています。
+## ジョブ実行のシーケンス (成功ケース)
 
 ```mermaid
 sequenceDiagram
     autonumber
-    participant User as User (alice)
-    participant Cloud as Cloud (Backend)
-    participant Provider as Provider (Device ID is 'SC')
+    participant User as User
+    participant Cloud as Cloud API
+    participant Storage as Object Storage
+    participant Provider as Provider
 
-    User->>Cloud: POST /tasks { "code": "OPENQASM ...", ... }
-    Note right of User: User submits a task
-    Note over Cloud: A new task is created.
-    Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1> }
+    User->>Cloud: POST /jobs
+    Note over Cloud: registered 状態のジョブ行を作成
+    Cloud-->>User: 200 { job_id, input.zip 用 presigned_url }
 
-    User->>Cloud: GET /tasks/<task ID-1>/status
-    Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "submitted" }
+    User->>Storage: presigned URL で <job_id>/input.zip をアップロード
+    Storage-->>User: アップロード成功
 
-    Note over Provider: Provider starts getting the tasks.
-    Provider->>Cloud: GET /jobs
-    Note over Cloud: The task status is updated to ready.
-    Cloud-->>Provider: HTTP 200 OK
+    User->>Cloud: POST /jobs/<job_id>/submit { device_id, job_type, shots, ... }
+    Note over Cloud: input.zip の存在を確認し status を submitted に更新
+    Cloud-->>User: 200 { message: "job submitted" }
 
-    Note over Provider: Provider starts execution of the tasks<br>and sends requests to update their statuses to running.
-    Provider->>Cloud: PATCH /tasks/<task ID-1> { "status": "running" }
-    Note over Cloud: The task status is updated to running.
-    Cloud-->>Provider: HTTP 200 OK
+    Provider->>Cloud: GET /jobs?device_id=<device_id>
+    Note over Cloud: Provider に返した submitted ジョブを ready に更新
+    Cloud-->>Provider: 200 [{ job_id, status: ready, input: download URL, ... }]
 
-    Provider->>Cloud: PATCH /tasks/<task ID-N> { "status": "running" }
-    Note over Cloud: The task status is updated to running.
-    Cloud-->>Provider: HTTP 200 OK
+    Provider->>Storage: <job_id>/input.zip をダウンロード
+    Storage-->>Provider: input.zip
 
-    User->>Cloud: GET /tasks/<task ID-1>/status
-    Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "running" }
-    Note over Provider: The execution of the task <task ID-1> is successfully completed.
-    Provider->>Cloud: POST /results { "taskId": <task ID-1>, "status": "succeeded", result: ... }
+    Provider->>Cloud: PATCH /jobs/<job_id>/status { status: "running" }
+    Note over Cloud: status を running に更新
+    Cloud-->>Provider: 200
 
-    Note over Cloud: The received result of the task is inserted to the DB,<br> then the task status is changed to succeeded (via a DB trigger).
-    Cloud-->>Provider: HTTP 200 OK
+    Provider->>Cloud: GET /jobs/<job_id>/upload?items=transpile_result,result
+    Cloud-->>Provider: 200 [出力ファイル用 upload URL data]
 
-    User->>Cloud: GET /tasks/<task ID-1>/status
-    Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "succeeded" }
+    Provider->>Storage: transpile_result.zip と result.zip をアップロード
+    Storage-->>Provider: アップロード成功
 
-    User->>Cloud: GET /results/<task ID-1>
-    Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "succeeded", "result": ... }
+    Provider->>Cloud: PATCH /jobs/<job_id>/status { status: "succeeded", output_files: ["<job_id>/transpile_result.zip", "<job_id>/result.zip"], execution_time, message }
+    Note over Cloud: アップロード済みキーを検証し、出力ファイル名を保存して status を succeeded に更新
+    Cloud-->>Provider: 200
+
+    User->>Cloud: GET /jobs/<job_id>
+    Cloud-->>User: 200 { status: "succeeded", job_info: { input, transpile_result, result, message }, ... }
+
+    User->>Storage: job_info の URL で結果ファイルをダウンロード
+    Storage-->>User: 結果ファイル
 ```
 
-Provider は定期的に、タスクの実行・実行結果の送信、の流れを繰り返します。
-上図では 1 回分の流れを記載しています。
+Provider が `GET /jobs` でジョブを取得すると、`submitted` のジョブは `ready` に進みます。
+その後 Provider は明示的に `ready` から `running` へ更新し、出力ファイルをストレージへアップロードしてから、終端状態へ更新するときにアップロード済みキーを申告します。
 
-### 各時点における DB 内のデータ
+## ジョブ実行のシーケンス (失敗ケース)
 
-シーケンス図の各時点における、DB 内のデータのサンプルを以下に示します。  
-`/tasks/sampling` と `/tasks/estimation` の 2 つのエンドポイントそれぞれに対して 1 回ずつタスクを送信した場合の例となっています。  
-以下の数字は、シーケンス図中の丸数字と対応しています。
-
-- (2)
-  - tasks テーブル: [success-case-tasks-02.csv](../../sample/architecture/success-case-tasks-02.csv)
-  - results テーブル: データ無し
-- (6)
-  - tasks テーブル: [success-case-tasks-06.csv](../../sample/architecture/success-case-tasks-06.csv)
-  - results テーブル: データ無し
-- (10)
-  - tasks テーブル: [success-case-tasks-10.csv](../../sample/architecture/success-case-tasks-10.csv)
-  - results テーブル: データ無し
-- (14)
-  - tasks テーブル: [success-case-tasks-14.csv](../../sample/architecture/success-case-tasks-14.csv)
-  - results テーブル: [success-case-results-14.csv](../../sample/architecture/success-case-results-14.csv)
-
-## タスク実行のシーケンス (失敗ケース)
-
-タスクの実行に失敗した場合のシーケンスを以下に示します。
-タスクの status が running に変化するまでは成功ケースと同様の流れです。図中の着色部分が、失敗した場合に特有の処理を示しています。
+Provider が失敗を報告する直前までは成功ケースと同じ流れです。
+Provider API は `ready` と `running` のどちらからでも `failed` への更新を受け付けるため、実行開始前の前処理失敗も報告できます。
 
 ```mermaid
 sequenceDiagram
     autonumber
-    participant User as User (alice)
-    participant Cloud as Cloud (Backend)
-    participant Provider as Provider (Device ID is 'SVSim')
+    participant User as User
+    participant Cloud as Cloud API
+    participant Storage as Object Storage
+    participant Provider as Provider
 
-    User->>Cloud: POST /tasks { "code": "OPENQASM ...", ... }
-    Note right of User: User submits a task
-    Note over Cloud: A new task is created.
-    Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1> }
+    User->>Cloud: POST /jobs
+    Cloud-->>User: 200 { job_id, input.zip 用 presigned_url }
+    User->>Storage: <job_id>/input.zip をアップロード
+    User->>Cloud: POST /jobs/<job_id>/submit { device_id, job_type, shots, ... }
+    Cloud-->>User: 200
 
-    User->>Cloud: GET /tasks/<task ID-1>/status
-    Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "submitted" }
+    Provider->>Cloud: GET /jobs?device_id=<device_id>
+    Note over Cloud: status を ready に更新
+    Cloud-->>Provider: 200 [{ job_id, status: ready, input: download URL, ... }]
 
-    Note over Provider: Provider starts getting the tasks.
-    Provider->>Cloud: GET /jobs
-    Note over Cloud: The task status is updated to ready.
-    Cloud-->>Provider: HTTP 200 OK
-
-    Note over Provider: Provider starts execution of the tasks<br>and sends requests to update their statuses to running.
-    Provider->>Cloud: PATCH /tasks/<task ID-1> { "status": "running" }
-    Note over Cloud: The task status is updated to running.
-    Cloud-->>Provider: HTTP 200 OK
-
-    Provider->>Cloud: PATCH /tasks/<task ID-N> { "status": "running" }
-    Note over Cloud: The task status is updated to running.
-    Cloud-->>Provider: HTTP 200 OK
-
-    User->>Cloud: GET /tasks/<task ID-1>/status
-    Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "running" }
-
-    rect rgb(255, 240, 240)
-        Note over Provider: The execution of the task <task ID-1> is failed.
-        Provider->>Cloud: POST /results { "taskId": <task ID-1>, "status": "failed", "reason": ... }
-        Note over Cloud: The received result of the task is inserted to the DB,<br> then the task status is changed to failed (via a DB trigger).
-        Cloud-->>Provider: HTTP 200 OK
-  
-        User->>Cloud: GET /tasks/<task ID-1>/status
-        Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "failed" }
-  
-        User->>Cloud: GET /results/<task ID-1>
-        Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "failed", "reason": ...}
+    alt 実行開始前に失敗した場合
+        Provider->>Cloud: PATCH /jobs/<job_id>/status { status: "failed", message }
+        Note over Cloud: status を failed に更新
+        Cloud-->>Provider: 200
+    else 実行開始後に失敗した場合
+        Provider->>Cloud: PATCH /jobs/<job_id>/status { status: "running" }
+        Cloud-->>Provider: 200
+        Provider->>Cloud: GET /jobs/<job_id>/upload?items=result
+        Cloud-->>Provider: 200 [upload URL data]
+        Provider->>Storage: result.zip をアップロード
+        Provider->>Cloud: PATCH /jobs/<job_id>/status { status: "failed", output_files: ["<job_id>/result.zip"], message }
+        Note over Cloud: アップロード済みキーを検証し status を failed に更新
+        Cloud-->>Provider: 200
     end
+
+    User->>Cloud: GET /jobs/<job_id>
+    Cloud-->>User: 200 { status: "failed", job_info: { input, result, message }, ... }
 ```
 
-### 各時点における DB 内のデータ
+失敗理由などの説明は `job_info.message` として返されます。
+Provider が診断用の出力ファイルをアップロードし `output_files` に含めた場合、User API はそれらの download presigned URL も返します。
 
-シーケンス図の各時点における、DB 内のデータのサンプルを以下に示します。  
-`/tasks/estimation` エンドポイントに対してタスクを送信した場合の例となっています。  
-以下の数字は、シーケンス図中の丸数字と対応しています。
-
-- (2), (6), (10)
-  - 成功ケースの場合と同様であるため省略。
-- (14)
-  - tasks テーブル: [failure-case-tasks-14.csv](../../sample/architecture/failure-case-tasks-14.csv)
-  - results テーブル: [failure-case-tasks-14.csv](../../sample/architecture/failure-case-results-14.csv)
-
-## タスクキャンセルのシーケンス
-
-タスクをキャンセルした際のシーケンス図を以下に示します。
-`/tasks/{taskId}/cancel` エンドポイントにリクエストを送った場合のシーケンスを示しています。
+## ジョブキャンセルのシーケンス
 
 ```mermaid
 sequenceDiagram
     autonumber
-    participant User as User (alice)
-    participant Cloud as Cloud (Backend)
-    participant Provider as Provider (Device ID is 'SVSim')
+    participant User as User
+    participant Cloud as Cloud API
+    participant Storage as Object Storage
 
-    User->>Cloud: POST /tasks/<task ID-1>/cancel
-    Note right of User: User sends a cancel requests for the task <task ID-1>.
-    Note over Cloud: The task status is updated to cancelled
-    Cloud-->>User: HTTP 200 OK
+    User->>Cloud: POST /jobs/<job_id>/cancel
+    Note over Cloud: registered, submitted, ready, running のジョブを cancelled に更新
+    Cloud-->>User: 200 { message: "cancel request accepted" }
 
-    User->>Cloud: GET /tasks/<task ID-1>/status
-    Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "cancelled" }
+    User->>Cloud: GET /jobs/<job_id>/status
+    Cloud-->>User: 200 { job_id, status: "cancelled" }
 
-    Note over Provider: Provider tries to cancel the executions of the tasks.
-    Note over Provider: The execution of the task <task ID-1> is successfully cancelled.
-    Provider->>Cloud: POST /results { "taskId": <task ID-1>, "status": "cancelled", "reason": ... }
+    User->>Cloud: GET /jobs/<job_id>
+    Cloud-->>User: 200 { status: "cancelled", job_info: { input, message, ... }, ... }
 
-    Note over Cloud: The received result of the task is inserted to the DB.
-    Cloud-->>Provider: HTTP 200 OK
-
-    User->>Cloud: GET /tasks/<task ID-1>/status
-    Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "cancelled" }
-
-    User->>Cloud: GET /results/<task ID-1>
-    Cloud-->>User: HTTP 200 OK { "taskId": <task ID-1>, "status": "cancelled", "reason": ... }
+    User->>Cloud: DELETE /jobs/<job_id>
+    Note over Cloud: DB 行と <job_id>/ 配下のストレージオブジェクトを削除
+    Cloud->>Storage: Delete <job_id>/*
+    Cloud-->>User: 200 { message: "job deleted" }
 ```
 
-Provider は定期的に、タスク実行のキャンセル・キャンセル結果の送信、の流れを繰り返します。
-上図では 1 回分の流れを記載しています。
-
-### 各時点における DB 内のデータ
-
-シーケンス図の各時点における、DB 内のデータのサンプルを以下に示します。  
-`/tasks/sampling/{taskId}/cancel` エンドポイントに対してリクエストした場合の例となっています。  
-以下の数字は、シーケンス図中の丸数字と対応しています。
-
-- (1)
-  - tasks テーブル: [cancel-case-tasks-01.csv](../../sample/architecture/cancel-case-tasks-01.csv)
-  - results テーブル: データ無し
-- (2)
-  - tasks テーブル: [cancel-case-tasks-02.csv](../../sample/architecture/cancel-case-tasks-02.csv)
-  - results テーブル: データ無し
-- (6)
-  - tasks テーブル: [cancel-case-tasks-08.csv](../../sample/architecture/cancel-case-tasks-08.csv)
-  - results テーブル: [cancel-case-results-08.csv](../../sample/architecture/cancel-case-results-08.csv)
-
+User は `registered`, `submitted`, `ready`, `running` のジョブに対してキャンセルを要求できます。
+削除できるのは `succeeded`, `failed`, `cancelled` の終端状態に到達したジョブだけです。

--- a/docs/ja/architecture/task_state_transition_diagram.md
+++ b/docs/ja/architecture/task_state_transition_diagram.md
@@ -2,7 +2,8 @@
 
 ```mermaid
 stateDiagram-v2
-    [*] --> submitted :job submitted
+    [*] --> registered :job registered
+    registered --> submitted :job submitted
 
     submitted --> ready : job readying
     ready --> running : execution started
@@ -17,8 +18,8 @@ stateDiagram-v2
     
     succeeded --> [*] :deleted
     failed --> [*] :deleted
+    registered --> cancelled :cancel requested
     submitted --> cancelled :cancel requested (cancelled in the cloud PF)
     ready --> cancelled :cancel requested
     cancelled --> [*] :deleted
 ```
-

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -90,6 +90,7 @@ plugins:
             Architecture: アーキテクチャ
             AWS System Architecture Diagram: AWSシステムアーキテクチャ図
             Task State Transition Diagram: タスクの状態遷移
+            Quantum Jobs in Detail: 量子ジョブの詳細
             Sequence Diagram: シーケンス図
 
             Developer Guidelines: 開発者ガイドライン


### PR DESCRIPTION
## Summary

- update quantum job architecture docs to match the current S3-based implementation
- replace legacy DB `job_info` / `/tasks` oriented descriptions with the current `/jobs` flow
- document job artifact names, zip entry names, and payload formats
- add the missing Japanese page for `Quantum Jobs in Detail`
- align state transition and sequence diagrams with the current implementation