### PR TITLE
fix(otel): isolate trace IDs across SnapStart restores and log response status

### DIFF
--- a/backend/oqtopus_cloud/admin/routers/__init__.py
+++ b/backend/oqtopus_cloud/admin/routers/__init__.py
@@ -2,7 +2,9 @@ from typing import Callable
 
 from aws_lambda_powertools.metrics import MetricUnit, single_metric
 from fastapi import Request, Response
+from fastapi.exceptions import RequestValidationError
 from fastapi.routing import APIRoute
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from oqtopus_cloud.admin.conf import logger
 
@@ -28,6 +30,28 @@ class LoggerRouteHandler(APIRoute):
                     name="route", value=f"{request.method} {self.path}"
                 )
 
-            return await original_route_handler(request)
+            def log_completion(status_code: int) -> None:
+                # FastAPI collapses the handler outcome into the HTTP response,
+                # so log the final status here; promote 5xx to error level so
+                # swallowed server errors are no longer invisible in the logs.
+                log = logger.error if status_code >= 500 else logger.info
+                log("Request completed", extra={"status_code": status_code})
+
+            try:
+                response = await original_route_handler(request)
+            except StarletteHTTPException as exc:
+                # FastAPI raises HTTP/validation errors out of the route handler
+                # for the app-level handlers to turn into responses; capture the
+                # eventual status before re-raising.
+                log_completion(exc.status_code)
+                raise
+            except RequestValidationError:
+                log_completion(422)
+                raise
+            except Exception:
+                log_completion(500)
+                raise
+            log_completion(response.status_code)
+            return response
 
         return route_handler

--- a/backend/oqtopus_cloud/common/tracing.py
+++ b/backend/oqtopus_cloud/common/tracing.py
@@ -1,4 +1,5 @@
 import os
+import random
 
 from fastapi import FastAPI
 from opentelemetry import trace
@@ -40,8 +41,35 @@ def setup_tracing(app: FastAPI, service_name: str) -> None:
         trace.set_tracer_provider(_provider)
         SQLAlchemyInstrumentor().instrument()
         LoggingInstrumentor().instrument(set_logging_format=True)
+        _register_snapstart_restore_hook()
 
     FastAPIInstrumentor.instrument_app(app)
+
+
+def _reseed_random_after_snapstart() -> None:
+    # SnapStart takes one memory snapshot at the end of Init and restores it
+    # into every execution environment. The ``random`` module's global state is
+    # frozen into that snapshot, so without re-seeding each restored environment
+    # generates the *same* sequence of values — including OTel trace/span IDs,
+    # because ``RandomIdGenerator`` draws them from ``random.getrandbits``.
+    # Identical sequences make unrelated invocations collide on a single trace
+    # ID (the symptom: distinct requests merged under one multi-hour trace).
+    #
+    # ``random.seed()`` (no argument) reseeds from OS entropy, giving each
+    # restored environment an independent stream. Seeding the module global is
+    # enough: every already-created ``RandomIdGenerator`` reads from it.
+    random.seed()
+
+
+def _register_snapstart_restore_hook() -> None:
+    # ``snapshot_restore_py`` ships with the AWS Lambda managed Python runtime.
+    # It is absent locally and in tests — where there is no snapshot to restore
+    # — so a missing import is a no-op.
+    try:
+        from snapshot_restore_py import register_after_restore
+    except ImportError:
+        return
+    register_after_restore(_reseed_random_after_snapstart)
 
 
 def force_flush(timeout_millis: int | None = None) -> None:

--- a/backend/oqtopus_cloud/common/tracing.py
+++ b/backend/oqtopus_cloud/common/tracing.py
@@ -66,7 +66,7 @@ def _register_snapstart_restore_hook() -> None:
     # It is absent locally and in tests — where there is no snapshot to restore
     # — so a missing import is a no-op.
     try:
-        from snapshot_restore_py import register_after_restore
+        from snapshot_restore_py import register_after_restore  # type: ignore[import-not-found]
     except ImportError:
         return
     register_after_restore(_reseed_random_after_snapstart)

