### PR TITLE
Fix : remove AWS CloudTrail dependency from terraform

### DIFF
--- a/backend/auth-demo/README.md
+++ b/backend/auth-demo/README.md
@@ -1,0 +1,142 @@
+# Flexible Auth Demo — OIDC (oauth2-proxy + Keycloak + LDAP)
+
+This demo runs the OQTOPUS **User API** locally with authentication decoupled
+from AWS Cognito. Instead, the browser authenticates against a standard **OIDC**
+provider (Keycloak), which federates an internal **LDAP** directory, fronted by
+**oauth2-proxy**. The API no longer depends on Amplify/Cognito — it just verifies
+an OIDC JWT and enforces its own authorization.
+
+## Why this exists
+
+The requirement is to deploy the whole stack **on an internal network without
+AWS**, letting the SPA drop its Cognito/Amplify dependency and authenticate via
+any OIDC-compliant server (and, behind it, LDAP). We split the concerns the way
+the AWS Lambda authorizer already did — just relocated:
+
+| Concern | AWS (prod) | This demo (local / on-prem) |
+| --- | --- | --- |
+| **Authentication** (who are you?) | API Gateway → Lambda authorizer verifies Cognito JWT | **oauth2-proxy + Keycloak (+ LDAP)**; the API verifies the OIDC JWT |
+| **Authorization** (may you in?) | Lambda authorizer: DB `userstatus == approved` | **In-app** middleware: same DB check (`common/auth/authorization.py`) |
+| **Identity contract** | `authorizer["user_id"]` (= email) | `email` claim → `request.state.user_id` (unchanged downstream) |
+
+The switch is the `AUTH_MODE` environment variable (`aws` | `oidc` | `local`).
+`ENV=local` still controls DB/storage wiring only — auth is now independent.
+
+## Topology
+
+```
+Browser
+  └─(session cookie)─▶ oauth2-proxy  :4180   ── OIDC ──▶ Keycloak :8081
+                          │                                  └─ LDAP federation ─▶ OpenLDAP :389
+                          └─(Authorization: Bearer <id_token>)─▶ user-api :8080
+                                                                   ├─ verify JWT vs Keycloak JWKS
+                                                                   ├─ user_id = email claim
+                                                                   └─ authorize: users.userstatus == approved
+```
+
+## Prerequisites
+
+- Docker + Docker Compose
+- Run from the `backend/` directory
+
+## Start
+
+```bash
+cd backend
+
+# 1) Bring up the full stack (base services + auth overlay)
+docker compose -f compose.yaml -f compose.auth.yaml up -d --build
+
+# 2) Apply DB migrations and seed (creates the approved demo user
+#    demo@oqtopus.local). These talk to the DB on localhost:3306.
+make migrate-up
+make seed
+```
+
+Wait ~30–60s for Keycloak to import the realm and OpenLDAP to seed
+(OpenLDAP runs under amd64 emulation on Apple Silicon, so first boot is slow).
+
+## Demo credentials
+
+| What | Value |
+| --- | --- |
+| LDAP demo user | `demo` / `demopassword` (email `demo@oqtopus.local`) |
+| Keycloak admin console | http://localhost:8081  (admin / admin) |
+| oauth2-proxy (app entry) | http://localhost:4180 |
+| User API (direct) | http://localhost:8080 |
+
+## Try it — browser (full flow)
+
+Open <http://localhost:4180/users/me> in a browser. You'll be redirected to
+Keycloak, log in as `demo` / `demopassword`, and land back on the User API
+response for the authenticated user — e.g.
+
+```json
+{"id":"demo@oqtopus.local","email":"demo@oqtopus.local","name":"OQTOPUS Demo User", ...}
+```
+
+## Try it — scripted (no browser)
+
+This exercises exactly the API-side auth seam (OIDC verify + authorization),
+getting a token straight from Keycloak via the password grant:
+
+```bash
+# 1) Get an ID token for the LDAP-backed demo user
+ID_TOKEN=$(curl -s \
+  -d grant_type=password \
+  -d client_id=oqtopus-oauth2-proxy \
+  -d client_secret=oauth2-proxy-secret \
+  -d username=demo -d password=demopassword \
+  -d scope=openid \
+  http://localhost:8081/realms/oqtopus/protocol/openid-connect/token \
+  | python3 -c 'import sys,json;print(json.load(sys.stdin)["id_token"])')
+
+# 2) Call the User API with the token
+curl -s -H "Authorization: Bearer $ID_TOKEN" http://localhost:8080/users/me | python3 -m json.tool
+curl -s -H "Authorization: Bearer $ID_TOKEN" http://localhost:8080/devices | python3 -m json.tool
+
+# 3) Negative checks
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/users/me                       # 401 (no token)
+curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer bad.jwt" http://localhost:8080/users/me  # 401
+```
+
+> Note: `/users/me` also exposes an AWS-CloudTrail-backed *login history*; that
+> feature is disabled in this demo (`LOGIN_HISTORY_ENABLED=false`) because it
+> requires AWS. Everything else (identity + authorization) is fully local.
+
+## How the pieces are configured
+
+- `compose.auth.yaml` — the overlay: `openldap`, `keycloak`, `oauth2-proxy`, and
+  the `user-api` override (`AUTH_MODE=oidc` + `OIDC_*`).
+- `auth-demo/ldap/demo.ldif` — the seed directory entry (uid=demo, mail=…).
+- `auth-demo/keycloak/realm.json` — realm `oqtopus`, the `oqtopus-oauth2-proxy`
+  client, and the LDAP user-federation provider + attribute mappers.
+
+### The Keycloak-in-Docker hostname split
+
+Tokens must carry a stable `iss` that both the browser and the in-network
+services agree on. Keycloak is pinned to `KC_HOSTNAME=http://localhost:8081`
+(so `iss` and browser redirects use `localhost:8081`), while
+`KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true` lets in-network services still reach it at
+`http://keycloak:8080`. Hence:
+
+- `OIDC_ISSUER = http://localhost:8081/realms/oqtopus` (matches the token `iss`)
+- `OIDC_JWKS_URL = http://keycloak:8080/realms/oqtopus/.../certs` (reachable from user-api)
+
+## Mapping back to production / a real deployment
+
+- To point at a **different OIDC provider** (incl. Cognito), change only the
+  `OIDC_ISSUER` / `OIDC_JWKS_URL` / `OIDC_AUDIENCE` / `OIDC_USERNAME_CLAIM` env
+  vars — no code changes. The verification in `common/auth/oidc.py` is generic.
+- The AWS production path is untouched: with `AUTH_MODE` unset (and not
+  `ENV=local`) the API still reads the API Gateway Lambda-authorizer context.
+- **Machine clients** (`quri-parts-oqtopus`, `q-api-token`) are out of scope for
+  this browser-OIDC demo; that path stays in-app (DB-backed API tokens) and can
+  be wired so oauth2-proxy skips requests carrying `Q-API-Token`.
+
+## Stop / reset
+
+```bash
+docker compose -f compose.yaml -f compose.auth.yaml down          # stop
+docker compose -f compose.yaml -f compose.auth.yaml down -v       # + wipe volumes
+```

--- a/backend/auth-demo/README.md
+++ b/backend/auth-demo/README.md
@@ -134,9 +134,121 @@ services agree on. Keycloak is pinned to `KC_HOSTNAME=http://localhost:8081`
   this browser-OIDC demo; that path stays in-app (DB-backed API tokens) and can
   be wired so oauth2-proxy skips requests carrying `Q-API-Token`.
 
