### PR TITLE
fix(ci): deploy pending-jobs-updater-worker via Deploy all workflow

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deploy-target: [user, provider, admin, lambda_auth, user_signup]
+        deploy-target: [user, provider, admin, lambda_auth, user_signup, pending-jobs-updater-worker]
 
     permissions:
       id-token: write

--- a/deployment/oqtopus-dev/Makefile
+++ b/deployment/oqtopus-dev/Makefile
@@ -287,6 +287,11 @@ deploy-user_signup-via-actions: zip-user_signup	## Deploy user_signup API Lambda
 	BIN=./bin/user_signup \
 	ALIAS_NAME=$(SNAPSTART_ALIAS)
 
+deploy-pending-jobs-updater-worker-via-actions: zip-pending-jobs-updater-worker	## Deploy pending-jobs-updater-worker Lambda Package via Github Actions
+	@$(MAKE) deploy-via-actions \
+	FUNCTION_NAME=oqtopus-$(PROFILE)-pending-jobs-updater-worker \
+	BIN=./bin/pending-jobs-updater
+
 deploy-via-actions: generate-tag-via-actions ## Deploy Lambda Package via Github Actions
 	@echo "Deploy ${FUNCTION_NAME} ..."
 	@export AWS_PAGER="" && \


### PR DESCRIPTION
## Summary

The `Deploy all` workflow (`deployment.yaml`) builds and deploys only the five API Lambdas — `pending-jobs-updater-worker` was never in the `deploy-target` matrix, and there was no `deploy-pending-jobs-updater-worker-via-actions` Make target for it to call. So CI has never been able to deploy the worker.

As a consequence, the oqtopus-dev `pending-jobs-updater-worker` function was last updated on 2026-05-22 with an app-code-only package (~51 KB, no bundled dependencies), while qiqb-dev was redeployed on 2026-06-17 with the full dependency-bundled package (~35 MB). The oqtopus-dev worker fails on every invocation at import time (`No module named 'aws_lambda_powertools'`, previously a `botocore` checksum error) and surfaces as the Grafana "High Error Rate" alert.

This change lets `Deploy all` cover the worker so it gets the same dependency-bundled package as the API Lambdas.

## Changes

- Add `pending-jobs-updater-worker` to the `deploy-target` matrix in `deployment.yaml`.
- Add a `deploy-pending-jobs-updater-worker-via-actions` target in `deployment/oqtopus-dev/Makefile` that reuses `deploy-via-actions` (non-aliased `update-function-code`, matching the existing non-CI `deploy-pending-jobs-updater-worker`).

## Test plan

- Run the `Deploy all` workflow (`workflow_dispatch`) and confirm the `pending-jobs-updater-worker` matrix leg builds the ~35 MB package and runs `aws lambda update-function-code` successfully.
- Confirm the worker stops erroring (CloudWatch / Grafana error rate returns to 0).

## Notes

- The workflow's `push` trigger is scoped to `paths: backend/oqtopus_cloud/**` and `backend/oas/**`. Merging this PR (workflow + Makefile only) will **not** auto-trigger a deploy. The trigger scope is intentionally left unchanged so that routine Makefile/workflow edits don't fire a full six-target deploy.
- To fix the currently-broken oqtopus-dev worker, run `Deploy all` manually via `workflow_dispatch` after merge. From then on, any change under `backend/oqtopus_cloud/**` will redeploy the worker alongside the APIs.