### PR TITLE
feat: OTel collector Lambda layer mode with decouple processor

### DIFF
--- a/terraform/service/modules/api-server/main.tf
+++ b/terraform/service/modules/api-server/main.tf
@@ -45,6 +45,8 @@ locals {
     COGNITO = try(aws_api_gateway_authorizer.cognito[0].id, null)
     LAMBDA  = try(aws_api_gateway_authorizer.lambda[0].id, null)
   }
+
+  otel_layer_enabled = var.otel_collector_layer_arn != ""
 }
 
 data "aws_caller_identity" "current" {}
@@ -88,17 +90,27 @@ resource "aws_lambda_function" "this" {
       var.editable_fields != "" ? { EDITABLE_FIELDS = var.editable_fields } : {},
       var.visible_fields != "" ? { VISIBLE_FIELDS = var.visible_fields } : {},
       var.login_history_enabled != "" ? { LOGIN_HISTORY_ENABLED = var.login_history_enabled } : {},
-      var.otel_enabled ? {
-        OTEL_ENABLED                = "true"
-        OTEL_EXPORTER_OTLP_ENDPOINT = var.otel_exporter_otlp_endpoint
-        OTEL_EXPORTER_OTLP_PROTOCOL = "http/protobuf"
-        # Cap each export attempt so an unreachable collector cannot push the
-        # function past the API Gateway/Lambda timeout. 0.2s × ~2 retries ≒ 0.4s
-        # worst case; kill switch is otel_enabled = false. Direct export beats a
-        # co-located collector layer here: the layer's own retry queue, which
-        # OTEL_EXPORTER_OTLP_TIMEOUT does not bound, billed ~20s storms on freeze.
-        OTEL_EXPORTER_OTLP_TIMEOUT = "0.2"
-      } : {},
+      var.otel_enabled ? merge(
+        {
+          OTEL_ENABLED = "true"
+          # Layer mode exports to the in-environment collector, which acks
+          # from memory (decouple processor) — monitoring health never rides
+          # the response. Direct mode posts straight to the remote collector.
+          OTEL_EXPORTER_OTLP_ENDPOINT = local.otel_layer_enabled ? "http://localhost:4318" : var.otel_exporter_otlp_endpoint
+          OTEL_EXPORTER_OTLP_PROTOCOL = "http/protobuf"
+          # Cap each export attempt so an unreachable collector cannot push the
+          # function past the API Gateway/Lambda timeout. 0.2s × ~2 retries ≒ 0.4s
+          # worst case; kill switch is otel_enabled = false. In layer mode the
+          # target is local and acks in ~ms, so the cap should never bite.
+          OTEL_EXPORTER_OTLP_TIMEOUT = "0.2"
+        },
+        local.otel_layer_enabled ? {
+          # The layer reads its whole collector config from the env var below
+          # (env confmap provider), so nothing is baked into the function zip.
+          OPENTELEMETRY_COLLECTOR_CONFIG_URI = "env:OTEL_COLLECTOR_CONFIG_CONTENT"
+          OTEL_COLLECTOR_CONFIG_CONTENT      = local.otel_collector_config
+        } : {},
+      ) : {},
       var.lambda_additional_env != null ? var.lambda_additional_env : {},
     )
   }