+---
+
+# Frontend (SPA) via BFF
+
+The sections above authenticate the **API**. This part puts the **oqtopus-frontend
+SPA** in front of it using the BFF (Backend-For-Frontend) pattern: a single-origin
+reverse proxy (nginx) fronts the SPA and the API, and oauth2-proxy owns the entire
+login lifecycle. **The SPA holds no tokens and is auth-unaware** — it only asks
+"who am I?" via `/oauth2/userinfo` and hands off to the proxy to log in.
+
+```
+Browser ─cookie─▶ nginx :4200 ─┬─ /          → SPA static (oqtopus-frontend/dist)
+                               ├─ /oauth2/*  → oauth2-proxy → Keycloak :8081 → LDAP
+                               └─ /api/*     → (auth_request) → user-api :8080
+                                              nginx injects the id_token oauth2-proxy
+                                              returns, and strips the /api prefix.
+```
+
+## Frontend changes — pluggable auth drivers (`cognito` | `proxy`)
+
+Auth is a **pluggable driver** selected by `VITE_APP_AUTH_MODE`; the rest of the
+app depends only on the driver contract, never on a specific identity provider.
+
+```
+src/auth/
+  contract.ts      # UseAuth (the driver contract), Result, AuthContext
+  hook.ts          # useAuth()
+  Provider.tsx     # registry: lazy-loads the driver for AUTH_MODE (code-split)
+  drivers/
+    cognito.tsx    # CognitoAuthProvider — isolates aws-amplify
+    proxy.tsx      # ProxyAuthProvider — BFF: userinfo/redirect only, no tokens
+```
+
+- The registry picks the driver from a **build-time constant**, so the unused
+  driver (and its deps) is dead-code-eliminated: a `proxy` build ships **no
+  aws-amplify/Cognito code**, a `cognito` build ships no proxy driver. Set
+  `VITE_APP_AUTH_MODE` explicitly at build time for a fully-split bundle.
+- **proxy driver**: login state from `/oauth2/userinfo`; `signIn`/`signOut` are
+  redirects to `/oauth2/start` / `/logout`; sign-up / MFA / password-reset are
+  delegated to Keycloak (see below). No `Authorization` header — the proxy
+  injects the token. API base defaults to same-origin `/api`.
+- **cognito driver**: the original Amplify/Cognito flows, unchanged.
+- Adding a new backend = add `drivers/<name>.tsx` returning a `UseAuth` and a
+  branch in `Provider.tsx`. `src/env/index.ts` also exposes `AUTH_MODE`.
+
+## Run it
+
+```bash
+# 1) Build the SPA in proxy mode (from the frontend repo)
+cd ../../oqtopus-frontend        # adjust to your checkout
+bun install
+VITE_APP_AUTH_MODE=proxy \
+  VITE_APP_ACCOUNT_CONSOLE_URL=http://localhost:8081/realms/oqtopus/account/ \
+  bun run build
+
+# 2) Bring up the full stack incl. nginx + SPA (from backend/)
+cd -                             # back to backend/
+docker compose -f compose.yaml -f compose.auth.yaml -f compose.frontend.yaml up -d --build
+make migrate-up && make seed     # if not already seeded
+```
+
+Then open <http://localhost:4200/dashboard> in a browser:
+
+1. You're redirected to Keycloak and log in as **`demo` / `demopassword`** (LDAP).
+2. **First login forces TOTP (MFA) enrollment** — scan the QR with an authenticator
+   app (Google Authenticator, etc.) and enter the 6-digit code. Subsequent logins
+   require that code.
+3. You land back in the SPA, authenticated; its API calls flow through nginx →
+   user-api with the proxy-injected token.
+
+MFA is enforced by Keycloak's realm (`requiredActions: CONFIGURE_TOTP`,
+`defaultAction: true` in `auth-demo/keycloak/realm.json`) — no MFA code lives in
+the SPA or the backend anymore.
+
+### Password change & MFA reset (proxy mode)
+
+These are delegated to Keycloak's self-service **Account Console** rather than
+reimplemented in the SPA. In proxy mode, **Settings → Account** shows a
+"Change password in Keycloak" button and **Settings → Security** shows a
+"Manage MFA in Keycloak" button; both open
+`…/realms/oqtopus/account/#/security/signing-in` (via `VITE_APP_ACCOUNT_CONSOLE_URL`),
+where the user can change their password and add/remove their OTP authenticator
+(= MFA reset). The existing Keycloak SSO session is reused, so no re-login is
+needed. Logout uses RP-initiated logout (`/logout` → Keycloak end-session with
+`id_token_hint` captured server-side by nginx+njs) so no confirmation prompt
+appears and both the proxy and IdP sessions end.
+
+## Configuration files
+
+- `compose.frontend.yaml` — adds `nginx`, switches oauth2-proxy to nginx
+  `auth_request` mode (`--set-authorization-header`), and mounts the SPA `dist/`.
+- `auth-demo/nginx/nginx.conf` — the single-origin front door (static + `/oauth2`
+  + `auth_request`-gated `/api` with prefix strip and Bearer injection).
+
+## Mapping to production
+
+- Any single-origin reverse proxy (nginx/ALB/CloudFront+Lambda@Edge, or a custom
+  BFF) can play nginx's role; oauth2-proxy stays the auth layer. The SPA build is
+  provider-agnostic — only `VITE_APP_AUTH_MODE` and the proxy config change.
+- The **Cognito/AWS** path is fully preserved: build without `VITE_APP_AUTH_MODE`
+  (or `=cognito`) and the SPA keeps its Amplify login, MFA and signup screens.
+- Login/sign-up/MFA/password UI is served by **Keycloak** (themeable — see
+  Keycloak themes / `keycloakify` to reproduce the brand). The SPA's
+  `src/pages/auth/**` screens are used only in `cognito` mode.
+
 ## Stop / reset
 
 ```bash
-docker compose -f compose.yaml -f compose.auth.yaml down          # stop
-docker compose -f compose.yaml -f compose.auth.yaml down -v       # + wipe volumes
+# API-only demo
+docker compose -f compose.yaml -f compose.auth.yaml down            # stop
+docker compose -f compose.yaml -f compose.auth.yaml down -v         # + wipe volumes
+
+# Full frontend BFF demo (add -f compose.frontend.yaml)
+docker compose -f compose.yaml -f compose.auth.yaml -f compose.frontend.yaml down
 ```
+
+> Recreating the `keycloak` container resets its in-memory dev DB, so the demo
+> user must re-enroll TOTP on the next login (expected for this ephemeral demo).

