### PR TITLE
Fix : Repair broken `make run` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,10 @@ copy: generate-oas terraform-docs
 	@cp .github/SECURITY.md ./docs/en/SECURITY.md
 
 docs: copy ## Build MkDocs
-	@uv run mkdocs build
+	@uv run --group docs mkdocs build
 
 run: copy ## Run MkDocs
-	@uv run mkdocs serve
+	@uv run --group docs mkdocs serve
 
 terraform-docs: ## Generate Terraform Docs
 	@$(MAKE) -C terraform/service docs


### PR DESCRIPTION
## Summary
Fix `make run` (and `make docs`) failing to launch `mkdocs`.

## Cause
The `mkdocs` packages live in the `docs` dependency-group in `pyproject.toml`.
`uv run` only syncs the `dev` group by default, so the `docs` group was never
installed and `uv run mkdocs serve` failed to spawn:

error: Failed to spawn: mkdocs
  Caused by: No such file or directory (os error 2)

## Changes
Add `--group docs` to the `uv run` invocations in the `docs` and `run` targets
so the docs group is synced before running mkdocs.

## Verification
- Confirmed `make run` now starts mkdocs serve.