### PR TITLE
feat(db): export RDS slow query log to CloudWatch Logs

### DIFF
--- a/backend/alembic/versions/20260724_0623_0e01e14a4bba_add_jobs_indexes.py
+++ b/backend/alembic/versions/20260724_0623_0e01e14a4bba_add_jobs_indexes.py
@@ -1,0 +1,37 @@
+"""add_jobs_indexes
+
+Revision ID: 0e01e14a4bba
+Revises: fc532120ca03
+Create Date: 2026-07-24 06:23:47.955159+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0e01e14a4bba'
+down_revision: Union[str, Sequence[str], None] = 'fc532120ca03'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Monitoring dashboard's per-status queue backlog query
+    # (WHERE status IN (...) GROUP BY device_id, status); status leads so the
+    # filter can range-scan it, and the index alone covers all selected columns.
+    op.create_index("ix_jobs_status_device_id", "jobs", ["status", "device_id"])
+    # Monitoring dashboard's job wait-time query
+    # (WHERE running_at >= ... GROUP BY device_id), which today full-scans
+    # jobs on every scrape since running_at has no index.
+    op.create_index(
+        "ix_jobs_running_at_device_id_submitted_at",
+        "jobs",
+        ["running_at", "device_id", "submitted_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_jobs_running_at_device_id_submitted_at", table_name="jobs")
+    op.drop_index("ix_jobs_status_device_id", table_name="jobs")

--- a/backend/oqtopus_cloud/common/models/job.py
+++ b/backend/oqtopus_cloud/common/models/job.py
@@ -2,7 +2,7 @@ import datetime
 import decimal
 from typing import Optional
 
-from sqlalchemy import Numeric, String, Text, text
+from sqlalchemy import Index, Numeric, String, Text, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from oqtopus_cloud.common.model_util import DateTimeTz
@@ -43,6 +43,15 @@ class Job(Base, TimestampMixin):
     """
 
     __tablename__ = "jobs"
+    __table_args__ = (
+        Index("ix_jobs_status_device_id", "status", "device_id"),
+        Index(
+            "ix_jobs_running_at_device_id_submitted_at",
+            "running_at",
+            "device_id",
+            "submitted_at",
+        ),
+    )
 
     id: Mapped[str] = mapped_column(
         String(64),

--- a/terraform/infrastructure/modules/db/main.tf
+++ b/terraform/infrastructure/modules/db/main.tf
@@ -35,6 +35,7 @@ resource "aws_db_instance" "this" {
   db_name                               = var.db_name
   db_subnet_group_name                  = aws_db_subnet_group.this.name
   deletion_protection                   = "true"
+  enabled_cloudwatch_logs_exports       = ["slowquery"]
   engine                                = "mysql"
   engine_version                        = "8.4.8"
   iam_database_authentication_enabled   = "true"
@@ -100,6 +101,24 @@ resource "aws_db_parameter_group" "this" {
   parameter {
     apply_method = "immediate"
     name         = "log_bin_trust_function_creators"
+    value        = "1"
+  }
+
+  parameter {
+    apply_method = "immediate"
+    name         = "log_output"
+    value        = "FILE"
+  }
+
+  parameter {
+    apply_method = "immediate"
+    name         = "long_query_time"
+    value        = "1"
+  }
+
+  parameter {
+    apply_method = "immediate"
+    name         = "slow_query_log"
     value        = "1"
   }
 }

--- a/terraform/infrastructure/modules/db/main.tf
+++ b/terraform/infrastructure/modules/db/main.tf
@@ -64,6 +64,13 @@ resource "aws_db_instance" "this" {
   lifecycle {
     ignore_changes = [engine_version]
   }
+
+  depends_on = [aws_cloudwatch_log_group.slow_query]
+}
+
+resource "aws_cloudwatch_log_group" "slow_query" {
+  name              = "/aws/rds/instance/${var.product}-${var.org}-${var.env}/slowquery"
+  retention_in_days = var.db_slow_query_log_retention_days
 }
 
 

--- a/terraform/infrastructure/modules/db/variables.tf
+++ b/terraform/infrastructure/modules/db/variables.tf
@@ -43,3 +43,9 @@ variable "db_performance_insights_enabled" {
   description = "DB performance insights enabled"
   type        = bool
 }
+
+variable "db_slow_query_log_retention_days" {
+  description = "Number of days for which slow query logs are retained in CloudWatch Logs"
+  type        = number
+  default     = 14
+}


### PR DESCRIPTION
## Summary

- Enable the MySQL slow query log (`slow_query_log=1`, `long_query_time=1`s) in the DB parameter group and export it to CloudWatch Logs via `enabled_cloudwatch_logs_exports = ["slowquery"]`.
- Set `log_output=FILE`: RDS for MySQL defaults to `TABLE`, which cannot be exported to CloudWatch Logs.
- Pre-create the log group `/aws/rds/instance/<identifier>/slowquery` with 14-day retention (`db_slow_query_log_retention_days`), matching how VPC flow log and API Gateway log groups are managed, instead of letting RDS auto-create it with unlimited retention.
- Add two `jobs` indexes so the monitoring dashboard's queue queries stop full-scanning the table: `(status, device_id)` covers the per-status backlog query, and `(running_at, device_id, submitted_at)` covers the job wait-time query. Both run every 60s from sql-exporter; today they run unindexed against a table with no secondary index at all.

All parameters are dynamic, so applying this requires no DB restart and no downtime. The index creation is a normal online DDL on InnoDB and does not lock writes.

## Test plan

- [x] `terraform validate` / `terraform fmt -check` pass on the module
- [ ] `terraform plan` on a dev environment shows only the parameter group update, log export modification, and new log group
- [ ] After apply, slow query entries (>1s) appear in the `slowquery` CloudWatch log group
- [x] `pytest tests/oqtopus_cloud/user/routers/test_jobs.py tests/oqtopus_cloud/provider/routers/test_jobs.py` passes
- [ ] After migration, `EXPLAIN` on both dashboard queries shows the new indexes used (`Using index` for the status/backlog query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)