--- a/backend/oqtopus_cloud/provider/routers/__init__.py
+++ b/backend/oqtopus_cloud/provider/routers/__init__.py
@@ -2,8 +2,10 @@ from typing import Callable
 
 from aws_lambda_powertools.metrics import MetricUnit, single_metric
 from fastapi import Request, Response
+from fastapi.exceptions import RequestValidationError
 from fastapi.routing import APIRoute
 from oqtopus_cloud.provider.conf import logger
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 
 class LoggerRouteHandler(APIRoute):
@@ -27,6 +29,28 @@ class LoggerRouteHandler(APIRoute):
                     name="route", value=f"{request.method} {self.path}"
                 )
 
-            return await original_route_handler(request)
+            def log_completion(status_code: int) -> None:
+                # FastAPI collapses the handler outcome into the HTTP response,
+                # so log the final status here; promote 5xx to error level so
+                # swallowed server errors are no longer invisible in the logs.
+                log = logger.error if status_code >= 500 else logger.info
+                log("Request completed", extra={"status_code": status_code})
+
+            try:
+                response = await original_route_handler(request)
+            except StarletteHTTPException as exc:
+                # FastAPI raises HTTP/validation errors out of the route handler
+                # for the app-level handlers to turn into responses; capture the
+                # eventual status before re-raising.
+                log_completion(exc.status_code)
+                raise
+            except RequestValidationError:
+                log_completion(422)
+                raise
+            except Exception:
+                log_completion(500)
+                raise
+            log_completion(response.status_code)
+            return response
 
         return route_handler

--- a/backend/oqtopus_cloud/user/routers/__init__.py
+++ b/backend/oqtopus_cloud/user/routers/__init__.py
@@ -2,7 +2,9 @@ from typing import Callable
 
 from aws_lambda_powertools.metrics import MetricUnit, single_metric
 from fastapi import Request, Response
+from fastapi.exceptions import RequestValidationError
 from fastapi.routing import APIRoute
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from oqtopus_cloud.user.conf import logger
 
@@ -28,6 +30,28 @@ class LoggerRouteHandler(APIRoute):
                     name="route", value=f"{request.method} {self.path}"
                 )
 
-            return await original_route_handler(request)
+            def log_completion(status_code: int) -> None:
+                # FastAPI collapses the handler outcome into the HTTP response,
+                # so log the final status here; promote 5xx to error level so
+                # swallowed server errors are no longer invisible in the logs.
+                log = logger.error if status_code >= 500 else logger.info
+                log("Request completed", extra={"status_code": status_code})
+
+            try:
+                response = await original_route_handler(request)
+            except StarletteHTTPException as exc:
+                # FastAPI raises HTTP/validation errors out of the route handler
+                # for the app-level handlers to turn into responses; capture the
+                # eventual status before re-raising.
+                log_completion(exc.status_code)
+                raise
+            except RequestValidationError:
+                log_completion(422)
+                raise
+            except Exception:
+                log_completion(500)
+                raise
+            log_completion(response.status_code)
+            return response
 
         return route_handler

--- a/backend/oqtopus_cloud/user_signup/routers/__init__.py
+++ b/backend/oqtopus_cloud/user_signup/routers/__init__.py
@@ -2,7 +2,9 @@ from typing import Callable
 
 from aws_lambda_powertools.metrics import MetricUnit, single_metric
 from fastapi import Request, Response
+from fastapi.exceptions import RequestValidationError
 from fastapi.routing import APIRoute
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from oqtopus_cloud.user_signup.conf import logger
 
@@ -28,6 +30,28 @@ class LoggerRouteHandler(APIRoute):
                     name="route", value=f"{request.method} {self.path}"
                 )
 