@@ -110,6 +122,7 @@ resource "aws_lambda_function" "this" {
   source_code_hash               = filebase64sha256("./bin/${var.identifier}/lambda.zip")
   function_name                  = "${var.product}-${var.org}-${var.env}-${var.identifier}-api"
   handler                        = var.lambda_handler
+  layers                         = local.otel_layer_enabled ? [var.otel_collector_layer_arn] : []
   memory_size                    = "1024"
   package_type                   = "Zip"
   reserved_concurrent_executions = "-1"

--- a/terraform/service/modules/api-server/observability.tf
+++ b/terraform/service/modules/api-server/observability.tf
@@ -21,3 +21,48 @@ resource "aws_cloudwatch_log_group" "lambda" {
   name              = "/aws/lambda/${var.product}-${var.org}-${var.env}-${var.identifier}-api"
   retention_in_days = var.lambda_log_retention_days
 }
+
+# Collector config for the OTel Lambda layer (otel_collector_layer_arn).
+#
+# The decouple processor acks spans into memory the moment they arrive, so
+# the app's force_flush returns immediately and the response never waits on
+# the remote collector. The layer ships the buffered spans after the response,
+# inside the extension window (the Extensions API delays environment freeze
+# until the extension reports done).
+#
+# The export bounds below are what keep that window short: the exporter
+# default (retry up to 5 min) is what billed ~20s per request when the remote
+# collector was unreachable. timeout 1s + retry ≤2s + no sending_queue caps
+# the post-response work at ~2.5s per batch; anything unsent past that is
+# dropped (telemetry stays best-effort).
+locals {
+  otel_collector_config = <<-EOT
+    receivers:
+      otlp:
+        protocols:
+          http:
+
+    processors:
+      decouple:
+
+    exporters:
+      otlp_http:
+        endpoint: ${var.otel_exporter_otlp_endpoint}
+        timeout: 1s
+        retry_on_failure:
+          initial_interval: 0.5s
+          # must stay <= max_elapsed_time or config validation fails and the
+          # extension refuses to start (logged only as "otelcol state is Closed")
+          max_interval: 1s
+          max_elapsed_time: 2s
+        sending_queue:
+          enabled: false
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [decouple]
+          exporters: [otlp_http]
+  EOT
+}

--- a/terraform/service/modules/api-server/variables.tf
+++ b/terraform/service/modules/api-server/variables.tf
@@ -250,6 +250,17 @@ variable "otel_exporter_otlp_endpoint" {
   }
 }
 
+variable "otel_collector_layer_arn" {
+  type        = string
+  default     = ""
+  description = "OTel Lambda collector layer ARN. When set, the app exports to the layer's in-environment collector, which forwards to otel_exporter_otlp_endpoint off the response path (decouple processor). Empty = direct export."
+
+  validation {
+    condition     = var.otel_collector_layer_arn == "" || var.otel_enabled
+    error_message = "otel_collector_layer_arn requires otel_enabled = true."
+  }
+}
+
 variable "lambda_log_retention_days" {
   type        = number
   default     = 14

--- a/terraform/service/oqtopus-dev/main.tf
+++ b/terraform/service/oqtopus-dev/main.tf
@@ -78,6 +78,7 @@ module "user_api" {
   api_gateway_log_retention_days = var.api_gateway_log_retention_days
   otel_enabled                   = var.otel_enabled
   otel_exporter_otlp_endpoint    = var.otel_exporter_otlp_endpoint
+  otel_collector_layer_arn       = var.otel_collector_layer_arn
   lambda_log_retention_days      = var.lambda_log_retention_days
 }
 
@@ -117,6 +118,7 @@ module "provider_api" {
   api_gateway_log_retention_days = var.api_gateway_log_retention_days
   otel_enabled                   = var.otel_enabled
   otel_exporter_otlp_endpoint    = var.otel_exporter_otlp_endpoint
+  otel_collector_layer_arn       = var.otel_collector_layer_arn
   lambda_log_retention_days      = var.lambda_log_retention_days
 }
 

--- a/terraform/service/oqtopus-dev/variables.tf
+++ b/terraform/service/oqtopus-dev/variables.tf
@@ -135,3 +135,9 @@ variable "otel_exporter_otlp_endpoint" {
     error_message = "otel_exporter_otlp_endpoint must be set when otel_enabled = true."
   }
 }
+
+variable "otel_collector_layer_arn" {
+  description = "OTel Lambda collector layer ARN. When set, user-api / provider-api export via the in-environment collector (decouple processor) instead of posting to otel_exporter_otlp_endpoint from the request path."
+  type        = string
+  default     = ""
+}

