### PR TITLE
fix(auth): fail fast on stalled dependencies and trace authorizer 500s

### DIFF
--- a/backend/oqtopus_cloud/common/session.py
+++ b/backend/oqtopus_cloud/common/session.py
@@ -39,13 +39,21 @@ _BOTO_TIMEOUT_CONFIG = Config(
 # credential-refresh window on the proxy while still failing fast on a
 # true stall (default OS TCP timeout is ~75s, way too long).
 _DB_CONNECT_TIMEOUT_SECONDS = 5
-# MySQL read_timeout (seconds). connect_timeout only bounds establishing the
+# MySQL read_timeout (seconds) for the AUTHORIZER ONLY (passed explicitly via
+# get_db(read_timeout=...)). connect_timeout only bounds establishing the
 # socket; without read_timeout a query that stalls AFTER connect (RDS Proxy
 # pinning, failover, max_connections wait) hangs unbounded and the Lambda is
 # SIGKILL'd at its 15s limit with no log -- exactly the silent timeout we are
 # trying to make traceable. Authorizer queries are single indexed lookups
 # (~tens of ms), so 5s is ~100x headroom while still failing fast.
-_DB_READ_TIMEOUT_SECONDS = 5
+#
+# NOT applied to the shared default: the worker (per-device COUNT aggregates)
+# and list endpoints (paginate/scalars().all()) legitimately run longer than
+# the authorizer and have larger Lambda budgets, so a global 5s read_timeout
+# would turn previously-slow-but-successful queries into 500s / worker failures
+# under the very same RDS Proxy conditions cited above. Those callers keep the
+# original unbounded read behavior.
+AUTH_DB_READ_TIMEOUT_SECONDS = 5
 
 
 def get_secret() -> Any:
@@ -80,7 +88,7 @@ def get_secret() -> Any:
     return json.loads(secret)
 
 
-def get_db() -> Generator:
+def get_db(read_timeout: int | None = None) -> Generator:
     """Returns a database session.
 
     This function creates a database session using the SQLAlchemy engine and sessionmaker.
@@ -104,13 +112,15 @@ def get_db() -> Generator:
     SQLALCHEMY_DATABASE_URL = (
         f"{connector}://{secret['username']}:{secret['password']}@{host}/{db_name}"
     )
+    connect_args = {
+        "init_command": "SET sql_mode='STRICT_TRANS_TABLES,NO_ZERO_DATE,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION', time_zone='+00:00'",
+        "connect_timeout": _DB_CONNECT_TIMEOUT_SECONDS,
+    }
+    if read_timeout is not None:
+        connect_args["read_timeout"] = read_timeout
     engine = create_engine(
         SQLALCHEMY_DATABASE_URL,
-        connect_args={
-            "init_command": "SET sql_mode='STRICT_TRANS_TABLES,NO_ZERO_DATE,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION', time_zone='+00:00'",
-            "connect_timeout": _DB_CONNECT_TIMEOUT_SECONDS,
-            "read_timeout": _DB_READ_TIMEOUT_SECONDS,
-        },
+        connect_args=connect_args,
     )
     SessionLocal = sessionmaker(
         autoflush=False,

--- a/backend/oqtopus_cloud/common/session.py
+++ b/backend/oqtopus_cloud/common/session.py
@@ -15,7 +15,7 @@ from botocore.exceptions import (
 from sqlalchemy import (
     create_engine,
 )
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 
 # Per-call timeouts so a stalled AWS API raises a Python exception
 # (visible in CloudWatch + X-Ray) instead of consuming the Lambda timeout
@@ -88,22 +88,12 @@ def get_secret() -> Any:
     return json.loads(secret)
 
 
-def get_db(read_timeout: int | None = None) -> Generator:
-    """Returns a database session.
+def _create_session(read_timeout: int | None = None) -> Session:
+    """Build and return a database session.
 
-    This function creates a database session using the SQLAlchemy engine and sessionmaker.
-    The session is then yielded to the caller, allowing them to perform database operations.
-    If an exception occurs during the database operation, the session is rolled back and the exception is raised.
-    Finally, the session is closed.
-
-    Yields:
-        Generator: A database session.
-
-    Raises:
-        Exception: If an exception occurs during the database operation.
-
-    Returns:
-        Generator: A database session.
+    read_timeout (seconds) is the PyMySQL read_timeout and is passed ONLY by the
+    authorizer (AUTH_DB_READ_TIMEOUT_SECONDS). It is intentionally NOT a parameter
+    of the get_db FastAPI dependency -- see get_db for why.
     """
     secret = get_secret()
     host = os.environ["DB_HOST"]
@@ -126,8 +116,19 @@ def get_db(read_timeout: int | None = None) -> Generator:
         autoflush=False,
         bind=engine,
     )
+    return SessionLocal()
 
-    db = SessionLocal()
+
+def get_db() -> Generator:
+    """FastAPI dependency that yields a database session.
+
+    Kept parameter-less on purpose: FastAPI treats a dependency callable's
+    parameters as request parameters, so adding e.g. read_timeout here would
+    expose a client-controllable `read_timeout` query parameter on every
+    Depends(get_db) endpoint. Callers that need a bounded read (the authorizer)
+    call _create_session directly instead of going through this dependency.
+    """
+    db = _create_session()
     try:
         yield db
     except:

--- a/backend/oqtopus_cloud/common/session.py
+++ b/backend/oqtopus_cloud/common/session.py
@@ -8,6 +8,7 @@ from typing import (
 import boto3
 
 # from aws_xray_sdk.core import xray_recorder
+from botocore.config import Config
 from botocore.exceptions import (
     ClientError,
 )
@@ -15,6 +16,36 @@ from sqlalchemy import (
     create_engine,
 )
 from sqlalchemy.orm import sessionmaker
+
+# Per-call timeouts so a stalled AWS API raises a Python exception
+# (visible in CloudWatch + X-Ray) instead of consuming the Lambda timeout
+# budget and being SIGKILL'd. Normal Secrets Manager latency is ~40-50ms;
+# read_timeout=3s gives ~60x headroom and with total_max_attempts=2 (one
+# initial + one retry) the worst case is ~7s (3s read + 1s backoff + 3s
+# read), well under the Lambda timeout. connect_timeout=2s bounds the
+# TCP+TLS handshake.
+#
+# NB: use total_max_attempts, NOT max_attempts. In a botocore retries
+# config, max_attempts means *retries excluding the initial call*
+# (max_attempts=N -> total_max_attempts=N+1), so max_attempts=2 would be
+# 3 calls (~11s) and blow the worst-case budget above.
+_BOTO_TIMEOUT_CONFIG = Config(
+    connect_timeout=2,
+    read_timeout=3,
+    retries={"total_max_attempts": 2, "mode": "standard"},
+)
+# MySQL connect_timeout (seconds) passed to PyMySQL. Normal RDS Proxy
+# connect latency is ~50-90ms; 5s is generous enough to ride out a brief
+# credential-refresh window on the proxy while still failing fast on a
+# true stall (default OS TCP timeout is ~75s, way too long).
+_DB_CONNECT_TIMEOUT_SECONDS = 5
+# MySQL read_timeout (seconds). connect_timeout only bounds establishing the
+# socket; without read_timeout a query that stalls AFTER connect (RDS Proxy
+# pinning, failover, max_connections wait) hangs unbounded and the Lambda is
+# SIGKILL'd at its 15s limit with no log -- exactly the silent timeout we are
+# trying to make traceable. Authorizer queries are single indexed lookups
+# (~tens of ms), so 5s is ~100x headroom while still failing fast.
+_DB_READ_TIMEOUT_SECONDS = 5
 
 
 def get_secret() -> Any:
@@ -38,6 +69,7 @@ def get_secret() -> Any:
     client = session.client(
         service_name="secretsmanager",
         region_name=region,
+        config=_BOTO_TIMEOUT_CONFIG,
     )
     try:
         get_secret_value_response = client.get_secret_value(SecretId=secret_name)
@@ -75,7 +107,9 @@ def get_db() -> Generator:
     engine = create_engine(
         SQLALCHEMY_DATABASE_URL,
         connect_args={
-            "init_command": "SET sql_mode='STRICT_TRANS_TABLES,NO_ZERO_DATE,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION', time_zone='+00:00'"
+            "init_command": "SET sql_mode='STRICT_TRANS_TABLES,NO_ZERO_DATE,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION', time_zone='+00:00'",
+            "connect_timeout": _DB_CONNECT_TIMEOUT_SECONDS,
+            "read_timeout": _DB_READ_TIMEOUT_SECONDS,
         },
     )
     SessionLocal = sessionmaker(

--- a/backend/oqtopus_cloud/lambda_auth/lambda_function.py
+++ b/backend/oqtopus_cloud/lambda_auth/lambda_function.py
@@ -6,16 +6,38 @@ import boto3
 import jwt
 from argon2 import PasswordHasher
 from argon2.exceptions import InvalidHash, VerificationError, VerifyMismatchError
+from botocore.config import Config
 from sqlalchemy import select, update
 from zoneinfo import ZoneInfo
 
 from oqtopus_cloud.common.models.user import MFAStatus, User, UserStatus
 from oqtopus_cloud.common.session import get_db
-from oqtopus_cloud.lambda_auth.conf import logger
+from oqtopus_cloud.lambda_auth.conf import logger, tracer
 
 utc = ZoneInfo("UTC")
 
 ph = PasswordHasher()
+
+# Per-call timeouts so a stalled external dependency raises a Python
+# exception (visible in CloudWatch + X-Ray) instead of consuming the
+# Lambda timeout budget and being SIGKILL'd. Normal latencies observed:
+# Cognito IDP ~120ms, JWKS fetch ~150ms. read_timeout=3s gives ~20x
+# headroom over normal while still failing fast on a real stall; with
+# total_max_attempts=2 (one initial + one retry) the SDK-level worst case
+# is ~7s (3s read + 1s backoff + 3s read), comfortably under the 15s
+# Lambda timeout. connect_timeout=2s bounds the TCP+TLS handshake
+# (anything beyond is anomalous).
+#
+# NB: use total_max_attempts, NOT max_attempts. In a botocore retries
+# config, max_attempts means *retries excluding the initial call*
+# (max_attempts=N -> total_max_attempts=N+1), so max_attempts=2 would be
+# 3 calls (~11s) and blow the worst-case budget above.
+_BOTO_TIMEOUT_CONFIG = Config(
+    connect_timeout=2,
+    read_timeout=3,
+    retries={"total_max_attempts": 2, "mode": "standard"},
+)
+_JWKS_HTTP_TIMEOUT_SECONDS = 5
 
 
 class AuthError(Exception):
@@ -24,6 +46,7 @@ class AuthError(Exception):
     pass
 
 
+@tracer.capture_method
 def _validate_user_status(
     user_id: str | None = None, cognito_id: str | None = None
 ) -> bool:
@@ -63,6 +86,7 @@ def _validate_user_status(
         raise AuthError("Failed to get user status")
 
 
+@tracer.capture_method
 def _verify_id_token(id_token: Optional[str]) -> str:
     if id_token is None:
         raise AuthError("ID token is not found")
@@ -83,7 +107,7 @@ def _verify_id_token(id_token: Optional[str]) -> str:
 
     try:
         # Get the signing key from the JWT
-        jwks_client = jwt.PyJWKClient(jwks_url)
+        jwks_client = jwt.PyJWKClient(jwks_url, timeout=_JWKS_HTTP_TIMEOUT_SECONDS)
         signing_key = jwks_client.get_signing_key_from_jwt(id_token)
     except Exception as e:
         raise AuthError(f"Failed to get signing key from JWT: {e}")
@@ -117,6 +141,7 @@ def _verify_id_token(id_token: Optional[str]) -> str:
         raise AuthError("ID token is invalid")
 
 
+@tracer.capture_method
 def _verify_api_token(api_token: Optional[str]) -> str:
     if api_token is None or api_token == "":
         raise AuthError("API token is None")
@@ -187,8 +212,9 @@ def _verify_api_token(api_token: Optional[str]) -> str:
         raise AuthError("User is not approved")
 
     try:
-        # Initialize the Cognito client
-        client = boto3.client("cognito-idp")
+        # Initialize the Cognito client with explicit short timeouts so a
+        # stalled IDP call fails fast instead of consuming the Lambda budget.
+        client = boto3.client("cognito-idp", config=_BOTO_TIMEOUT_CONFIG)
         # Get list users in the Cognito user pool with the specified Cognito ID
         response = client.list_users(
             UserPoolId=USER_POOL_ID, Filter=f'sub = "{cognito_id}"'
@@ -246,10 +272,14 @@ def _generate_policy_deny(principal_id="", resource="", user_id=""):
     return auth_response
 
 
+@tracer.capture_lambda_handler
 def lambda_handler(event, context):
+    method_arn = event["methodArn"]
+    # Marker log so that, on a future timeout, we can tell init/import stall
+    # (no marker) from handler-body stall (marker present, no later logs).
+    logger.info("lambda_handler entered", extra={"method_arn": method_arn})
     headers_raw = event.get("headers", {})
     headers = {k.lower(): v for k, v in headers_raw.items()}
-    method_arn = event["methodArn"]
     user_id = None
     unknown_user_id = "unknown"
 

--- a/backend/oqtopus_cloud/lambda_auth/lambda_function.py
+++ b/backend/oqtopus_cloud/lambda_auth/lambda_function.py
@@ -11,7 +11,7 @@ from sqlalchemy import select, update
 from zoneinfo import ZoneInfo
 
 from oqtopus_cloud.common.models.user import MFAStatus, User, UserStatus
-from oqtopus_cloud.common.session import AUTH_DB_READ_TIMEOUT_SECONDS, get_db
+from oqtopus_cloud.common.session import AUTH_DB_READ_TIMEOUT_SECONDS, _create_session
 from oqtopus_cloud.lambda_auth.conf import logger, tracer
 
 utc = ZoneInfo("UTC")
@@ -52,26 +52,26 @@ def _validate_user_status(
 ) -> bool:
     try:
         # Get a database session
-        dbs = get_db(read_timeout=AUTH_DB_READ_TIMEOUT_SECONDS)
-        db = next(dbs)
-
-        user = None
-        # Get the user status from the database
-        if user_id:
-            stmt = select(User).where(
-                User.id == user_id,
-                User.userstatus == UserStatus.approved,
-            )
-            user = db.execute(stmt).scalar()
+        db = _create_session(read_timeout=AUTH_DB_READ_TIMEOUT_SECONDS)
+        try:
+            user = None
+            # Get the user status from the database
+            if user_id:
+                stmt = select(User).where(
+                    User.id == user_id,
+                    User.userstatus == UserStatus.approved,
+                )
+                user = db.execute(stmt).scalar()
+            elif cognito_id:
+                stmt = select(User).where(
+                    User.cognito_id == cognito_id,
+                    User.userstatus == UserStatus.approved,
+                )
+                user = db.execute(stmt).scalar()
+            else:
+                raise AuthError("user_id or cognito_id is not given")
+        finally:
             db.close()
-        elif cognito_id:
-            stmt = select(User).where(
-                User.cognito_id == cognito_id, User.userstatus == UserStatus.approved
-            )
-            user = db.execute(stmt).scalar()
-            db.close()
-        else:
-            raise AuthError("user_id or cognito_id is not given")
 
         if user is None:
             logger.info(f"User {user_id} or {cognito_id} is not approved")
@@ -159,45 +159,46 @@ def _verify_api_token(api_token: Optional[str]) -> str:
 
     try:
         # Get a database session
-        dbs = get_db(read_timeout=AUTH_DB_READ_TIMEOUT_SECONDS)
-        db = next(dbs)
-
-        select_stmt = select(
-            User.mfa_status,
-            User.api_token_hash,
-            User.api_token_expiration,
-            User.cognito_id,
-        ).where(User.api_token_id == api_token_id)
-        verification_data = db.execute(select_stmt).first()
-        if verification_data is None:
-            raise AuthError("Invalid API token")
-
-        mfa_status, api_token_hash, api_token_expiration, cognito_id = verification_data
-
-        # Check the API token hash
+        db = _create_session(read_timeout=AUTH_DB_READ_TIMEOUT_SECONDS)
         try:
-            ph.verify(api_token_hash, api_token_secret)
-        except VerifyMismatchError:
-            raise AuthError("Invalid API token")
-        except (VerificationError, InvalidHash):
-            raise AuthError("API token verification error")
+            select_stmt = select(
+                User.mfa_status,
+                User.api_token_hash,
+                User.api_token_expiration,
+                User.cognito_id,
+            ).where(User.api_token_id == api_token_id)
+            verification_data = db.execute(select_stmt).first()
+            if verification_data is None:
+                raise AuthError("Invalid API token")
 
-        if ph.check_needs_rehash(api_token_hash):
-            update_stmt = (
-                update(User)
-                .where(User.api_token_id == api_token_id)
-                .values(api_token_hash=ph.hash(api_token_secret))
+            mfa_status, api_token_hash, api_token_expiration, cognito_id = (
+                verification_data
             )
-            db.execute(update_stmt)
-            db.commit()
 
-        # Check the API token expiration
-        if (api_token_expiration is None) or (
-            api_token_expiration.astimezone(utc) < datetime.now(utc)
-        ):
-            raise AuthError("API token is expired")
+            # Check the API token hash
+            try:
+                ph.verify(api_token_hash, api_token_secret)
+            except VerifyMismatchError:
+                raise AuthError("Invalid API token")
+            except (VerificationError, InvalidHash):
+                raise AuthError("API token verification error")
 
-        db.close()
+            if ph.check_needs_rehash(api_token_hash):
+                update_stmt = (
+                    update(User)
+                    .where(User.api_token_id == api_token_id)
+                    .values(api_token_hash=ph.hash(api_token_secret))
+                )
+                db.execute(update_stmt)
+                db.commit()
+
+            # Check the API token expiration
+            if (api_token_expiration is None) or (
+                api_token_expiration.astimezone(utc) < datetime.now(utc)
+            ):
+                raise AuthError("API token is expired")
+        finally:
+            db.close()
     except Exception as e:
         raise AuthError(f"Database error {e}")
 

--- a/backend/oqtopus_cloud/lambda_auth/lambda_function.py
+++ b/backend/oqtopus_cloud/lambda_auth/lambda_function.py
@@ -11,7 +11,7 @@ from sqlalchemy import select, update
 from zoneinfo import ZoneInfo
 
 from oqtopus_cloud.common.models.user import MFAStatus, User, UserStatus
-from oqtopus_cloud.common.session import get_db
+from oqtopus_cloud.common.session import AUTH_DB_READ_TIMEOUT_SECONDS, get_db
 from oqtopus_cloud.lambda_auth.conf import logger, tracer
 
 utc = ZoneInfo("UTC")
@@ -52,7 +52,7 @@ def _validate_user_status(
 ) -> bool:
     try:
         # Get a database session
-        dbs = get_db()
+        dbs = get_db(read_timeout=AUTH_DB_READ_TIMEOUT_SECONDS)
         db = next(dbs)
 
         user = None
@@ -159,7 +159,7 @@ def _verify_api_token(api_token: Optional[str]) -> str:
 
     try:
         # Get a database session
-        dbs = get_db()
+        dbs = get_db(read_timeout=AUTH_DB_READ_TIMEOUT_SECONDS)
         db = next(dbs)
 
         select_stmt = select(

--- a/backend/tests/oqtopus_cloud/lambda_auth/conftest.py
+++ b/backend/tests/oqtopus_cloud/lambda_auth/conftest.py
@@ -97,7 +97,7 @@ def test_session() -> Generator:
 
 @pytest.fixture(autouse=True, scope="function")
 def override_get_db_session(test_session, monkeypatch):
-    def _get_test_db_session():
+    def _get_test_db_session(read_timeout=None):
         yield test_session
 
     monkeypatch.setenv("DB_HOST", "sqlite:///:memory:")

--- a/backend/tests/oqtopus_cloud/lambda_auth/conftest.py
+++ b/backend/tests/oqtopus_cloud/lambda_auth/conftest.py
@@ -96,12 +96,12 @@ def test_session() -> Generator:
 
 
 @pytest.fixture(autouse=True, scope="function")
-def override_get_db_session(test_session, monkeypatch):
-    def _get_test_db_session(read_timeout=None):
-        yield test_session
-
+def override_create_session(test_session, monkeypatch):
     monkeypatch.setenv("DB_HOST", "sqlite:///:memory:")
-    monkeypatch.setattr("oqtopus_cloud.common.session.get_db", _get_test_db_session)
+    monkeypatch.setattr(
+        "oqtopus_cloud.lambda_auth.lambda_function._create_session",
+        lambda read_timeout=None: test_session,
+    )
 
 
 @pytest.fixture()

--- a/backend/tests/oqtopus_cloud/lambda_auth/conftest.py
+++ b/backend/tests/oqtopus_cloud/lambda_auth/conftest.py
@@ -58,15 +58,18 @@ class FakeCognitoClientMultipleUsers:
 
 
 class FakePyJWKClient:
-    def __init__(self, uri):
+    # Mirror jwt.PyJWKClient(uri, timeout=...) so the production call,
+    # which now passes an explicit timeout, can be monkeypatched.
+    def __init__(self, uri, timeout=None, **kwargs):
         self.uri = uri
+        self.timeout = timeout
 
     def get_signing_key_from_jwt(self, token):
         return mock.MagicMock()
 
 
 class FakePyJWKClientFailure:
-    def __init__(self, uri):
+    def __init__(self, uri, timeout=None, **kwargs):
         self.uri = uri
 
     def get_signing_key_from_jwt(self, token):

--- a/backend/tests/oqtopus_cloud/lambda_auth/routers/test_lambda_function.py
+++ b/backend/tests/oqtopus_cloud/lambda_auth/routers/test_lambda_function.py
@@ -15,7 +15,7 @@ from oqtopus_cloud.lambda_auth.lambda_function import (
 
 
 def fake_get_db_client(test_session):
-    yield test_session
+    return test_session
 
 
 def fake__verify_api_token(api_token=""):
@@ -112,7 +112,9 @@ def test__verify_id_token(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
+        lambda_function,
+        "_create_session",
+        lambda **kwargs: fake_get_db_client(test_session),
     )
 
     actual = _verify_id_token("id_token")
@@ -126,7 +128,9 @@ def test__verify_id_token_no_token(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
+        lambda_function,
+        "_create_session",
+        lambda **kwargs: fake_get_db_client(test_session),
     )
     with pytest.raises(AuthError) as excinfo:
         _ = _verify_id_token(None)
@@ -140,7 +144,9 @@ def test__verify_id_token_no_env_variable(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
+        lambda_function,
+        "_create_session",
+        lambda **kwargs: fake_get_db_client(test_session),
     )
     monkeypatch.delenv("USER_POOL_WEB_CLIENT_ID", raising=False)
     with pytest.raises(AuthError) as excinfo:
@@ -167,7 +173,9 @@ def test__verify_suspended(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
+        lambda_function,
+        "_create_session",
+        lambda **kwargs: fake_get_db_client(test_session),
     )
 
     pytest.raises(AuthError, _verify_id_token, "id_token")
@@ -179,7 +187,9 @@ def test__verify_unapproved(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
+        lambda_function,
+        "_create_session",
+        lambda **kwargs: fake_get_db_client(test_session),
     )
 
     pytest.raises(AuthError, _verify_id_token, "id_token")
@@ -191,7 +201,9 @@ def test__verify_mfa_inactive(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
+        lambda_function,
+        "_create_session",
+        lambda **kwargs: fake_get_db_client(test_session),
     )
 
     pytest.raises(AuthError, _verify_id_token, "id_token")
@@ -203,7 +215,9 @@ def test__verify_api_token(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
+        lambda_function,
+        "_create_session",
+        lambda **kwargs: fake_get_db_client(test_session),
     )
     ret = _verify_api_token("api_token_id_1.api_token_secret_1")
 
@@ -216,7 +230,9 @@ def test__verify_api_token_expired(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
+        lambda_function,
+        "_create_session",
+        lambda **kwargs: fake_get_db_client(test_session),
     )
 
     try:
@@ -233,7 +249,9 @@ def test__verify_api_token_api_no_token(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
+        lambda_function,
+        "_create_session",
+        lambda **kwargs: fake_get_db_client(test_session),
     )
     with pytest.raises(AuthError) as excinfo:
         _ = _verify_api_token(None)
@@ -247,7 +265,9 @@ def test__verify_api_token_no_env_variable(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
+        lambda_function,
+        "_create_session",
+        lambda **kwargs: fake_get_db_client(test_session),
     )
     monkeypatch.delenv("AUTH_USER_POOL_ID", raising=False)
     with pytest.raises(AuthError) as excinfo:
@@ -262,7 +282,9 @@ def test__verify_api_token_mfa_inactive(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
+        lambda_function,
+        "_create_session",
+        lambda **kwargs: fake_get_db_client(test_session),
     )
 
     with pytest.raises(AuthError) as excinfo:
@@ -277,7 +299,9 @@ def test__verify_api_token_no_cognito_user(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
+        lambda_function,
+        "_create_session",
+        lambda **kwargs: fake_get_db_client(test_session),
     )
     with pytest.raises(AuthError) as excinfo:
         _ = _verify_api_token("api_token_id_1.api_token_secret_1")
@@ -294,7 +318,9 @@ def test__verify_api_token_multiple_cognito_user(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
+        lambda_function,
+        "_create_session",
+        lambda **kwargs: fake_get_db_client(test_session),
     )
     with pytest.raises(AuthError) as excinfo:
         _ = _verify_api_token("api_token_id_1.api_token_secret_1")
@@ -310,7 +336,9 @@ def test__verify_api_token_suspended(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
+        lambda_function,
+        "_create_session",
+        lambda **kwargs: fake_get_db_client(test_session),
     )
     with pytest.raises(AuthError) as excinfo:
         _ = _verify_api_token("api_token_id_1.api_token_secret_1")
@@ -322,7 +350,9 @@ def test__verify_api_token_unapproved(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
+        lambda_function,
+        "_create_session",
+        lambda **kwargs: fake_get_db_client(test_session),
     )
     with pytest.raises(AuthError) as excinfo:
         _ = _verify_api_token("api_token_id_1.api_token_secret_1")

--- a/backend/tests/oqtopus_cloud/lambda_auth/routers/test_lambda_function.py
+++ b/backend/tests/oqtopus_cloud/lambda_auth/routers/test_lambda_function.py
@@ -98,7 +98,9 @@ def _get_model(n: int, expiration_day=90, status=UserStatus.approved) -> User:
         "mfa_status": MFAStatus.disabled if n % 2 == 0 else MFAStatus.enabled,
         "api_token_id": f"api_token_id_{n}",
         "api_token_hash": PasswordHasher().hash(f"api_token_secret_{n}"),
-        "api_token_expiration": datetime.now(timezone.utc).replace(second=0, microsecond=0)
+        "api_token_expiration": datetime.now(timezone.utc).replace(
+            second=0, microsecond=0
+        )
         + timedelta(days=expiration_day),
     }
     return User(**model_dict)
@@ -110,7 +112,7 @@ def test__verify_id_token(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda: fake_get_db_client(test_session)
+        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
     )
 
     actual = _verify_id_token("id_token")
@@ -124,7 +126,7 @@ def test__verify_id_token_no_token(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda: fake_get_db_client(test_session)
+        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
     )
     with pytest.raises(AuthError) as excinfo:
         _ = _verify_id_token(None)
@@ -138,7 +140,7 @@ def test__verify_id_token_no_env_variable(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda: fake_get_db_client(test_session)
+        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
     )
     monkeypatch.delenv("USER_POOL_WEB_CLIENT_ID", raising=False)
     with pytest.raises(AuthError) as excinfo:
@@ -165,7 +167,7 @@ def test__verify_suspended(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda: fake_get_db_client(test_session)
+        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
     )
 
     pytest.raises(AuthError, _verify_id_token, "id_token")
@@ -177,7 +179,7 @@ def test__verify_unapproved(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda: fake_get_db_client(test_session)
+        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
     )
 
     pytest.raises(AuthError, _verify_id_token, "id_token")
@@ -189,7 +191,7 @@ def test__verify_mfa_inactive(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda: fake_get_db_client(test_session)
+        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
     )
 
     pytest.raises(AuthError, _verify_id_token, "id_token")
@@ -201,7 +203,7 @@ def test__verify_api_token(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda: fake_get_db_client(test_session)
+        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
     )
     ret = _verify_api_token("api_token_id_1.api_token_secret_1")
 
@@ -214,7 +216,7 @@ def test__verify_api_token_expired(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda: fake_get_db_client(test_session)
+        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
     )
 
     try:
@@ -231,7 +233,7 @@ def test__verify_api_token_api_no_token(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda: fake_get_db_client(test_session)
+        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
     )
     with pytest.raises(AuthError) as excinfo:
         _ = _verify_api_token(None)
@@ -245,7 +247,7 @@ def test__verify_api_token_no_env_variable(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda: fake_get_db_client(test_session)
+        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
     )
     monkeypatch.delenv("AUTH_USER_POOL_ID", raising=False)
     with pytest.raises(AuthError) as excinfo:
@@ -260,7 +262,7 @@ def test__verify_api_token_mfa_inactive(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda: fake_get_db_client(test_session)
+        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
     )
 
     with pytest.raises(AuthError) as excinfo:
@@ -275,7 +277,7 @@ def test__verify_api_token_no_cognito_user(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda: fake_get_db_client(test_session)
+        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
     )
     with pytest.raises(AuthError) as excinfo:
         _ = _verify_api_token("api_token_id_1.api_token_secret_1")
@@ -292,7 +294,7 @@ def test__verify_api_token_multiple_cognito_user(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda: fake_get_db_client(test_session)
+        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
     )
     with pytest.raises(AuthError) as excinfo:
         _ = _verify_api_token("api_token_id_1.api_token_secret_1")
@@ -308,7 +310,7 @@ def test__verify_api_token_suspended(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda: fake_get_db_client(test_session)
+        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
     )
     with pytest.raises(AuthError) as excinfo:
         _ = _verify_api_token("api_token_id_1.api_token_secret_1")
@@ -320,7 +322,7 @@ def test__verify_api_token_unapproved(test_session, monkeypatch):
     test_session.add(user)
     test_session.commit()
     monkeypatch.setattr(
-        lambda_function, "get_db", lambda: fake_get_db_client(test_session)
+        lambda_function, "get_db", lambda **kwargs: fake_get_db_client(test_session)
     )
     with pytest.raises(AuthError) as excinfo:
         _ = _verify_api_token("api_token_id_1.api_token_secret_1")
@@ -402,9 +404,7 @@ def test_lambda_handler_api_token(monkeypatch):
 
 
 def test_lambda_handler_no_api_token(monkeypatch):
-    def fake__verify_api_token_deny(
-        principal_id=None, resource=None, user_id=None
-    ):
+    def fake__verify_api_token_deny(principal_id=None, resource=None, user_id=None):
         return "fake_username"
 
     input = {"headers": {"q-api-token": None}, "methodArn": "methodArn"}
@@ -480,9 +480,7 @@ def test_lambda_handler_none_user_id(monkeypatch):
 
 
 def test_lambda_handler_unexpected_header(monkeypatch):
-    def fake__verify_api_token_deny(
-        principal_id=None, resource=None, user_id=None
-    ):
+    def fake__verify_api_token_deny(principal_id=None, resource=None, user_id=None):
         return "fake_username"
 
     input = {"headers": {"q-api-token-unexpected": None}, "methodArn": "methodArn"}

--- a/terraform/service/modules/api-server/main.tf
+++ b/terraform/service/modules/api-server/main.tf
@@ -132,6 +132,11 @@ resource "aws_lambda_function" "this" {
   }
   publish = true
 
+  # Ensure the explicitly-managed log group (with retention) is created before
+  # the function, so the function does not auto-create it first with infinite
+  # retention. No-op when otel_enabled = false (the group has count = 0).
+  depends_on = [aws_cloudwatch_log_group.lambda]
+
   lifecycle {
     ignore_changes = [tags["github-sha"]]
   }

--- a/terraform/service/modules/api-server/observability.tf
+++ b/terraform/service/modules/api-server/observability.tf
@@ -1,0 +1,23 @@
+# CloudWatch Logs group — explicit TF management (opt-in via otel_enabled)
+#
+# When otel_enabled = true, the monitoring stack's Alloy pulls these logs
+# into Loki. Making the log group explicit here ensures:
+#   - Retention is set before Lambda creates it automatically
+#   - The group name is authoritative in TF state
+#
+# No subscription filter or forwarder Lambda is needed; the monitoring EC2
+# IAM role already has logs:FilterLogEvents access and Alloy polls directly.
+#
+# IMPORTANT (existing environments): if the Lambda has already run, this log
+# group exists and `terraform apply` will fail with ResourceAlreadyExists.
+# Import it first, once per api-server instance, e.g.:
+#   terraform import 'module.user_api.aws_cloudwatch_log_group.lambda[0]' \
+#     /aws/lambda/oqtopus-<org>-<env>-user-api
+#   terraform import 'module.provider_api.aws_cloudwatch_log_group.lambda[0]' \
+#     /aws/lambda/oqtopus-<org>-<env>-provider-api
+
+resource "aws_cloudwatch_log_group" "lambda" {
+  count             = var.otel_enabled ? 1 : 0
+  name              = "/aws/lambda/${var.product}-${var.org}-${var.env}-${var.identifier}-api"
+  retention_in_days = var.lambda_log_retention_days
+}

--- a/terraform/service/modules/api-server/variables.tf
+++ b/terraform/service/modules/api-server/variables.tf
@@ -249,3 +249,9 @@ variable "otel_exporter_otlp_endpoint" {
     error_message = "otel_exporter_otlp_endpoint must be set when otel_enabled = true."
   }
 }
+
+variable "lambda_log_retention_days" {
+  type        = number
+  default     = 14
+  description = "CloudWatch log retention (days) for the Lambda function log group. Used when otel_enabled = true."
+}

--- a/terraform/service/modules/lambda-auth/main.tf
+++ b/terraform/service/modules/lambda-auth/main.tf
@@ -85,6 +85,11 @@ resource "aws_lambda_function" "this" {
   }
   publish = true
 
+  # Ensure the explicitly-managed log group (with retention) is created before
+  # the function, so the function does not auto-create it first with infinite
+  # retention. No-op when otel_enabled = false (the group has count = 0).
+  depends_on = [aws_cloudwatch_log_group.lambda]
+
   lifecycle {
     ignore_changes = [tags["github-sha"]]
   }

--- a/terraform/service/modules/lambda-auth/observability.tf
+++ b/terraform/service/modules/lambda-auth/observability.tf
@@ -1,0 +1,28 @@
+# CloudWatch Logs group — explicit TF management (opt-in via otel_enabled)
+#
+# The user-API 500s observed in dev (2026-06-26, 13:04 / 14:05 / 15:14 JST)
+# were all this authorizer Lambda hitting its 15s timeout. Without explicit
+# management this log group is auto-created with infinite retention and is
+# not authoritative in TF state, which is why those timeouts were hard to
+# trace. Making it explicit here mirrors the api-server module:
+#   - Retention is set before Lambda creates the group automatically
+#   - The group name is authoritative in TF state
+#   - The monitoring stack's Alloy can poll a known group name into Loki
+#
+# NOTE: the function_name here has NO "-api" suffix (see main.tf), unlike the
+# api-server module, so the log-group name differs accordingly.
+#
+# IMPORTANT (existing environments): if the Lambda has already run, the log
+# group exists and `terraform apply` will fail with ResourceAlreadyExists.
+# Import it first, e.g.:
+#   terraform import 'module.lambda_auth.aws_cloudwatch_log_group.lambda[0]' \
+#     /aws/lambda/oqtopus-<org>-<env>-lambda_auth
+#
+# The monitoring side (Alloy config, outside this repo) must also include
+# this log group in its poll/discovery set for the logs to reach Loki.
+
+resource "aws_cloudwatch_log_group" "lambda" {
+  count             = var.otel_enabled ? 1 : 0
+  name              = "/aws/lambda/${var.product}-${var.org}-${var.env}-${var.identifier}"
+  retention_in_days = var.lambda_log_retention_days
+}

--- a/terraform/service/modules/lambda-auth/variables.tf
+++ b/terraform/service/modules/lambda-auth/variables.tf
@@ -105,3 +105,15 @@ variable "lambda_timeout" {
   description = "Lambda execution timeout"
   default     = 15
 }
+
+variable "otel_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable explicit CloudWatch log-group management so the monitoring stack (Loki/Alloy) can ingest this Lambda's logs with a known name and retention."
+}
+
+variable "lambda_log_retention_days" {
+  type        = number
+  default     = 14
+  description = "CloudWatch log retention (days) for the Lambda function log group. Used when otel_enabled = true."
+}

--- a/terraform/service/oqtopus-dev/main.tf
+++ b/terraform/service/oqtopus-dev/main.tf
@@ -32,6 +32,8 @@ module "lambda_auth" {
   allow_headers                          = "*"
   log_level                              = "INFO"
   lambda_timeout                         = 15
+  otel_enabled                           = var.otel_enabled
+  lambda_log_retention_days              = var.lambda_log_retention_days
 }
 
 module "user_api" {
@@ -76,6 +78,7 @@ module "user_api" {
   api_gateway_log_retention_days = var.api_gateway_log_retention_days
   otel_enabled                   = var.otel_enabled
   otel_exporter_otlp_endpoint    = var.otel_exporter_otlp_endpoint
+  lambda_log_retention_days      = var.lambda_log_retention_days
 }
 
 module "provider_api" {
@@ -114,6 +117,7 @@ module "provider_api" {
   api_gateway_log_retention_days = var.api_gateway_log_retention_days
   otel_enabled                   = var.otel_enabled
   otel_exporter_otlp_endpoint    = var.otel_exporter_otlp_endpoint
+  lambda_log_retention_days      = var.lambda_log_retention_days
 }
 
 module "admin_api" {

--- a/terraform/service/oqtopus-prod/main.tf
+++ b/terraform/service/oqtopus-prod/main.tf
@@ -32,6 +32,8 @@ module "lambda_auth" {
   allow_headers                          = "*"
   log_level                              = "INFO"
   lambda_timeout                         = 15
+  otel_enabled                           = var.otel_enabled
+  lambda_log_retention_days              = var.lambda_log_retention_days
 }
 
 module "user_api" {
@@ -71,6 +73,7 @@ module "user_api" {
   api_gateway_log_retention_days         = var.api_gateway_log_retention_days
   otel_enabled                           = var.otel_enabled
   otel_exporter_otlp_endpoint            = var.otel_exporter_otlp_endpoint
+  lambda_log_retention_days              = var.lambda_log_retention_days
 
   storage_driver = "s3"
   storage_env_vars_s3 = {
@@ -106,6 +109,7 @@ module "provider_api" {
   api_gateway_log_retention_days = var.api_gateway_log_retention_days
   otel_enabled                   = var.otel_enabled
   otel_exporter_otlp_endpoint    = var.otel_exporter_otlp_endpoint
+  lambda_log_retention_days      = var.lambda_log_retention_days
   storage_driver                 = "s3"
   storage_env_vars_s3 = {
     "STORAGE_S3_REGION"      = var.region


### PR DESCRIPTION
# 📃 Ticket
<!--- Paste related ticket -->
N/A

## ✍ Description

While building monitoring, the dev user-API showed three intermittent **500s** on 2026-06-26 (≈13:04 / 14:05 / 15:14 JST) that could not be traced. Investigation of the dev CloudWatch logs showed all three were the **Lambda authorizer (`lambda_auth`) hitting its 15s timeout**:

- `START` → **15s of total silence** (zero application logs) → `Task timed out` → SIGKILL.
- Memory normal (~285 MB, not OOM). **Not** a cold start / SnapStart restore (the timed-out requests came after many successful invocations in the same warm environment). **Not** a systemic outage (3 of ~80k requests).
- No usable X-Ray trace either — the function is SIGKILL'd before the log or trace is flushed. That is exactly *why* it was untraceable.

Root cause: a single external call stalled on an **unbounded socket** and ran out the whole Lambda budget. This PR makes such a stall **fail fast with a logged exception** and makes the authorizer's logs **retained and queryable in Grafana/Loki**, so the next occurrence pinpoints the exact dependency.

### Backend — fail fast + traceability (`backend/`)
- Explicit boto3 connect/read timeouts + retries on **Secrets Manager** and **Cognito** calls.
- Bound the **JWKS** HTTP fetch (`PyJWKClient(timeout=…)`) and the **DB connection** (PyMySQL `connect_timeout`), and add a DB **`read_timeout`** so a query that stalls *after* connect (RDS Proxy pinning / failover / `max_connections` wait) is bounded too — otherwise that path could still hang to 15s silently.
- Use `retries.total_max_attempts` instead of `max_attempts`. In a botocore retries config, `max_attempts` excludes the initial call (`max_attempts=N` → `N+1` total), which broke the worst-case latency budget described in the comments.
- Add a **marker log at handler entry** and `tracer` decorators, so a future timeout can be split into *init/import stall* (no marker) vs *handler-body stall* (marker present, then the failing call is logged).

### Terraform — retained, queryable authorizer logs (`terraform/`)
- Explicitly manage the `lambda_auth` **and** api-server Lambda log groups with retention (opt-in via `otel_enabled`), so they are authoritative in state and polled into Loki by the monitoring stack.
- Propagate `lambda_log_retention_days` to `user_api` / `provider_api`, which previously received only `otel_enabled` and so were stuck at the module default.
- `depends_on` the log group from the function so retention is applied before the function can auto-create the group (no-op when `otel_enabled = false`).

> ⚠️ **Deploy note (existing environments):** the Lambda log groups already exist, so `terraform apply` will fail with `ResourceAlreadyExists` until they are imported. Import commands are documented in each `observability.tf`, e.g.:
> ```
> terraform import 'module.lambda_auth.aws_cloudwatch_log_group.lambda[0]' /aws/lambda/oqtopus-<org>-<env>-lambda_auth
> terraform import 'module.user_api.aws_cloudwatch_log_group.lambda[0]'     /aws/lambda/oqtopus-<org>-<env>-user-api
> terraform import 'module.provider_api.aws_cloudwatch_log_group.lambda[0]' /aws/lambda/oqtopus-<org>-<env>-provider-api
> ```

### Out of scope (follow-up)
The deeper contributor is that `get_db()` calls Secrets Manager and builds a new engine on **every** authorizer request, which both adds latency and widens the intermittent-stall surface. Caching the secret/engine across warm invocations (carefully, given SnapStart credential staleness) is a larger change and left for a separate PR.

## 📸 Test Result
```
$ uv run pytest tests/oqtopus_cloud/lambda_auth/ -q
============================== 24 passed in 2.10s ==============================
```
`terraform fmt -check` is clean for all files changed in this PR.

## 🔗 Related PRs
- #452 feat(otel): export cloud-api traces directly to the monitoring collector
- #471 fix(otel): isolate trace IDs across SnapStart restores and log response status