-            return await original_route_handler(request)
+            def log_completion(status_code: int) -> None:
+                # FastAPI collapses the handler outcome into the HTTP response,
+                # so log the final status here; promote 5xx to error level so
+                # swallowed server errors are no longer invisible in the logs.
+                log = logger.error if status_code >= 500 else logger.info
+                log("Request completed", extra={"status_code": status_code})
+
+            try:
+                response = await original_route_handler(request)
+            except StarletteHTTPException as exc:
+                # FastAPI raises HTTP/validation errors out of the route handler
+                # for the app-level handlers to turn into responses; capture the
+                # eventual status before re-raising.
+                log_completion(exc.status_code)
+                raise
+            except RequestValidationError:
+                log_completion(422)
+                raise
+            except Exception:
+                log_completion(500)
+                raise
+            log_completion(response.status_code)
+            return response
 
         return route_handler

--- a/backend/tests/oqtopus_cloud/common/test_request_logging.py
+++ b/backend/tests/oqtopus_cloud/common/test_request_logging.py
@@ -1,0 +1,93 @@
+import importlib
+
+import pytest
+from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+ROUTER_MODULES = [
+    "oqtopus_cloud.user.routers",
+    "oqtopus_cloud.provider.routers",
+    "oqtopus_cloud.admin.routers",
+    "oqtopus_cloud.user_signup.routers",
+]
+
+
+class RecordingLogger:
+    def __init__(self):
+        self.calls = []
+
+    def append_keys(self, **_keys):
+        pass
+
+    def info(self, message, **kwargs):
+        self.calls.append(("info", message, kwargs))
+
+    def error(self, message, **kwargs):
+        self.calls.append(("error", message, kwargs))
+
+
+@pytest.fixture(params=ROUTER_MODULES)
+def client_and_logger(request, monkeypatch):
+    module = importlib.import_module(request.param)
+    recorder = RecordingLogger()
+    monkeypatch.setattr(module, "logger", recorder)
+
+    router = APIRouter(route_class=module.LoggerRouteHandler)
+
+    @router.get("/ok")
+    def ok():
+        return {"ok": True}
+
+    @router.get("/client-error")
+    def client_error():
+        raise HTTPException(status_code=404, detail="not found")
+
+    @router.get("/server-error")
+    def server_error():
+        raise RuntimeError("boom")
+
+    @router.get("/needs-query")
+    def needs_query(value: int):
+        return {"value": value}
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app, raise_server_exceptions=False), recorder
+
+
+def _completion(recorder):
+    calls = [c for c in recorder.calls if c[1] == "Request completed"]
+    assert len(calls) == 1, recorder.calls
+    return calls[0]
+
+
+def test_success_logged_at_info(client_and_logger):
+    client, recorder = client_and_logger
+    assert client.get("/ok").status_code == 200
+    level, _, kwargs = _completion(recorder)
+    assert level == "info"
+    assert kwargs["extra"] == {"status_code": 200}
+
+
+def test_client_error_logged_at_info(client_and_logger):
+    client, recorder = client_and_logger
+    assert client.get("/client-error").status_code == 404
+    level, _, kwargs = _completion(recorder)
+    assert level == "info"
+    assert kwargs["extra"] == {"status_code": 404}
+
+
+def test_validation_error_logged_at_info(client_and_logger):
+    client, recorder = client_and_logger
+    assert client.get("/needs-query").status_code == 422
+    level, _, kwargs = _completion(recorder)
+    assert level == "info"
+    assert kwargs["extra"] == {"status_code": 422}
+
+
+def test_server_error_promoted_to_error(client_and_logger):
+    client, recorder = client_and_logger
+    assert client.get("/server-error").status_code == 500
+    level, _, kwargs = _completion(recorder)
+    assert level == "error"
+    assert kwargs["extra"] == {"status_code": 500}