--- a/terraform/service/oqtopus-prod/main.tf
+++ b/terraform/service/oqtopus-prod/main.tf
@@ -73,6 +73,7 @@ module "user_api" {
   api_gateway_log_retention_days         = var.api_gateway_log_retention_days
   otel_enabled                           = var.otel_enabled
   otel_exporter_otlp_endpoint            = var.otel_exporter_otlp_endpoint
+  otel_collector_layer_arn               = var.otel_collector_layer_arn
   lambda_log_retention_days              = var.lambda_log_retention_days
 
   storage_driver = "s3"
@@ -109,6 +110,7 @@ module "provider_api" {
   api_gateway_log_retention_days = var.api_gateway_log_retention_days
   otel_enabled                   = var.otel_enabled
   otel_exporter_otlp_endpoint    = var.otel_exporter_otlp_endpoint
+  otel_collector_layer_arn       = var.otel_collector_layer_arn
   lambda_log_retention_days      = var.lambda_log_retention_days
   storage_driver                 = "s3"
   storage_env_vars_s3 = {

--- a/terraform/service/oqtopus-prod/variables.tf
+++ b/terraform/service/oqtopus-prod/variables.tf
@@ -115,3 +115,9 @@ variable "otel_exporter_otlp_endpoint" {
     error_message = "otel_exporter_otlp_endpoint must be set when otel_enabled = true."
   }
 }
+
+variable "otel_collector_layer_arn" {
+  description = "OTel Lambda collector layer ARN. When set, user-api / provider-api export via the in-environment collector (decouple processor) instead of posting to otel_exporter_otlp_endpoint from the request path."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Adds an opt-in "layer mode" for Lambda trace export. When the new `otel_collector_layer_arn` variable is set, the user/provider API Lambdas attach the [official OTel collector Lambda layer](https://github.com/open-telemetry/opentelemetry-lambda) and export traces to it at `http://localhost:4318` instead of posting to the remote monitoring collector on the request path.

The layer's decouple processor acks spans from memory, so the API response never waits on monitoring health (previously an unreachable collector added up to ~0.4 s to every request). The actual export runs after the response, inside the Lambda extension window, bounded by `timeout: 1s` + `retry max_elapsed_time: 2s` + `sending_queue: enabled: false` — the unbounded default retry (up to 5 min) is what caused ~20 s billed storms in an earlier layer experiment.

The collector config is injected via the layer's `env:` confmap provider (`OPENTELEMETRY_COLLECTOR_CONFIG_URI=env:OTEL_COLLECTOR_CONFIG_CONTENT`), so **no changes to the function zip, app code, or deploy pipeline are needed**. An empty ARN (default) keeps the existing direct-export behavior; rollback is removing one tfvars line.

## Test plan

- `terraform validate` passes for oqtopus-dev / oqtopus-prod
- Collector config validated with `otelcol-contrib 0.151.0 validate` (matches layer 0.22.0's bundled collector)
- Deployed to oqtopus-dev with `otel_collector_layer_arn = arn:aws:lambda:ap-northeast-1:184161586896:layer:opentelemetry-collector-amd64-0_22_0:1`:
  - SnapStart snapshot Init succeeds with the extension (new versions Active)
  - Live `GET /jobs` traffic: traces reach Tempo end-to-end (app → layer collector → monitoring collector :34318 → Tempo), response durations unchanged
  - No exporter errors or deprecation warnings in function logs

## Notes

- `retry_on_failure.max_interval` must stay ≤ `max_elapsed_time`; otherwise the collector fails config validation and the extension refuses to start, which surfaces only as a SnapStart Init failure ("otelcol state is Closed") — hence the comment in the config.
- The exporter type is `otlp_http`: the bundled collector v0.151 deprecates the old `otlphttp` spelling (warns on every cold start).
- oqtopus-prod keeps direct export until `otel_collector_layer_arn` is set in its tfvars.

## Fault-injection test: monitoring outage (2026-07-13, oqtopus-dev)

**Experiment**: intentionally stopped the monitoring collector for 6 minutes (simulating a monitoring outage) while normal traffic (`GET /jobs`, ~every 10 s) kept flowing, and measured response time and billed duration.

| | Monitoring healthy | During outage — direct export (before) | During outage — this PR |
|---|---|---|---|
| API response time | ~600 ms | ~1,000 ms (+0.4 s on every request) | **~600 ms (unchanged)** |
| Lambda billed duration | same as response | same as response | +1.6 s per request<br>(**≈ +$0.2 even if monitoring stays down for a whole day** — at current volume ~8,600 req/day, 1 GB memory) |

- The user-facing impact (+0.4 s on every request) is now measurably zero: telemetry export moved from inside the response to after the response is returned.
- Export retries were cut off at the configured 2 s cap on every request — the ~20 s billed-duration storms seen in the earlier (decouple-less) layer experiment did not recur.
- With monitoring healthy there is no difference at all (measured: avg 615 ms for both response and billed, gap < 1 ms).
- Spans produced during the outage are dropped (accepted best-effort policy); export resumed automatically 12 s after the collector came back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

