### PR TITLE
feat: make DB instance class and Multi-AZ configurable per environment

### DIFF
--- a/terraform/infrastructure/modules/db/main.tf
+++ b/terraform/infrastructure/modules/db/main.tf
@@ -38,7 +38,7 @@ resource "aws_db_instance" "this" {
   engine                                = "mysql"
   engine_version                        = "8.4.8"
   iam_database_authentication_enabled   = "true"
-  instance_class                        = var.db_performance_insights_enabled == true ? "db.t3.medium" : "db.t3.micro"
+  instance_class                        = var.db_instance_class
   iops                                  = "0"
   kms_key_id                            = aws_kms_key.db_storage.arn
   manage_master_user_password           = true #追加 https://tech.dentsusoken.com/entry/terraform_manage_master_user_password
@@ -46,7 +46,7 @@ resource "aws_db_instance" "this" {
   maintenance_window                    = "sat:16:23-sat:16:53"
   max_allocated_storage                 = "1000"
   monitoring_interval                   = "0"
-  multi_az                              = "true"
+  multi_az                              = var.db_multi_az
   network_type                          = "IPV4"
   option_group_name                     = "default:mysql-8-4"
   parameter_group_name                  = aws_db_parameter_group.this.name

--- a/terraform/infrastructure/modules/db/variables.tf
+++ b/terraform/infrastructure/modules/db/variables.tf
@@ -48,6 +48,11 @@ variable "db_instance_class" {
   description = "The instance class for the RDS instance (e.g. db.t4g.micro, db.t4g.small, db.t4g.medium)"
   type        = string
   default     = "db.t4g.medium"
+
+  validation {
+    condition     = can(regex("^db\\.[a-z0-9]+\\.[a-z0-9]+$", var.db_instance_class))
+    error_message = "db_instance_class must be a valid RDS instance class, e.g. db.t4g.medium or db.r6g.2xlarge."
+  }
 }
 
 variable "db_multi_az" {

--- a/terraform/infrastructure/modules/db/variables.tf
+++ b/terraform/infrastructure/modules/db/variables.tf
@@ -43,3 +43,15 @@ variable "db_performance_insights_enabled" {
   description = "DB performance insights enabled"
   type        = bool
 }
+
+variable "db_instance_class" {
+  description = "The instance class for the RDS instance (e.g. db.t4g.micro, db.t4g.small, db.t4g.medium)"
+  type        = string
+  default     = "db.t4g.medium"
+}
+
+variable "db_multi_az" {
+  description = "Whether to deploy the RDS instance in Multi-AZ for high availability"
+  type        = bool
+  default     = true
+}

--- a/terraform/infrastructure/oqtopus-dev/main.tf
+++ b/terraform/infrastructure/oqtopus-dev/main.tf
@@ -45,7 +45,9 @@ module "db" {
   db_name                         = "main"
   user_name                       = var.db_user_name
   db_proxy_security_group_ids     = module.security_group.db_proxy_security_group_ids
-  db_performance_insights_enabled = true
+  db_instance_class               = "db.t4g.micro"
+  db_multi_az                     = false
+  db_performance_insights_enabled = false
 }
 
 module "management" {

--- a/terraform/infrastructure/oqtopus-prod/main.tf
+++ b/terraform/infrastructure/oqtopus-prod/main.tf
@@ -45,6 +45,8 @@ module "db" {
   db_name                         = "main"
   user_name                       = var.db_user_name
   db_proxy_security_group_ids     = module.security_group.db_proxy_security_group_ids
+  db_instance_class               = "db.t4g.medium"
+  db_multi_az                     = true
   db_performance_insights_enabled = true
 }
 


### PR DESCRIPTION
## Summary

The RDS instance class was previously derived indirectly from the Performance Insights flag (`db.t3.medium` when enabled, `db.t3.micro` otherwise) and `multi_az` was hardcoded to `true`, so neither could be set per environment. This makes both explicit, configurable module inputs and applies right-sizing to `dev` while keeping `prod` capacity intact.

## Changes

- **`modules/db`**: add explicit `db_instance_class` (default `db.t4g.medium`) and `db_multi_az` (default `true`) variables; wire `instance_class` and `multi_az` to them. `db_instance_class` has a format validation to catch typos before apply.
- **`dev`**: `db.t4g.micro` / Single-AZ / Performance Insights disabled. dev runs at single-digit CPU and a few GB; PI is unsupported on micro anyway.
- **`prod`**: `db.t4g.medium` / Multi-AZ / Performance Insights kept. Graviton `t4g.medium` has the same 2 vCPU / 4 GB as `t3.medium` at ~10% lower cost — **capacity is unchanged**, this is a family swap, not a downsize.

## Verification

- `terraform fmt` clean on changed files.
- Reviewed `terraform plan` intent per environment:
  - `dev`: in-place modify (instance class + Multi-AZ → Single-AZ + PI off). Instance-class change reboots; not a destroy/recreate.
  - `prod`: `t3.medium → t4g.medium` is an in-place instance-class modify (one reboot; Multi-AZ failover). No change to Multi-AZ or PI.
- Plan should be run against each environment's state before merge/apply.

## Follow-ups

- **prod downsize to `small`** is intentionally *not* included here — pending an index/query review (Performance Insights) to confirm the memory headroom (currently ~65–67%).
- A cross-variable guard (reject Performance Insights on micro/small classes) was considered but left out: it requires validation referencing another variable, whose failure mode (config load error) was judged too risky versus the marginal benefit. Documenting the "PI requires `medium`+" constraint here instead.