--- a/backend/tests/oqtopus_cloud/common/test_tracing.py
+++ b/backend/tests/oqtopus_cloud/common/test_tracing.py
@@ -1,0 +1,45 @@
+import random
+
+import pytest
+from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
+
+from oqtopus_cloud.common import tracing
+
+
+@pytest.fixture(autouse=True)
+def restore_random_state():
+    state = random.getstate()
+    yield
+    random.setstate(state)
+
+
+def _trace_ids_from_restored_env(snapshot, reseed):
+    # Emulate a SnapStart restore: every restored environment starts from the
+    # same PRNG state that was frozen into the snapshot at Init time.
+    random.setstate(snapshot)
+    if reseed:
+        tracing._reseed_random_after_snapstart()
+    generator = RandomIdGenerator()
+    return [generator.generate_trace_id() for _ in range(2)]
+
+
+def test_restored_environments_collide_without_reseed():
+    # Documents the hazard: without the hook, two environments restored from the
+    # same snapshot generate identical trace-id sequences.
+    snapshot = random.getstate()
+    first = _trace_ids_from_restored_env(snapshot, reseed=False)
+    second = _trace_ids_from_restored_env(snapshot, reseed=False)
+    assert first == second
+
+
+def test_reseed_diverges_trace_ids_across_restored_environments():
+    snapshot = random.getstate()
+    first = _trace_ids_from_restored_env(snapshot, reseed=True)
+    second = _trace_ids_from_restored_env(snapshot, reseed=True)
+    assert first != second
+
+
+def test_register_hook_is_noop_when_runtime_module_absent():
+    # snapshot_restore_py ships only with the AWS Lambda managed runtime, so the
+    # registration must degrade to a no-op locally rather than raise.
+    tracing._register_snapstart_restore_hook()


### PR DESCRIPTION
## Summary

Fixes two instrumentation defects surfaced by the Grafana/Tempo monitoring stack on `oqtopus-dev`. Both root causes were reproduced from the code before fixing.

### 1. Trace IDs collide across SnapStart restores
Distinct requests showed up merged under a single trace ID (e.g. a 3h34m "trace" mixing a failed `GET /jobs` with an unrelated `PUT /jobs/{id}/transpiler_info` two minutes later).

OTel's `RandomIdGenerator` draws trace/span IDs from the global `random` module. SnapStart takes one memory snapshot at the end of Init and restores it into every execution environment, so the PRNG state is frozen and **every restored environment emits the same sequence of trace/span IDs** — guaranteeing collisions across invocations.

Fix: register an `afterRestore` runtime hook (`snapshot_restore_py`) that reseeds `random` from OS entropy. Reseeding the module global fixes every already-created generator, so one call is enough. `snapshot_restore_py` ships with the managed Lambda runtime and is imported defensively, so it is a no-op locally and in tests.

### 2. Response status was never logged
`LoggerRouteHandler` only logged `"Received request"`, so a swallowed 5xx left no trace in the structured logs. It now also logs `"Request completed"` with the resolved `status_code`, **promoting 5xx to error level**. FastAPI raises `HTTPException`/validation errors out of the route handler, so those are caught and mapped to the correct status before re-raising (4xx is not mislabelled as 500). Applied to `user`, `provider`, `admin`, `user_signup`.

## Investigated, no change needed
- **Span status on 5xx.** Verified end-to-end (real app + `CustomMiddleware` + Mangum + `FastAPIInstrumentor` 0.62b1): the SERVER span already gets `status=ERROR` with `http.status_code=500` on a 5xx. Per the OTel HTTP semantics a SERVER span is `UNSET` for 2xx/4xx and `ERROR` only for 5xx (it is never `OK`), so error-rate detection works for 5xx. The "all UNSET" symptom in span-metrics was a side effect of defect #1 corrupting traces, not the instrumentation.
- **DB credential caching.** `common/session.py` re-reads the secret from Secrets Manager on every `get_db()` call (no module-import cache), so there is no stale-credential exposure from SnapStart/rotation. The observed `Access denied for 'admin'@'10.2.150.66'` is a credential value mismatch (Secrets Manager vs RDS Proxy / DB user) and needs to be resolved on the AWS side; adding caching here would introduce the very staleness risk it would aim to prevent, so no code change was made.

## Test plan
- New unit tests (19, all green):
  - `test_tracing.py` — restored environments collide without the reseed; diverge with it; hook registration is a no-op when the runtime module is absent.
  - `test_request_logging.py` — 200/404/422 logged at info, 500 promoted to error, across all four router modules.
- Full suite unchanged otherwise: `18 failed / 262 passed` before → `18 failed / 281 passed` after (the 18 pre-existing failures are unrelated OAS/test-data mismatches; **no new failures**).
- `ruff` and `mypy` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