--- a/backend/auth-demo/keycloak/realm.json
+++ b/backend/auth-demo/keycloak/realm.json
@@ -1,0 +1,122 @@
+{
+  "realm": "oqtopus",
+  "enabled": true,
+  "sslRequired": "none",
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "registrationAllowed": false,
+  "resetPasswordAllowed": true,
+  "editUsernameAllowed": false,
+  "clients": [
+    {
+      "clientId": "oqtopus-oauth2-proxy",
+      "name": "OQTOPUS oauth2-proxy",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "oauth2-proxy-secret",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://localhost:4180/oauth2/callback",
+        "http://localhost:4180/*"
+      ],
+      "webOrigins": [
+        "http://localhost:4180"
+      ],
+      "defaultClientScopes": [
+        "openid",
+        "email",
+        "profile",
+        "roles",
+        "web-origins"
+      ],
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      }
+    }
+  ],
+  "components": {
+    "org.keycloak.storage.UserStorageProvider": [
+      {
+        "name": "ldap",
+        "providerId": "ldap",
+        "config": {
+          "enabled": ["true"],
+          "priority": ["0"],
+          "fullSyncPeriod": ["-1"],
+          "changedSyncPeriod": ["-1"],
+          "cachePolicy": ["DEFAULT"],
+          "batchSizeForSync": ["1000"],
+          "editMode": ["READ_ONLY"],
+          "importEnabled": ["true"],
+          "syncRegistrations": ["false"],
+          "vendor": ["other"],
+          "usePasswordModifyExtendedOp": ["false"],
+          "usernameLDAPAttribute": ["uid"],
+          "rdnLDAPAttribute": ["uid"],
+          "uuidLDAPAttribute": ["entryUUID"],
+          "userObjectClasses": ["inetOrgPerson"],
+          "connectionUrl": ["ldap://openldap:389"],
+          "usersDn": ["ou=people,dc=oqtopus,dc=local"],
+          "authType": ["simple"],
+          "bindDn": ["cn=admin,dc=oqtopus,dc=local"],
+          "bindCredential": ["admin"],
+          "searchScope": ["1"],
+          "pagination": ["true"],
+          "connectionPooling": ["true"],
+          "allowKerberosAuthentication": ["false"]
+        },
+        "subComponents": {
+          "org.keycloak.storage.ldap.mappers.LDAPStorageMapper": [
+            {
+              "name": "username",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "user.model.attribute": ["username"],
+                "ldap.attribute": ["uid"],
+                "read.only": ["true"],
+                "always.read.value.from.ldap": ["false"],
+                "is.mandatory.in.ldap": ["true"]
+              }
+            },
+            {
+              "name": "email",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "user.model.attribute": ["email"],
+                "ldap.attribute": ["mail"],
+                "read.only": ["true"],
+                "always.read.value.from.ldap": ["true"],
+                "is.mandatory.in.ldap": ["false"]
+              }
+            },
+            {
+              "name": "first name",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "user.model.attribute": ["firstName"],
+                "ldap.attribute": ["givenName"],
+                "read.only": ["true"],
+                "always.read.value.from.ldap": ["true"],
+                "is.mandatory.in.ldap": ["false"]
+              }
+            },
+            {
+              "name": "last name",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "user.model.attribute": ["lastName"],
+                "ldap.attribute": ["sn"],
+                "read.only": ["true"],
+                "always.read.value.from.ldap": ["true"],
+                "is.mandatory.in.ldap": ["true"]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/backend/auth-demo/keycloak/realm.json
+++ b/backend/auth-demo/keycloak/realm.json
@@ -7,6 +7,26 @@
   "registrationAllowed": false,
   "resetPasswordAllowed": true,
   "editUsernameAllowed": false,
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": true,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    }
+  ],
   "clients": [
     {
       "clientId": "oqtopus-oauth2-proxy",
@@ -20,10 +40,13 @@
       "serviceAccountsEnabled": false,
       "redirectUris": [
         "http://localhost:4180/oauth2/callback",
-        "http://localhost:4180/*"
+        "http://localhost:4180/*",
+        "http://localhost:4200/oauth2/callback",
+        "http://localhost:4200/*"
       ],
       "webOrigins": [
-        "http://localhost:4180"
+        "http://localhost:4180",
+        "http://localhost:4200"
       ],
       "defaultClientScopes": [
         "openid",

--- a/backend/auth-demo/ldap/demo.ldif
+++ b/backend/auth-demo/ldap/demo.ldif
@@ -1,0 +1,20 @@
+# Seed tree for the flexible-auth demo.
+# Applied by bitnami/openldap via LDAP_CUSTOM_LDIF_DIR after the base
+# dc=oqtopus,dc=local suffix and cn=admin bind account are created.
+#
+# The demo user's `mail` is the identity that flows all the way through:
+#   LDAP mail -> Keycloak `email` claim -> oauth2-proxy -> user-api user_id
+#             -> DB users.id (seeded as approved in scripts/seed.py)
+
+dn: ou=people,dc=oqtopus,dc=local
+objectClass: organizationalUnit
+ou: people
+
+dn: uid=demo,ou=people,dc=oqtopus,dc=local
+objectClass: inetOrgPerson
+uid: demo
+cn: OQTOPUS Demo User
+sn: Demo
+givenName: OQTOPUS
+mail: demo@oqtopus.local
+userPassword: demopassword

--- a/backend/auth-demo/nginx/logout.js
+++ b/backend/auth-demo/nginx/logout.js
@@ -1,0 +1,27 @@
+// RP-initiated logout helper for the BFF front door.
+//
+// Invoked as a content handler AFTER `auth_request`, so the id_token that
+// oauth2-proxy returned (in the Authorization header, captured into
+// $logout_bearer via auth_request_set) is available here. We pass it as
+// `id_token_hint` so Keycloak logs out silently (no confirmation page), and set
+// `post_logout_redirect_uri` back through /oauth2/sign_out to also clear the
+// oauth2-proxy session cookie. The token is used server-side only — it never
+// reaches the browser JS.
+
+var KEYCLOAK_LOGOUT =
+  'http://localhost:8081/realms/oqtopus/protocol/openid-connect/logout';
+// After the IdP logout, bounce through the proxy sign_out (clears its cookie),
+// then land on the app root.
+var POST_LOGOUT = 'http://localhost:4200/oauth2/sign_out?rd=/';
+
+function redirect(r) {
+  var bearer = r.variables.logout_bearer || '';
+  var idToken = bearer.replace(/^Bearer\s+/i, '');
+  var url =
+    KEYCLOAK_LOGOUT +
+    '?id_token_hint=' + idToken +
+    '&post_logout_redirect_uri=' + encodeURIComponent(POST_LOGOUT);
+  r.return(302, url);
+}
+
+export default { redirect };

--- a/backend/auth-demo/nginx/nginx-main.conf
+++ b/backend/auth-demo/nginx/nginx-main.conf
@@ -1,0 +1,30 @@
+# Main nginx config for the frontend demo — identical to the stock image config
+# except it loads the njs module (used by /logout to build an RP-initiated
+# logout URL with id_token_hint captured server-side).
+load_module modules/ngx_http_js_module.so;
+
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/backend/auth-demo/nginx/nginx.conf
+++ b/backend/auth-demo/nginx/nginx.conf
@@ -1,0 +1,99 @@
+# Single-origin BFF front door for the flexible-auth frontend demo.
+#
+#   /          -> SPA static files (with SPA history fallback)
+#   /oauth2/*  -> oauth2-proxy (login, callback, userinfo, sign_out)
+#   /api/*     -> user-api, gated by an auth_request subrequest to oauth2-proxy.
+#                 On success nginx forwards the id_token (which oauth2-proxy
+#                 returns in the Authorization header) to the backend and strips
+#                 the /api prefix. On 401 it redirects the browser to login.
+
+js_import logout from /etc/nginx/njs/logout.js;
+
+server {
+    listen 80;
+    server_name _;
+
+    # nginx listens on :80 inside the container but is published on :4200; keep
+    # redirects relative so the browser's real origin (host:port) is preserved.
+    absolute_redirect off;
+
+    # oauth2-proxy session cookies + Keycloak's large KC_RESTART cookie make the
+    # request Cookie header exceed the default 8k buffer → 400. Enlarge it.
+    large_client_header_buffers 8 32k;
+    client_header_buffer_size 8k;
+
+    # Upstream (oauth2-proxy / API) may return large headers (Bearer id_token).
+    proxy_buffer_size 16k;
+    proxy_buffers 8 16k;
+    proxy_busy_buffers_size 32k;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # --- oauth2-proxy public endpoints (start / callback / userinfo / sign_out) ---
+    location /oauth2/ {
+        proxy_pass http://oauth2-proxy:4180;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Auth-Request-Redirect $request_uri;
+    }
+
+    # --- internal auth check used by auth_request below ---
+    location = /oauth2/auth {
+        internal;
+        proxy_pass http://oauth2-proxy:4180;
+        proxy_set_header Host             $host;
+        proxy_set_header X-Real-IP        $remote_addr;
+        proxy_set_header X-Forwarded-For  $proxy_add_x_forwarded_for;
+        # No request body / large headers needed for the auth subrequest.
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length   "";
+    }
+
+    # --- protected API: verify session, inject Bearer, strip /api, proxy to backend ---
+    location /api/ {
+        auth_request /oauth2/auth;
+
+        # oauth2-proxy (--set-authorization-header) returns the id_token in the
+        # Authorization header of the auth subrequest response; capture + forward.
+        auth_request_set $auth_authorization $upstream_http_authorization;
+
+        # If unauthenticated, send the browser through the login flow.
+        error_page 401 = @proxy_signin;
+
+        proxy_set_header Authorization $auth_authorization;
+        proxy_set_header Host          $host;
+        proxy_set_header X-Real-IP     $remote_addr;
+
+        rewrite ^/api/(.*)$ /$1 break;
+        proxy_pass http://user-api:8080;
+    }
+
+    # RP-initiated logout without a Keycloak confirmation page: capture the
+    # id_token server-side (from oauth2-proxy's auth response) and pass it as
+    # id_token_hint. Keycloak then logs out silently and, via
+    # post_logout_redirect_uri, returns through /oauth2/sign_out (which clears
+    # the oauth2-proxy session cookie) back to the app. The token never reaches
+    # the browser JS — BFF is preserved.
+    location = /logout {
+        auth_request /oauth2/auth;
+        auth_request_set $logout_bearer $upstream_http_authorization;
+        error_page 401 = @proxy_signin;
+        # js_content is a content-phase handler, so auth_request (access phase)
+        # runs first and $logout_bearer is populated before the njs code reads it.
+        js_content logout.redirect;
+    }
+
+    location @proxy_signin {
+        # Relative redirect keeps the browser's current origin (host:port); rd is
+        # a relative path oauth2-proxy accepts for post-login return.
+        return 302 /oauth2/start?rd=$request_uri;
+    }
+
+    # --- SPA static assets with client-side-routing fallback ---
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/backend/compose.auth.yaml
+++ b/backend/compose.auth.yaml
@@ -1,0 +1,111 @@
+# Flexible-auth demonstration overlay.
+#
+# Use together with the base compose file:
+#
+#   docker compose -f compose.yaml -f compose.auth.yaml up -d
+#
+# It layers an OIDC auth stack in front of the User API without changing the
+# default local-dev experience of `compose.yaml`:
+#
+#   Browser
+#     -> oauth2-proxy (:4180)   authentication (OIDC, session cookie)
+#        -> Keycloak (:8081)     OIDC provider, federates ...
+#           -> OpenLDAP (:389)   directory of users (uid=demo / demopassword)
+#        -> user-api (:8080)     verifies the OIDC JWT + authorizes (DB status)
+#
+# The User API is switched to AUTH_MODE=oidc here (ENV stays `local`, so DB /
+# storage behavior is unchanged). It verifies the Bearer JWT that oauth2-proxy
+# forwards, against Keycloak's JWKS, and resolves the caller from the `email`
+# claim -- which must match an approved row in `users` (see scripts/seed.py:
+# demo@oqtopus.local).
+
+services:
+  openldap:
+    image: osixia/openldap:1.5.0
+    # osixia publishes amd64 only; run under emulation on Apple Silicon.
+    platform: linux/amd64
+    # --copy-service makes the entrypoint pick up the bootstrap LDIF mounted
+    # below and apply it on first init.
+    command: ["--copy-service"]
+    environment:
+      LDAP_ORGANISATION: "OQTOPUS"
+      LDAP_DOMAIN: "oqtopus.local"
+      LDAP_ADMIN_PASSWORD: "admin"
+    volumes:
+      - ./auth-demo/ldap/demo.ldif:/container/service/slapd/assets/config/bootstrap/ldif/custom/50-demo.ldif:ro
+    ports:
+      - "389:389"
+    restart: unless-stopped
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.0
+    command: ["start-dev", "--import-realm"]
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      # Fixed public URL so the `iss` claim and browser redirects are stable
+      # at localhost:8081; backchannel-dynamic lets in-network services still
+      # reach Keycloak at http://keycloak:8080.
+      KC_HOSTNAME: "http://localhost:8081"
+      KC_HOSTNAME_BACKCHANNEL_DYNAMIC: "true"
+      KC_HTTP_ENABLED: "true"
+      KC_HEALTH_ENABLED: "true"
+    volumes:
+      - ./auth-demo/keycloak/realm.json:/opt/keycloak/data/import/realm.json:ro
+    depends_on:
+      openldap:
+        condition: service_started
+    ports:
+      - "8081:8080"
+    restart: unless-stopped
+
+  oauth2-proxy:
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
+    depends_on:
+      keycloak:
+        condition: service_started
+      user-api:
+        condition: service_started
+    command:
+      - --provider=oidc
+      - --oidc-issuer-url=http://localhost:8081/realms/oqtopus
+      - --skip-oidc-discovery=true
+      - --login-url=http://localhost:8081/realms/oqtopus/protocol/openid-connect/auth
+      - --redeem-url=http://keycloak:8080/realms/oqtopus/protocol/openid-connect/token
+      - --oidc-jwks-url=http://keycloak:8080/realms/oqtopus/protocol/openid-connect/certs
+      - --client-id=oqtopus-oauth2-proxy
+      - --client-secret=oauth2-proxy-secret
+      - --redirect-url=http://localhost:4180/oauth2/callback
+      - --upstream=http://user-api:8080
+      - --http-address=0.0.0.0:4180
+      - --cookie-secret=0123456789abcdef0123456789abcdef
+      - --cookie-secure=false
+      - --email-domain=*
+      - --scope=openid email profile
+      - --insecure-oidc-allow-unverified-email=true
+      - --skip-provider-button=true
+      - --pass-authorization-header=true
+      - --pass-access-token=true
+      - --set-xauthrequest=true
+      - --pass-user-headers=true
+    ports:
+      - "4180:4180"
+    restart: unless-stopped
+
+  # Switch the User API to OIDC auth for the demo. ENV stays `local` so the
+  # DB/MinIO wiring is unchanged; AUTH_MODE is the independent switch that
+  # controls only how the caller identity is resolved.
+  user-api:
+    environment:
+      AUTH_MODE: oidc
+      OIDC_ISSUER: "http://localhost:8081/realms/oqtopus"
+      OIDC_JWKS_URL: "http://keycloak:8080/realms/oqtopus/protocol/openid-connect/certs"
+      OIDC_AUDIENCE: "oqtopus-oauth2-proxy"
+      OIDC_USERNAME_CLAIM: "email"
+      AUTH_ENFORCE_STATUS: "true"
+      # Login history is an AWS-only feature (CloudTrail); disable it in the
+      # non-AWS OIDC deployment so /users/me does not require a region/AWS creds.
+      LOGIN_HISTORY_ENABLED: "false"
+    depends_on:
+      keycloak:
+        condition: service_started

--- a/backend/compose.frontend.yaml
+++ b/backend/compose.frontend.yaml
@@ -1,0 +1,64 @@
+# Frontend (SPA) BFF demo overlay — layers on top of compose.yaml + compose.auth.yaml:
+#
+#   docker compose -f compose.yaml -f compose.auth.yaml -f compose.frontend.yaml up -d
+#
+# It puts the SPA and the API behind a single-origin front door (nginx :4200)
+# and switches oauth2-proxy into nginx auth_request mode. The SPA is built with
+# VITE_APP_AUTH_MODE=proxy and holds no tokens; nginx injects the id_token that
+# oauth2-proxy returns into the /api requests it forwards to the backend.
+#
+#   Browser -> nginx :4200 ─┬─ /         -> SPA static (oqtopus-frontend/dist)
+#                           ├─ /oauth2/* -> oauth2-proxy -> Keycloak :8081 -> LDAP
+#                           └─ /api/*     -> (auth_request) -> user-api :8080
+#
+# Prereq: build the SPA first (from the oqtopus-frontend repo):
+#   VITE_APP_AUTH_MODE=proxy bun run build
+
+services:
+  # Reconfigure oauth2-proxy for nginx auth_request mode (no direct upstream;
+  # it only validates the session and hands nginx the id_token).
+  oauth2-proxy:
+    command:
+      - --http-address=0.0.0.0:4180
+      - --reverse-proxy=true
+      - --provider=oidc
+      - --oidc-issuer-url=http://localhost:8081/realms/oqtopus
+      - --skip-oidc-discovery=true
+      - --login-url=http://localhost:8081/realms/oqtopus/protocol/openid-connect/auth
+      - --redeem-url=http://keycloak:8080/realms/oqtopus/protocol/openid-connect/token
+      - --oidc-jwks-url=http://keycloak:8080/realms/oqtopus/protocol/openid-connect/certs
+      - --client-id=oqtopus-oauth2-proxy
+      - --client-secret=oauth2-proxy-secret
+      - --redirect-url=http://localhost:4200/oauth2/callback
+      - --upstream=static://200
+      - --cookie-secret=0123456789abcdef0123456789abcdef
+      - --cookie-secure=false
+      - --email-domain=*
+      - --scope=openid email profile
+      - --insecure-oidc-allow-unverified-email=true
+      # Return the id_token in the Authorization header of the auth subrequest
+      # so nginx can forward it to the backend.
+      - --set-authorization-header=true
+      - --set-xauthrequest=true
+      - --whitelist-domain=localhost:4200
+      # Allow the post-sign_out redirect to Keycloak's end-session endpoint
+      # (RP-initiated logout).
+      - --whitelist-domain=localhost:8081
+
+  nginx:
+    image: nginx:1.27-alpine
+    depends_on:
+      oauth2-proxy:
+        condition: service_started
+      user-api:
+        condition: service_started
+    volumes:
+      - ./auth-demo/nginx/nginx-main.conf:/etc/nginx/nginx.conf:ro
+      - ./auth-demo/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./auth-demo/nginx/logout.js:/etc/nginx/njs/logout.js:ro
+      # SPA build output from the sibling frontend repo (build with
+      # VITE_APP_AUTH_MODE=proxy). Adjust the path if your checkout differs.
+      - ../../oqtopus-frontend/dist:/usr/share/nginx/html:ro
+    ports:
+      - "4200:80"
+    restart: unless-stopped

--- a/backend/oqtopus_cloud/common/auth/__init__.py
+++ b/backend/oqtopus_cloud/common/auth/__init__.py
@@ -1,0 +1,31 @@
+"""Flexible authentication/authorization for the OQTOPUS backend.
+
+Historically the User API trusted a single identity contract: the API Gateway
+Lambda authorizer verified the caller's Cognito ID token (or ``q-api-token``)
+and injected ``requestContext.authorizer["user_id"]``, which the FastAPI
+middleware read into ``request.state.user_id``.
+
+To let the whole stack run outside AWS (e.g. on an internal network fronted by
+oauth2-proxy + Keycloak + LDAP), identity resolution is now pluggable via the
+``AUTH_MODE`` environment variable:
+
+- ``aws``   : read the identity from the API Gateway authorizer context
+              (Mangum ``request.scope["aws.event"]``). Unchanged prod behavior.
+- ``oidc``  : verify a Bearer JWT against any OIDC issuer (JWKS) and derive the
+              identity from a configurable claim. Authorization (account-status
+              check) is enforced in-app, replacing what the Lambda authorizer
+              did upstream.
+- ``local`` : hardcoded developer identity (the existing ``ENV=local`` bypass).
+
+When ``AUTH_MODE`` is unset the mode defaults to ``local`` if ``ENV=local`` else
+``aws`` -- so existing deployments and tests behave exactly as before.
+"""
+
+from oqtopus_cloud.common.auth.identity import (
+    AuthError,
+    Identity,
+    auth_mode,
+    resolve_identity,
+)
+
+__all__ = ["AuthError", "Identity", "auth_mode", "resolve_identity"]

--- a/backend/oqtopus_cloud/common/auth/authorization.py
+++ b/backend/oqtopus_cloud/common/auth/authorization.py
@@ -1,0 +1,52 @@
+"""Authorization: decide whether an *authenticated* caller may access the API.
+
+This mirrors the account-status portion of the Lambda authorizer
+(``lambda_auth/lambda_function.py::_validate_user_status``). Authentication
+(token/credential validity) is handled upstream -- by the API Gateway authorizer
+in ``aws`` mode, or by oauth2-proxy + the OIDC verification in ``oidc`` mode.
+What remains, and what this module owns, is the app-level authorization gate:
+the user must exist in the DB and be ``approved``.
+
+MFA is intentionally NOT re-checked here: in the OIDC deployment MFA is enforced
+by the identity provider (Keycloak), not by this service.
+"""
+
+import os
+
+from sqlalchemy import select
+
+from oqtopus_cloud.common.models.user import User, UserStatus
+from oqtopus_cloud.common.session import (
+    AUTH_DB_READ_TIMEOUT_SECONDS,
+    _create_session,
+)
+
+
+def _status_enforced() -> bool:
+    return os.getenv("AUTH_ENFORCE_STATUS", "true").strip().lower() not in (
+        "false",
+        "0",
+        "no",
+    )
+
+
+def validate_user_status(user_id: str) -> bool:
+    """Return True iff ``user_id`` maps to an ``approved`` user.
+
+    Set ``AUTH_ENFORCE_STATUS=false`` to skip the check (e.g. for a demo where
+    the IdP is the only gate and no user rows are provisioned yet).
+    """
+    if not _status_enforced():
+        return True
+
+    db = _create_session(read_timeout=AUTH_DB_READ_TIMEOUT_SECONDS)
+    try:
+        user = db.execute(
+            select(User).where(
+                User.id == user_id,
+                User.userstatus == UserStatus.approved,
+            )
+        ).scalar()
+    finally:
+        db.close()
+    return user is not None

--- a/backend/oqtopus_cloud/common/auth/identity.py
+++ b/backend/oqtopus_cloud/common/auth/identity.py
@@ -1,0 +1,110 @@
+"""Resolve the caller's identity from the incoming request.
+
+The dispatch on ``AUTH_MODE`` is the single seam that decouples the FastAPI apps
+from any specific identity provider. Each strategy produces an :class:`Identity`
+whose ``user_id`` matches the DB ``users.id`` / ``jobs.owner`` key (an email in
+practice), so everything downstream is unchanged regardless of how the caller
+authenticated.
+"""
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from aws_lambda_powertools.utilities.data_classes import APIGatewayProxyEvent
+from fastapi import Request
+
+from oqtopus_cloud.common.auth.authorization import validate_user_status
+from oqtopus_cloud.common.auth.oidc import OidcError, verify_bearer_token
+
+
+class AuthError(Exception):
+    """Raised when the caller cannot be authenticated or authorized."""
+
+
+@dataclass
+class Identity:
+    """The resolved caller identity handed to the request handlers."""
+
+    user_id: str
+    email: Optional[str] = None
+    user_pool_id: Optional[str] = None
+    region: Optional[str] = None
+
+
+def auth_mode() -> str:
+    """Return the active auth mode.
+
+    Explicit ``AUTH_MODE`` wins; otherwise fall back to the historical behavior
+    (``local`` when ``ENV=local``, else ``aws``) so nothing changes for existing
+    deployments and tests.
+    """
+    mode = os.getenv("AUTH_MODE")
+    if mode:
+        return mode.strip().lower()
+    return "local" if os.getenv("ENV") == "local" else "aws"
+
+
+def _local_identity() -> Identity:
+    # Preserves the previous ENV=local hardcoded developer identity.
+    return Identity(
+        user_id="admin-email",
+        email="admin-email",
+        user_pool_id="ap-northeast-1_XXXXXXXXX",
+        region="ap-northeast-1",
+    )
+
+
+def _aws_identity(request: Request) -> Identity:
+    # Unchanged prod behavior: read the id the Lambda authorizer injected.
+    # A missing event/authorizer raises KeyError, which the middleware maps to
+    # a 500 (as before) rather than a 401.
+    user_id = APIGatewayProxyEvent(
+        request.scope["aws.event"]
+    ).request_context.authorizer["user_id"]
+    user_pool_id = os.getenv("CLIENT_COGNITO_USER_POOL_ID")
+    region = user_pool_id.split("_")[0] if user_pool_id else None
+    return Identity(
+        user_id=user_id,
+        user_pool_id=user_pool_id,
+        region=region,
+    )
+
+
+def _oidc_identity(request: Request) -> Identity:
+    # Authentication: oauth2-proxy forwards the verified token as a Bearer.
+    auth_header = request.headers.get("authorization")
+    if not auth_header:
+        raise AuthError("Missing Authorization header")
+    token = auth_header.removeprefix("Bearer ").removeprefix("bearer ").strip()
+    if not token:
+        raise AuthError("Empty Bearer token")
+
+    try:
+        claims = verify_bearer_token(token)
+    except OidcError as e:
+        raise AuthError(str(e))
+
+    username_claim = os.getenv("OIDC_USERNAME_CLAIM", "email")
+    user_id = claims.get(username_claim)
+    if not user_id:
+        raise AuthError(f"Token is missing the '{username_claim}' claim")
+
+    # Authorization: the account must exist and be approved (the piece the
+    # Lambda authorizer used to enforce upstream).
+    if not validate_user_status(user_id=user_id):
+        raise AuthError(f"User '{user_id}' is not approved")
+
+    return Identity(user_id=user_id, email=claims.get("email"))
+
+
+def resolve_identity(request: Request) -> Identity:
+    """Resolve the caller identity for the active :func:`auth_mode`."""
+    mode = auth_mode()
+    if mode == "local":
+        return _local_identity()
+    if mode == "aws":
+        return _aws_identity(request)
+    if mode == "oidc":
+        return _oidc_identity(request)
+    raise AuthError(f"Unknown AUTH_MODE: {mode!r}")

--- a/backend/oqtopus_cloud/common/auth/oidc.py
+++ b/backend/oqtopus_cloud/common/auth/oidc.py
@@ -1,0 +1,104 @@
+"""Generic OIDC Bearer-token verification.
+
+This generalizes the Cognito-specific JWT verification that lived in the Lambda
+authorizer (``lambda_auth/lambda_function.py::_verify_id_token``) to any OIDC
+issuer -- Cognito, Keycloak, or anything else that exposes a JWKS endpoint.
+
+Configuration (environment variables):
+- ``OIDC_ISSUER``        (required) expected ``iss`` claim; also the base for
+                          JWKS/discovery when the explicit URLs are not set.
+- ``OIDC_JWKS_URL``      (optional) explicit JWKS endpoint. Useful when the
+                          issuer that appears in the token (browser-facing host,
+                          e.g. ``http://localhost:8080/...``) differs from the
+                          host reachable from this service (``http://keycloak:8080/...``).
+- ``OIDC_AUDIENCE``      (optional) expected ``aud``; when set, audience is
+                          verified, otherwise the ``aud`` check is skipped.
+- ``OIDC_ALGORITHMS``    (optional) comma-separated allow-list, default ``RS256``.
+"""
+
+import json
+import os
+import urllib.request
+from functools import lru_cache
+
+import jwt
+
+# Match the authorizer's JWKS fetch timeout so a stalled IdP fails fast.
+_JWKS_HTTP_TIMEOUT_SECONDS = 5
+_DISCOVERY_HTTP_TIMEOUT_SECONDS = 5
+
+
+class OidcError(Exception):
+    """Raised when a Bearer token cannot be verified."""
+
+
+@lru_cache(maxsize=8)
+def _jwks_client(jwks_url: str) -> "jwt.PyJWKClient":
+    # PyJWKClient caches signing keys internally; lru_cache keeps one client per
+    # URL so keys are not re-fetched on every request.
+    return jwt.PyJWKClient(jwks_url, timeout=_JWKS_HTTP_TIMEOUT_SECONDS)
+
+
+@lru_cache(maxsize=8)
+def _discover_jwks_url(issuer: str) -> str:
+    """Resolve the JWKS URL from the issuer's OIDC discovery document."""
+    discovery_url = issuer.rstrip("/") + "/.well-known/openid-configuration"
+    try:
+        with urllib.request.urlopen(
+            discovery_url, timeout=_DISCOVERY_HTTP_TIMEOUT_SECONDS
+        ) as resp:
+            doc = json.loads(resp.read())
+        return doc["jwks_uri"]
+    except Exception as e:  # noqa: BLE001 - surface a single typed error
+        raise OidcError(f"OIDC discovery failed for {discovery_url}: {e}")
+
+
+def _resolve_jwks_url(issuer: str) -> str:
+    explicit = os.getenv("OIDC_JWKS_URL")
+    if explicit:
+        return explicit
+    return _discover_jwks_url(issuer)
+
+
+def verify_bearer_token(token: str) -> dict:
+    """Verify an OIDC JWT and return its (validated) claims.
+
+    Verifies signature (via JWKS), ``iss``, ``exp`` and -- when ``OIDC_AUDIENCE``
+    is configured -- ``aud``. Raises :class:`OidcError` on any failure.
+    """
+    issuer = os.getenv("OIDC_ISSUER")
+    if not issuer:
+        raise OidcError("OIDC_ISSUER is not configured")
+
+    audience = os.getenv("OIDC_AUDIENCE")
+    algorithms = [
+        a.strip() for a in os.getenv("OIDC_ALGORITHMS", "RS256").split(",") if a.strip()
+    ]
+
+    jwks_url = _resolve_jwks_url(issuer)
+    try:
+        signing_key = _jwks_client(jwks_url).get_signing_key_from_jwt(token)
+    except Exception as e:  # noqa: BLE001
+        raise OidcError(f"Failed to get signing key from JWKS: {e}")
+
+    require = ["exp", "iss"]
+    options: dict = {"verify_iss": True, "verify_exp": True}
+    decode_kwargs: dict = {"issuer": issuer}
+    if audience:
+        require.append("aud")
+        options["verify_aud"] = True
+        decode_kwargs["audience"] = audience
+    else:
+        options["verify_aud"] = False
+    options["require"] = require
+
+    try:
+        return jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=algorithms,
+            options=options,
+            **decode_kwargs,
+        )
+    except Exception as e:  # noqa: BLE001
+        raise OidcError(f"Bearer token verification failed: {e}")

--- a/backend/oqtopus_cloud/user/middleware.py
+++ b/backend/oqtopus_cloud/user/middleware.py
@@ -1,12 +1,10 @@
 import os
 
-from aws_lambda_powertools.utilities.data_classes import (
-    APIGatewayProxyEvent,
-)
 from fastapi import Request
-from fastapi.exceptions import HTTPException
+from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from oqtopus_cloud.common.auth import AuthError, resolve_identity
 from oqtopus_cloud.user.conf import logger
 
 
@@ -18,27 +16,33 @@ class CustomMiddleware(BaseHTTPMiddleware):
             corr_id = "local-correlation-id"
         if not corr_id:
             corr_id = request.scope["aws.context"].aws_request_id
+        corr_id = str(corr_id)
 
         logger.set_correlation_id(corr_id)
 
+        # NB: this runs OUTSIDE FastAPI's ExceptionMiddleware, so raising
+        # HTTPException here would surface as a 500 (only ServerErrorMiddleware
+        # is further out). Return an explicit Response for auth failures instead.
         try:
-            if os.getenv("ENV") == "local":
-                request.state.user_id = "admin-email"
-                request.state.user_pool_id = "ap-northeast-1_XXXXXXXXX"
-                request.state.region = "ap-northeast-1"
-            else:
-                user_id = APIGatewayProxyEvent(
-                    request.scope["aws.event"]
-                ).request_context.authorizer["user_id"]
-                request.state.user_id = user_id
-                user_pool_id = os.getenv("CLIENT_COGNITO_USER_POOL_ID")
-                request.state.user_pool_id = user_pool_id
-                if user_pool_id:
-                    request.state.region = user_pool_id.split("_")[0]
+            identity = resolve_identity(request)
+            request.state.user_id = identity.user_id
+            request.state.user_pool_id = identity.user_pool_id
+            request.state.region = identity.region
+        except AuthError as e:
+            # OIDC path: caller could not be authenticated/authorized.
+            logger.warning(f"Authentication/authorization failed: {e}")
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Unauthorized"},
+                headers={"X-Correlation-Id": corr_id},
+            )
         except KeyError:
+            # AWS path: the API Gateway authorizer context is missing.
             logger.error("No AWS event found in request scope")
-            raise HTTPException(
-                status_code=500, detail="No AWS event found in request scope"
+            return JSONResponse(
+                status_code=500,
+                content={"detail": "No AWS event found in request scope"},
+                headers={"X-Correlation-Id": corr_id},
             )
 
         response = await call_next(request)

--- a/backend/scripts/seed.py
+++ b/backend/scripts/seed.py
@@ -236,6 +236,25 @@ USERS: list[dict[str, Any]] = [
         "api_token_hash": "$2a$12$srgz4gTm0kBLmDJvkX.XRexiz3VFn5vVtmquYoDLVnNjjDk6LtbPa",
         "api_token_expiration": _EXPIRED_TOKEN,
     },
+    # Demo user for the flexible-auth (AUTH_MODE=oidc) local demonstration.
+    # `id` == the email Keycloak issues for the LDAP-federated user, since the
+    # OIDC middleware resolves user_id from the `email` claim. Provisioned as
+    # `approved` so the in-app authorization check passes. No API token: this
+    # user authenticates interactively via oauth2-proxy + Keycloak, not q-api-token.
+    {
+        "id": "demo@oqtopus.local",
+        "cognito_id": "ldap-demo-0001",
+        "email": "demo@oqtopus.local",
+        "display_name": "OQTOPUS Demo User",
+        "userstatus": "approved",
+        "organization": "OQTOPUS Demo Org",
+        "group_id": "demo-group",
+        "available_devices": "*",
+        "mfa_status": "disabled",
+        "api_token_id": None,
+        "api_token_hash": None,
+        "api_token_expiration": None,
+    },
 ]
 
 

--- a/docs/en/operation/deployment.md
+++ b/docs/en/operation/deployment.md
@@ -96,17 +96,22 @@ env="dev"
 region = "ap-northeast-1"
 
 vpc_flow_log_retention_days = 14
-s3_api_trail_cloudwatch_retention_in_days = 30
-cloudtrail_s3_logs_expiration_days = 365
-cloudtrail_s3_logs_transition_days_standard_ia = 30
-cloudtrail_s3_logs_transition_days_glacier_ir = 90
-cloudtrail_s3_logs_transition_days_deep_archive = 180
+s3_logs_expiration_days = 365
+s3_logs_transition_days_standard_ia = 30
+s3_logs_transition_days_glacier_ir = 90
+s3_logs_transition_days_deep_archive = 180
 
 enable_guardduty               = false
 enable_guardduty_s3_protection = false
 ```
 
 These files set the storage location for the state file and environment variables.
+
+!!! note
+
+    OQTOPUS does not create or manage an account-level CloudTrail trail. The AWS
+    account owner is responsible for configuring management-event logging and,
+    when required, S3 object-level data-event logging for the OQTOPUS bucket.
 
 Initialize with `terraform init`. Run the following command:
 

--- a/terraform/example/oqtopus-dev/infrastructure/terraform.tfvars.txt
+++ b/terraform/example/oqtopus-dev/infrastructure/terraform.tfvars.txt
@@ -5,11 +5,10 @@ env="dev"
 region = "ap-northeast-1"
 
 vpc_flow_log_retention_days = 14
-s3_api_trail_cloudwatch_retention_in_days = 30
-cloudtrail_s3_logs_expiration_days = 365
-cloudtrail_s3_logs_transition_days_standard_ia = 30
-cloudtrail_s3_logs_transition_days_glacier_ir = 90
-cloudtrail_s3_logs_transition_days_deep_archive = 180
+s3_logs_expiration_days = 365
+s3_logs_transition_days_standard_ia = 30
+s3_logs_transition_days_glacier_ir = 90
+s3_logs_transition_days_deep_archive = 180
 
 enable_guardduty               = false
 enable_guardduty_s3_protection = false

--- a/terraform/infrastructure/modules/s3-logging/README.md
+++ b/terraform/infrastructure/modules/s3-logging/README.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-This module manages S3 data bucket logging: S3 access logs, and S3 API logs with CloudTrail.
+This module manages S3 server access logging.
 
 ## Usage
 
@@ -34,10 +34,6 @@ module "s3-logging" {
 
 | Name | Type |
 |------|------|
-| [aws_cloudtrail.s3_api_trail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail) | resource |
-| [aws_cloudwatch_log_group.s3_api_trail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
-| [aws_iam_role.s3_api_trail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy.s3_api_trail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_s3_bucket.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_lifecycle_configuration.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_logging.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
@@ -45,21 +41,19 @@ module "s3-logging" {
 | [aws_s3_bucket_public_access_block.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cloudtrail_s3_logs_expiration_days"></a> [cloudtrail\_s3\_logs\_expiration\_days](#input\_cloudtrail\_s3\_logs\_expiration\_days) | Number of days after which objects in the log bucket expire | `number` | `365` | no |
-| <a name="input_cloudtrail_s3_logs_transition_days_deep_archive"></a> [cloudtrail\_s3\_logs\_transition\_days\_deep\_archive](#input\_cloudtrail\_s3\_logs\_transition\_days\_deep\_archive) | Number of days after which objects in the log bucket are moved to DEEP\_ARCHIVE storage | `number` | `180` | no |
-| <a name="input_cloudtrail_s3_logs_transition_days_glacier_ir"></a> [cloudtrail\_s3\_logs\_transition\_days\_glacier\_ir](#input\_cloudtrail\_s3\_logs\_transition\_days\_glacier\_ir) | Number of days after which objects in the log bucket are moved to GLACIER\_IR storage | `number` | `90` | no |
-| <a name="input_cloudtrail_s3_logs_transition_days_standard_ia"></a> [cloudtrail\_s3\_logs\_transition\_days\_standard\_ia](#input\_cloudtrail\_s3\_logs\_transition\_days\_standard\_ia) | Number of days after which objects in the log bucket are moved to STANDARD\_IA storage | `number` | `30` | no |
 | <a name="input_env"></a> [env](#input\_env) | environment name | `string` | n/a | yes |
 | <a name="input_force_destroy_bucket"></a> [force\_destroy\_bucket](#input\_force\_destroy\_bucket) | Should allow S3 log bucket to be destroyed even if it contains objects? | `bool` | `false` | no |
 | <a name="input_org"></a> [org](#input\_org) | organization name | `string` | n/a | yes |
 | <a name="input_product"></a> [product](#input\_product) | product name | `string` | n/a | yes |
-| <a name="input_s3_api_trail_cloudwatch_retention_in_days"></a> [s3\_api\_trail\_cloudwatch\_retention\_in\_days](#input\_s3\_api\_trail\_cloudwatch\_retention\_in\_days) | Number of days to retain S3 API CloudTrail events in CloudWatch | `number` | `30` | no |
-| <a name="input_s3_target_bucket_arn"></a> [s3\_target\_bucket\_arn](#input\_s3\_target\_bucket\_arn) | ARN of the S3 target bucket to be monitored by the trail | `string` | n/a | yes |
-| <a name="input_s3_target_bucket_name"></a> [s3\_target\_bucket\_name](#input\_s3\_target\_bucket\_name) | name of the S3 target bucket to be monitored by the trail | `string` | n/a | yes |
+| <a name="input_s3_logs_expiration_days"></a> [s3\_logs\_expiration\_days](#input\_s3\_logs\_expiration\_days) | Number of days after which objects in the log bucket expire | `number` | `365` | no |
+| <a name="input_s3_logs_transition_days_deep_archive"></a> [s3\_logs\_transition\_days\_deep\_archive](#input\_s3\_logs\_transition\_days\_deep\_archive) | Number of days after which objects in the log bucket are moved to DEEP\_ARCHIVE storage | `number` | `180` | no |
+| <a name="input_s3_logs_transition_days_glacier_ir"></a> [s3\_logs\_transition\_days\_glacier\_ir](#input\_s3\_logs\_transition\_days\_glacier\_ir) | Number of days after which objects in the log bucket are moved to GLACIER\_IR storage | `number` | `90` | no |
+| <a name="input_s3_logs_transition_days_standard_ia"></a> [s3\_logs\_transition\_days\_standard\_ia](#input\_s3\_logs\_transition\_days\_standard\_ia) | Number of days after which objects in the log bucket are moved to STANDARD\_IA storage | `number` | `30` | no |
+| <a name="input_s3_target_bucket_arn"></a> [s3\_target\_bucket\_arn](#input\_s3\_target\_bucket\_arn) | ARN of the S3 target bucket whose server access logs are collected | `string` | n/a | yes |
+| <a name="input_s3_target_bucket_name"></a> [s3\_target\_bucket\_name](#input\_s3\_target\_bucket\_name) | Name of the S3 target bucket whose server access logs are collected | `string` | n/a | yes |
 <!-- END_TF_DOCS -->

--- a/terraform/infrastructure/modules/s3-logging/main.tf
+++ b/terraform/infrastructure/modules/s3-logging/main.tf
@@ -4,7 +4,7 @@
 *
 * ## Description
 *
-* This module manages S3 data bucket logging: S3 access logs, and S3 API logs with CloudTrail.
+* This module manages S3 server access logging.
 *
 * ## Usage
 *
@@ -19,13 +19,7 @@
 *
 */
 
-data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
-
-locals {
-  trail_name = "s3-api-trail"
-  trail_arn  = "arn:aws:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${local.trail_name}"
-}
 
 resource "aws_s3_bucket" "logs" {
   bucket        = "${var.product}-${var.org}-${var.env}-logs"
@@ -91,35 +85,6 @@ resource "aws_s3_bucket_policy" "logs" {
             "aws:SourceAccount" = data.aws_caller_identity.current.account_id
           }
         }
-      },
-      {
-        Sid    = "AllowCloudTrailAclCheck"
-        Effect = "Allow"
-        Principal = {
-          Service = "cloudtrail.amazonaws.com"
-        }
-        Action   = "s3:GetBucketAcl"
-        Resource = aws_s3_bucket.logs.arn
-        Condition = {
-          StringEquals = {
-            "aws:SourceArn" = local.trail_arn
-          }
-        }
-      },
-      {
-        Sid    = "AllowCloudTrailWrite"
-        Effect = "Allow"
-        Principal = {
-          Service = "cloudtrail.amazonaws.com"
-        }
-        Action   = "s3:PutObject"
-        Resource = "${aws_s3_bucket.logs.arn}/s3-api-trail/*"
-        Condition = {
-          StringEquals = {
-            "s3:x-amz-acl"  = "bucket-owner-full-control"
-            "aws:SourceArn" = local.trail_arn
-          }
-        }
       }
     ]
   })
@@ -140,92 +105,22 @@ resource "aws_s3_bucket_lifecycle_configuration" "logs" {
     status = "Enabled"
 
     expiration {
-      days = var.cloudtrail_s3_logs_expiration_days
+      days = var.s3_logs_expiration_days
     }
 
     transition {
-      days          = var.cloudtrail_s3_logs_transition_days_standard_ia
+      days          = var.s3_logs_transition_days_standard_ia
       storage_class = "STANDARD_IA"
     }
 
     transition {
-      days          = var.cloudtrail_s3_logs_transition_days_glacier_ir
+      days          = var.s3_logs_transition_days_glacier_ir
       storage_class = "GLACIER_IR"
     }
 
     transition {
-      days          = var.cloudtrail_s3_logs_transition_days_deep_archive
+      days          = var.s3_logs_transition_days_deep_archive
       storage_class = "DEEP_ARCHIVE"
     }
-  }
-}
-
-resource "aws_cloudwatch_log_group" "s3_api_trail" {
-  name              = "/aws/cloudtrail/${local.trail_name}"
-  retention_in_days = var.s3_api_trail_cloudwatch_retention_in_days
-
-  tags = {
-    Name = "${var.product}-${var.org}-${var.env}-${local.trail_name}-cloudwatch-logs"
-  }
-}
-
-resource "aws_iam_role" "s3_api_trail" {
-  name = "${var.product}-${var.org}-${var.env}-cloudwatch-role"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Service = "cloudtrail.amazonaws.com"
-        }
-        Action = "sts:AssumeRole"
-      }
-    ]
-  })
-}
-
-resource "aws_iam_role_policy" "s3_api_trail" {
-  name = "${var.product}-${var.org}-${var.env}-${local.trail_name}-cloudwatch-policy"
-  role = aws_iam_role.s3_api_trail.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "logs:CreateLogStream",
-          "logs:PutLogEvents"
-        ]
-        Resource = "${aws_cloudwatch_log_group.s3_api_trail.arn}:*"
-      }
-    ]
-  })
-}
-
-resource "aws_cloudtrail" "s3_api_trail" {
-  name           = local.trail_name
-  s3_bucket_name = aws_s3_bucket.logs.id
-  s3_key_prefix  = local.trail_name
-
-  include_global_service_events = false
-
-  event_selector {
-    read_write_type           = "All"
-    include_management_events = true
-
-    data_resource {
-      type   = "AWS::S3::Object"
-      values = ["${var.s3_target_bucket_arn}/*"]
-    }
-  }
-
-  cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.s3_api_trail.arn}:*"
-  cloud_watch_logs_role_arn  = aws_iam_role.s3_api_trail.arn
-
-  tags = {
-    Name = "${var.product}-${var.org}-${var.env}-${local.trail_name}"
   }
 }

--- a/terraform/infrastructure/modules/s3-logging/variables.tf
+++ b/terraform/infrastructure/modules/s3-logging/variables.tf
@@ -14,12 +14,12 @@ variable "env" {
 }
 
 variable "s3_target_bucket_name" {
-  description = "name of the S3 target bucket to be monitored by the trail"
+  description = "Name of the S3 target bucket whose server access logs are collected"
   type        = string
 }
 
 variable "s3_target_bucket_arn" {
-  description = "ARN of the S3 target bucket to be monitored by the trail"
+  description = "ARN of the S3 target bucket whose server access logs are collected"
   type        = string
 }
 
@@ -29,32 +29,26 @@ variable "force_destroy_bucket" {
   default     = false
 }
 
-variable "cloudtrail_s3_logs_expiration_days" {
+variable "s3_logs_expiration_days" {
   description = "Number of days after which objects in the log bucket expire"
   type        = number
   default     = 365
 }
 
-variable "cloudtrail_s3_logs_transition_days_standard_ia" {
+variable "s3_logs_transition_days_standard_ia" {
   description = "Number of days after which objects in the log bucket are moved to STANDARD_IA storage"
   type        = number
   default     = 30
 }
 
-variable "cloudtrail_s3_logs_transition_days_glacier_ir" {
+variable "s3_logs_transition_days_glacier_ir" {
   description = "Number of days after which objects in the log bucket are moved to GLACIER_IR storage"
   type        = number
   default     = 90
 }
 
-variable "cloudtrail_s3_logs_transition_days_deep_archive" {
+variable "s3_logs_transition_days_deep_archive" {
   description = "Number of days after which objects in the log bucket are moved to DEEP_ARCHIVE storage"
   type        = number
   default     = 180
-}
-
-variable "s3_api_trail_cloudwatch_retention_in_days" {
-  description = "Number of days to retain S3 API CloudTrail events in CloudWatch"
-  type        = number
-  default     = 30
 }

--- a/terraform/infrastructure/oqtopus-dev/main.tf
+++ b/terraform/infrastructure/oqtopus-dev/main.tf
@@ -96,17 +96,16 @@ module "s3" {
 module "s3-logging" {
   source = "../modules/s3-logging"
 
-  product                                         = var.product
-  org                                             = var.org
-  env                                             = var.env
-  s3_target_bucket_name                           = module.s3.s3_bucket_name
-  s3_target_bucket_arn                            = module.s3.s3_bucket_arn
-  force_destroy_bucket                            = true
-  s3_api_trail_cloudwatch_retention_in_days       = var.s3_api_trail_cloudwatch_retention_in_days
-  cloudtrail_s3_logs_expiration_days              = var.cloudtrail_s3_logs_expiration_days
-  cloudtrail_s3_logs_transition_days_standard_ia  = var.cloudtrail_s3_logs_transition_days_standard_ia
-  cloudtrail_s3_logs_transition_days_glacier_ir   = var.cloudtrail_s3_logs_transition_days_glacier_ir
-  cloudtrail_s3_logs_transition_days_deep_archive = var.cloudtrail_s3_logs_transition_days_deep_archive
+  product                              = var.product
+  org                                  = var.org
+  env                                  = var.env
+  s3_target_bucket_name                = module.s3.s3_bucket_name
+  s3_target_bucket_arn                 = module.s3.s3_bucket_arn
+  force_destroy_bucket                 = true
+  s3_logs_expiration_days              = var.s3_logs_expiration_days
+  s3_logs_transition_days_standard_ia  = var.s3_logs_transition_days_standard_ia
+  s3_logs_transition_days_glacier_ir   = var.s3_logs_transition_days_glacier_ir
+  s3_logs_transition_days_deep_archive = var.s3_logs_transition_days_deep_archive
 }
 
 module "guardduty_detector" {

--- a/terraform/infrastructure/oqtopus-dev/variables.tf
+++ b/terraform/infrastructure/oqtopus-dev/variables.tf
@@ -58,31 +58,25 @@ variable "vpc_flow_log_retention_days" {
   default     = 14
 }
 
-variable "s3_api_trail_cloudwatch_retention_in_days" {
-  description = "Number of days to retain S3 API CloudTrail events in CloudWatch"
-  type        = number
-  default     = 30
-}
-
-variable "cloudtrail_s3_logs_expiration_days" {
+variable "s3_logs_expiration_days" {
   description = "Number of days after which objects in the log bucket expire"
   type        = number
   default     = 365
 }
 
-variable "cloudtrail_s3_logs_transition_days_standard_ia" {
+variable "s3_logs_transition_days_standard_ia" {
   description = "Number of days after which objects in the log bucket are moved to STANDARD_IA storage"
   type        = number
   default     = 30
 }
 
-variable "cloudtrail_s3_logs_transition_days_glacier_ir" {
+variable "s3_logs_transition_days_glacier_ir" {
   description = "Number of days after which objects in the log bucket are moved to GLACIER_IR storage"
   type        = number
   default     = 90
 }
 
-variable "cloudtrail_s3_logs_transition_days_deep_archive" {
+variable "s3_logs_transition_days_deep_archive" {
   description = "Number of days after which objects in the log bucket are moved to DEEP_ARCHIVE storage"
   type        = number
   default     = 180

--- a/terraform/infrastructure/oqtopus-prod/main.tf
+++ b/terraform/infrastructure/oqtopus-prod/main.tf
@@ -95,16 +95,15 @@ module "s3" {
 module "s3-logging" {
   source = "../modules/s3-logging"
 
-  product                                         = var.product
-  org                                             = var.org
-  env                                             = var.env
-  s3_target_bucket_name                           = module.s3.s3_bucket_name
-  s3_target_bucket_arn                            = module.s3.s3_bucket_arn
-  s3_api_trail_cloudwatch_retention_in_days       = var.s3_api_trail_cloudwatch_retention_in_days
-  cloudtrail_s3_logs_expiration_days              = var.cloudtrail_s3_logs_expiration_days
-  cloudtrail_s3_logs_transition_days_standard_ia  = var.cloudtrail_s3_logs_transition_days_standard_ia
-  cloudtrail_s3_logs_transition_days_glacier_ir   = var.cloudtrail_s3_logs_transition_days_glacier_ir
-  cloudtrail_s3_logs_transition_days_deep_archive = var.cloudtrail_s3_logs_transition_days_deep_archive
+  product                              = var.product
+  org                                  = var.org
+  env                                  = var.env
+  s3_target_bucket_name                = module.s3.s3_bucket_name
+  s3_target_bucket_arn                 = module.s3.s3_bucket_arn
+  s3_logs_expiration_days              = var.s3_logs_expiration_days
+  s3_logs_transition_days_standard_ia  = var.s3_logs_transition_days_standard_ia
+  s3_logs_transition_days_glacier_ir   = var.s3_logs_transition_days_glacier_ir
+  s3_logs_transition_days_deep_archive = var.s3_logs_transition_days_deep_archive
 }
 
 module "guardduty_detector" {

--- a/terraform/infrastructure/oqtopus-prod/variables.tf
+++ b/terraform/infrastructure/oqtopus-prod/variables.tf
@@ -58,31 +58,25 @@ variable "vpc_flow_log_retention_days" {
   default     = 14
 }
 
-variable "s3_api_trail_cloudwatch_retention_in_days" {
-  description = "Number of days to retain S3 API CloudTrail events in CloudWatch"
-  type        = number
-  default     = 30
-}
-
-variable "cloudtrail_s3_logs_expiration_days" {
+variable "s3_logs_expiration_days" {
   description = "Number of days after which objects in the log bucket expire"
   type        = number
   default     = 365
 }
 
-variable "cloudtrail_s3_logs_transition_days_standard_ia" {
+variable "s3_logs_transition_days_standard_ia" {
   description = "Number of days after which objects in the log bucket are moved to STANDARD_IA storage"
   type        = number
   default     = 30
 }
 
-variable "cloudtrail_s3_logs_transition_days_glacier_ir" {
+variable "s3_logs_transition_days_glacier_ir" {
   description = "Number of days after which objects in the log bucket are moved to GLACIER_IR storage"
   type        = number
   default     = 90
 }
 
-variable "cloudtrail_s3_logs_transition_days_deep_archive" {
+variable "s3_logs_transition_days_deep_archive" {
   description = "Number of days after which objects in the log bucket are moved to DEEP_ARCHIVE storage"
   type        = number
   default     = 180

--- a/uv.lock
+++ b/uv.lock
@@ -250,7 +250,7 @@ wheels = [
 
 [[package]]
 name = "backend"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiobotocore" },


### PR DESCRIPTION
This PR brings the following changes:
  - remove CloudTrail related resources from terraform

## Background

### Problems

Currently, OQTOPUS configures a CloudTrail trail to enhance S3 security. 
However, due to its default settings, this CloudTrail trail saves logs for 
almost all AWS management events into S3, in addition to S3 data object-related events.This behavior causes an issue if an existing trail already exists in the AWS account where OQTOPUS is deployed. 
Under the CloudTrail pricing model, the first copy of management events delivered to S3 is free, but charges apply for the second and subsequent copies.
In fact, a maintainer actually detected an unusual spike in CloudTrail costs on their AWS account due to this duplicate storage of trails.

### Proposed Approach

To address this issue, we would like to take the following approach:
  - Turning off CloudTrail completely is not recommended, as it would trigger a failed (red) status in Security Hub. However, Security Hub evaluates the overall governance of the AWS account rather than the quality of a single application. Therefore, this responsibility lies with the AWS account owner rather than OQTOPUS itself
  - Consequently, OQTOPUS should drop the CloudTrail configuration entirely and eliminate its dependency on CloudTrail.
  
## Side Effects & Mitigation

As a side effect of this change, lambda_version_cleaner, which currently relies on CloudTrail, will no longer trigger automatically. We plan to mitigate this by explicitly executing it during deployment instead.