### PR TITLE
ci(deploy): trigger Deploy all on dependency changes

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'backend/oqtopus_cloud/**'
       - 'backend/oas/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- `Deploy all` only auto-runs on push to `develop` when `backend/oqtopus_cloud/**` or `backend/oas/**` change. Dependency-only updates (`pyproject.toml` / `uv.lock`) that alter the bundled Lambda package were therefore not deployed automatically (e.g. #468 had to be deployed manually).
- Add `pyproject.toml` and `uv.lock` to the push `paths` filter so dependency changes trigger a redeploy.

## Notes
- `uv.lock` is the authoritative installed-dependency set; `pyproject.toml` is included so a dependency edit that forgets to relock still triggers.
- Workflow trigger only; affects future pushes (does not retroactively deploy already-merged changes).