### PR TITLE
Refactor: remove cloudtrail related resources from terraform

### DIFF
--- a/docs/en/operation/deployment.md
+++ b/docs/en/operation/deployment.md
@@ -96,17 +96,22 @@ env="dev"
 region = "ap-northeast-1"
 
 vpc_flow_log_retention_days = 14
-s3_api_trail_cloudwatch_retention_in_days = 30
-cloudtrail_s3_logs_expiration_days = 365
-cloudtrail_s3_logs_transition_days_standard_ia = 30
-cloudtrail_s3_logs_transition_days_glacier_ir = 90
-cloudtrail_s3_logs_transition_days_deep_archive = 180
+s3_logs_expiration_days = 365
+s3_logs_transition_days_standard_ia = 30
+s3_logs_transition_days_glacier_ir = 90
+s3_logs_transition_days_deep_archive = 180
 
 enable_guardduty               = false
 enable_guardduty_s3_protection = false
 ```
 
 These files set the storage location for the state file and environment variables.
+
+!!! note
+
+    OQTOPUS does not create or manage an account-level CloudTrail trail. The AWS
+    account owner is responsible for configuring management-event logging and,
+    when required, S3 object-level data-event logging for the OQTOPUS bucket.
 
 Initialize with `terraform init`. Run the following command:
 

--- a/terraform/example/oqtopus-dev/infrastructure/terraform.tfvars.txt
+++ b/terraform/example/oqtopus-dev/infrastructure/terraform.tfvars.txt
@@ -5,11 +5,10 @@ env="dev"
 region = "ap-northeast-1"
 
 vpc_flow_log_retention_days = 14
-s3_api_trail_cloudwatch_retention_in_days = 30
-cloudtrail_s3_logs_expiration_days = 365
-cloudtrail_s3_logs_transition_days_standard_ia = 30
-cloudtrail_s3_logs_transition_days_glacier_ir = 90
-cloudtrail_s3_logs_transition_days_deep_archive = 180
+s3_logs_expiration_days = 365
+s3_logs_transition_days_standard_ia = 30
+s3_logs_transition_days_glacier_ir = 90
+s3_logs_transition_days_deep_archive = 180
 
 enable_guardduty               = false
 enable_guardduty_s3_protection = false

--- a/terraform/infrastructure/modules/s3-logging/README.md
+++ b/terraform/infrastructure/modules/s3-logging/README.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-This module manages S3 data bucket logging: S3 access logs, and S3 API logs with CloudTrail.
+This module manages S3 server access logging.
 
 ## Usage
 
@@ -34,10 +34,6 @@ module "s3-logging" {
 
 | Name | Type |
 |------|------|
-| [aws_cloudtrail.s3_api_trail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail) | resource |
-| [aws_cloudwatch_log_group.s3_api_trail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
-| [aws_iam_role.s3_api_trail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy.s3_api_trail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_s3_bucket.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_lifecycle_configuration.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_logging.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
@@ -45,21 +41,19 @@ module "s3-logging" {
 | [aws_s3_bucket_public_access_block.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cloudtrail_s3_logs_expiration_days"></a> [cloudtrail\_s3\_logs\_expiration\_days](#input\_cloudtrail\_s3\_logs\_expiration\_days) | Number of days after which objects in the log bucket expire | `number` | `365` | no |
-| <a name="input_cloudtrail_s3_logs_transition_days_deep_archive"></a> [cloudtrail\_s3\_logs\_transition\_days\_deep\_archive](#input\_cloudtrail\_s3\_logs\_transition\_days\_deep\_archive) | Number of days after which objects in the log bucket are moved to DEEP\_ARCHIVE storage | `number` | `180` | no |
-| <a name="input_cloudtrail_s3_logs_transition_days_glacier_ir"></a> [cloudtrail\_s3\_logs\_transition\_days\_glacier\_ir](#input\_cloudtrail\_s3\_logs\_transition\_days\_glacier\_ir) | Number of days after which objects in the log bucket are moved to GLACIER\_IR storage | `number` | `90` | no |
-| <a name="input_cloudtrail_s3_logs_transition_days_standard_ia"></a> [cloudtrail\_s3\_logs\_transition\_days\_standard\_ia](#input\_cloudtrail\_s3\_logs\_transition\_days\_standard\_ia) | Number of days after which objects in the log bucket are moved to STANDARD\_IA storage | `number` | `30` | no |
 | <a name="input_env"></a> [env](#input\_env) | environment name | `string` | n/a | yes |
 | <a name="input_force_destroy_bucket"></a> [force\_destroy\_bucket](#input\_force\_destroy\_bucket) | Should allow S3 log bucket to be destroyed even if it contains objects? | `bool` | `false` | no |
 | <a name="input_org"></a> [org](#input\_org) | organization name | `string` | n/a | yes |
 | <a name="input_product"></a> [product](#input\_product) | product name | `string` | n/a | yes |
-| <a name="input_s3_api_trail_cloudwatch_retention_in_days"></a> [s3\_api\_trail\_cloudwatch\_retention\_in\_days](#input\_s3\_api\_trail\_cloudwatch\_retention\_in\_days) | Number of days to retain S3 API CloudTrail events in CloudWatch | `number` | `30` | no |
-| <a name="input_s3_target_bucket_arn"></a> [s3\_target\_bucket\_arn](#input\_s3\_target\_bucket\_arn) | ARN of the S3 target bucket to be monitored by the trail | `string` | n/a | yes |
-| <a name="input_s3_target_bucket_name"></a> [s3\_target\_bucket\_name](#input\_s3\_target\_bucket\_name) | name of the S3 target bucket to be monitored by the trail | `string` | n/a | yes |
+| <a name="input_s3_logs_expiration_days"></a> [s3\_logs\_expiration\_days](#input\_s3\_logs\_expiration\_days) | Number of days after which objects in the log bucket expire | `number` | `365` | no |
+| <a name="input_s3_logs_transition_days_deep_archive"></a> [s3\_logs\_transition\_days\_deep\_archive](#input\_s3\_logs\_transition\_days\_deep\_archive) | Number of days after which objects in the log bucket are moved to DEEP\_ARCHIVE storage | `number` | `180` | no |
+| <a name="input_s3_logs_transition_days_glacier_ir"></a> [s3\_logs\_transition\_days\_glacier\_ir](#input\_s3\_logs\_transition\_days\_glacier\_ir) | Number of days after which objects in the log bucket are moved to GLACIER\_IR storage | `number` | `90` | no |
+| <a name="input_s3_logs_transition_days_standard_ia"></a> [s3\_logs\_transition\_days\_standard\_ia](#input\_s3\_logs\_transition\_days\_standard\_ia) | Number of days after which objects in the log bucket are moved to STANDARD\_IA storage | `number` | `30` | no |
+| <a name="input_s3_target_bucket_arn"></a> [s3\_target\_bucket\_arn](#input\_s3\_target\_bucket\_arn) | ARN of the S3 target bucket whose server access logs are collected | `string` | n/a | yes |
+| <a name="input_s3_target_bucket_name"></a> [s3\_target\_bucket\_name](#input\_s3\_target\_bucket\_name) | Name of the S3 target bucket whose server access logs are collected | `string` | n/a | yes |
 <!-- END_TF_DOCS -->

--- a/terraform/infrastructure/modules/s3-logging/main.tf
+++ b/terraform/infrastructure/modules/s3-logging/main.tf
@@ -4,7 +4,7 @@
 *
 * ## Description
 *
-* This module manages S3 data bucket logging: S3 access logs, and S3 API logs with CloudTrail.
+* This module manages S3 server access logging.
 *
 * ## Usage
 *
@@ -19,13 +19,7 @@
 *
 */
 
-data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
-
-locals {
-  trail_name = "s3-api-trail"
-  trail_arn  = "arn:aws:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${local.trail_name}"
-}
 
 resource "aws_s3_bucket" "logs" {
   bucket        = "${var.product}-${var.org}-${var.env}-logs"
@@ -91,35 +85,6 @@ resource "aws_s3_bucket_policy" "logs" {
             "aws:SourceAccount" = data.aws_caller_identity.current.account_id
           }
         }
-      },
-      {
-        Sid    = "AllowCloudTrailAclCheck"
-        Effect = "Allow"
-        Principal = {
-          Service = "cloudtrail.amazonaws.com"
-        }
-        Action   = "s3:GetBucketAcl"
-        Resource = aws_s3_bucket.logs.arn
-        Condition = {
-          StringEquals = {
-            "aws:SourceArn" = local.trail_arn
-          }
-        }
-      },
-      {
-        Sid    = "AllowCloudTrailWrite"
-        Effect = "Allow"
-        Principal = {
-          Service = "cloudtrail.amazonaws.com"
-        }
-        Action   = "s3:PutObject"
-        Resource = "${aws_s3_bucket.logs.arn}/s3-api-trail/*"
-        Condition = {
-          StringEquals = {
-            "s3:x-amz-acl"  = "bucket-owner-full-control"
-            "aws:SourceArn" = local.trail_arn
-          }
-        }
       }
     ]
   })
@@ -140,92 +105,22 @@ resource "aws_s3_bucket_lifecycle_configuration" "logs" {
     status = "Enabled"
 
     expiration {
-      days = var.cloudtrail_s3_logs_expiration_days
+      days = var.s3_logs_expiration_days
     }
 
     transition {
-      days          = var.cloudtrail_s3_logs_transition_days_standard_ia
+      days          = var.s3_logs_transition_days_standard_ia
       storage_class = "STANDARD_IA"
     }
 
     transition {
-      days          = var.cloudtrail_s3_logs_transition_days_glacier_ir
+      days          = var.s3_logs_transition_days_glacier_ir
       storage_class = "GLACIER_IR"
     }
 
     transition {
-      days          = var.cloudtrail_s3_logs_transition_days_deep_archive
+      days          = var.s3_logs_transition_days_deep_archive
       storage_class = "DEEP_ARCHIVE"
     }
-  }
-}
-
-resource "aws_cloudwatch_log_group" "s3_api_trail" {
-  name              = "/aws/cloudtrail/${local.trail_name}"
-  retention_in_days = var.s3_api_trail_cloudwatch_retention_in_days
-
-  tags = {
-    Name = "${var.product}-${var.org}-${var.env}-${local.trail_name}-cloudwatch-logs"
-  }
-}
-
-resource "aws_iam_role" "s3_api_trail" {
-  name = "${var.product}-${var.org}-${var.env}-cloudwatch-role"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Service = "cloudtrail.amazonaws.com"
-        }
-        Action = "sts:AssumeRole"
-      }
-    ]
-  })
-}
-
-resource "aws_iam_role_policy" "s3_api_trail" {
-  name = "${var.product}-${var.org}-${var.env}-${local.trail_name}-cloudwatch-policy"
-  role = aws_iam_role.s3_api_trail.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "logs:CreateLogStream",
-          "logs:PutLogEvents"
-        ]
-        Resource = "${aws_cloudwatch_log_group.s3_api_trail.arn}:*"
-      }
-    ]
-  })
-}
-
-resource "aws_cloudtrail" "s3_api_trail" {
-  name           = local.trail_name
-  s3_bucket_name = aws_s3_bucket.logs.id
-  s3_key_prefix  = local.trail_name
-
-  include_global_service_events = false
-
-  event_selector {
-    read_write_type           = "All"
-    include_management_events = true
-
-    data_resource {
-      type   = "AWS::S3::Object"
-      values = ["${var.s3_target_bucket_arn}/*"]
-    }
-  }
-
-  cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.s3_api_trail.arn}:*"
-  cloud_watch_logs_role_arn  = aws_iam_role.s3_api_trail.arn
-
-  tags = {
-    Name = "${var.product}-${var.org}-${var.env}-${local.trail_name}"
   }
 }

--- a/terraform/infrastructure/modules/s3-logging/variables.tf
+++ b/terraform/infrastructure/modules/s3-logging/variables.tf
@@ -14,12 +14,12 @@ variable "env" {
 }
 
 variable "s3_target_bucket_name" {
-  description = "name of the S3 target bucket to be monitored by the trail"
+  description = "Name of the S3 target bucket whose server access logs are collected"
   type        = string
 }
 
 variable "s3_target_bucket_arn" {
-  description = "ARN of the S3 target bucket to be monitored by the trail"
+  description = "ARN of the S3 target bucket whose server access logs are collected"
   type        = string
 }
 
@@ -29,32 +29,26 @@ variable "force_destroy_bucket" {
   default     = false
 }
 
-variable "cloudtrail_s3_logs_expiration_days" {
+variable "s3_logs_expiration_days" {
   description = "Number of days after which objects in the log bucket expire"
   type        = number
   default     = 365
 }
 
-variable "cloudtrail_s3_logs_transition_days_standard_ia" {
+variable "s3_logs_transition_days_standard_ia" {
   description = "Number of days after which objects in the log bucket are moved to STANDARD_IA storage"
   type        = number
   default     = 30
 }
 
-variable "cloudtrail_s3_logs_transition_days_glacier_ir" {
+variable "s3_logs_transition_days_glacier_ir" {
   description = "Number of days after which objects in the log bucket are moved to GLACIER_IR storage"
   type        = number
   default     = 90
 }
 
-variable "cloudtrail_s3_logs_transition_days_deep_archive" {
+variable "s3_logs_transition_days_deep_archive" {
   description = "Number of days after which objects in the log bucket are moved to DEEP_ARCHIVE storage"
   type        = number
   default     = 180
-}
-
-variable "s3_api_trail_cloudwatch_retention_in_days" {
-  description = "Number of days to retain S3 API CloudTrail events in CloudWatch"
-  type        = number
-  default     = 30
 }

--- a/terraform/infrastructure/oqtopus-dev/main.tf
+++ b/terraform/infrastructure/oqtopus-dev/main.tf
@@ -96,17 +96,16 @@ module "s3" {
 module "s3-logging" {
   source = "../modules/s3-logging"
 
-  product                                         = var.product
-  org                                             = var.org
-  env                                             = var.env
-  s3_target_bucket_name                           = module.s3.s3_bucket_name
-  s3_target_bucket_arn                            = module.s3.s3_bucket_arn
-  force_destroy_bucket                            = true
-  s3_api_trail_cloudwatch_retention_in_days       = var.s3_api_trail_cloudwatch_retention_in_days
-  cloudtrail_s3_logs_expiration_days              = var.cloudtrail_s3_logs_expiration_days
-  cloudtrail_s3_logs_transition_days_standard_ia  = var.cloudtrail_s3_logs_transition_days_standard_ia
-  cloudtrail_s3_logs_transition_days_glacier_ir   = var.cloudtrail_s3_logs_transition_days_glacier_ir
-  cloudtrail_s3_logs_transition_days_deep_archive = var.cloudtrail_s3_logs_transition_days_deep_archive
+  product                              = var.product
+  org                                  = var.org
+  env                                  = var.env
+  s3_target_bucket_name                = module.s3.s3_bucket_name
+  s3_target_bucket_arn                 = module.s3.s3_bucket_arn
+  force_destroy_bucket                 = true
+  s3_logs_expiration_days              = var.s3_logs_expiration_days
+  s3_logs_transition_days_standard_ia  = var.s3_logs_transition_days_standard_ia
+  s3_logs_transition_days_glacier_ir   = var.s3_logs_transition_days_glacier_ir
+  s3_logs_transition_days_deep_archive = var.s3_logs_transition_days_deep_archive
 }
 
 module "guardduty_detector" {

--- a/terraform/infrastructure/oqtopus-dev/variables.tf
+++ b/terraform/infrastructure/oqtopus-dev/variables.tf
@@ -58,31 +58,25 @@ variable "vpc_flow_log_retention_days" {
   default     = 14
 }
 
-variable "s3_api_trail_cloudwatch_retention_in_days" {
-  description = "Number of days to retain S3 API CloudTrail events in CloudWatch"
-  type        = number
-  default     = 30
-}
-
-variable "cloudtrail_s3_logs_expiration_days" {
+variable "s3_logs_expiration_days" {
   description = "Number of days after which objects in the log bucket expire"
   type        = number
   default     = 365
 }
 
-variable "cloudtrail_s3_logs_transition_days_standard_ia" {
+variable "s3_logs_transition_days_standard_ia" {
   description = "Number of days after which objects in the log bucket are moved to STANDARD_IA storage"
   type        = number
   default     = 30
 }
 
-variable "cloudtrail_s3_logs_transition_days_glacier_ir" {
+variable "s3_logs_transition_days_glacier_ir" {
   description = "Number of days after which objects in the log bucket are moved to GLACIER_IR storage"
   type        = number
   default     = 90
 }
 
-variable "cloudtrail_s3_logs_transition_days_deep_archive" {
+variable "s3_logs_transition_days_deep_archive" {
   description = "Number of days after which objects in the log bucket are moved to DEEP_ARCHIVE storage"
   type        = number
   default     = 180

--- a/terraform/infrastructure/oqtopus-prod/main.tf
+++ b/terraform/infrastructure/oqtopus-prod/main.tf
@@ -95,16 +95,15 @@ module "s3" {
 module "s3-logging" {
   source = "../modules/s3-logging"
 
-  product                                         = var.product
-  org                                             = var.org
-  env                                             = var.env
-  s3_target_bucket_name                           = module.s3.s3_bucket_name
-  s3_target_bucket_arn                            = module.s3.s3_bucket_arn
-  s3_api_trail_cloudwatch_retention_in_days       = var.s3_api_trail_cloudwatch_retention_in_days
-  cloudtrail_s3_logs_expiration_days              = var.cloudtrail_s3_logs_expiration_days
-  cloudtrail_s3_logs_transition_days_standard_ia  = var.cloudtrail_s3_logs_transition_days_standard_ia
-  cloudtrail_s3_logs_transition_days_glacier_ir   = var.cloudtrail_s3_logs_transition_days_glacier_ir
-  cloudtrail_s3_logs_transition_days_deep_archive = var.cloudtrail_s3_logs_transition_days_deep_archive
+  product                              = var.product
+  org                                  = var.org
+  env                                  = var.env
+  s3_target_bucket_name                = module.s3.s3_bucket_name
+  s3_target_bucket_arn                 = module.s3.s3_bucket_arn
+  s3_logs_expiration_days              = var.s3_logs_expiration_days
+  s3_logs_transition_days_standard_ia  = var.s3_logs_transition_days_standard_ia
+  s3_logs_transition_days_glacier_ir   = var.s3_logs_transition_days_glacier_ir
+  s3_logs_transition_days_deep_archive = var.s3_logs_transition_days_deep_archive
 }
 
 module "guardduty_detector" {

--- a/terraform/infrastructure/oqtopus-prod/variables.tf
+++ b/terraform/infrastructure/oqtopus-prod/variables.tf
@@ -58,31 +58,25 @@ variable "vpc_flow_log_retention_days" {
   default     = 14
 }
 
-variable "s3_api_trail_cloudwatch_retention_in_days" {
-  description = "Number of days to retain S3 API CloudTrail events in CloudWatch"
-  type        = number
-  default     = 30
-}
-
-variable "cloudtrail_s3_logs_expiration_days" {
+variable "s3_logs_expiration_days" {
   description = "Number of days after which objects in the log bucket expire"
   type        = number
   default     = 365
 }
 
-variable "cloudtrail_s3_logs_transition_days_standard_ia" {
+variable "s3_logs_transition_days_standard_ia" {
   description = "Number of days after which objects in the log bucket are moved to STANDARD_IA storage"
   type        = number
   default     = 30
 }
 
-variable "cloudtrail_s3_logs_transition_days_glacier_ir" {
+variable "s3_logs_transition_days_glacier_ir" {
   description = "Number of days after which objects in the log bucket are moved to GLACIER_IR storage"
   type        = number
   default     = 90
 }
 
-variable "cloudtrail_s3_logs_transition_days_deep_archive" {
+variable "s3_logs_transition_days_deep_archive" {
   description = "Number of days after which objects in the log bucket are moved to DEEP_ARCHIVE storage"
   type        = number
   default     = 180


### PR DESCRIPTION
This PR brings the following changes:
  - remove CloudTrail related resources from terraform

## Background

### Problems

Currently, OQTOPUS configures a CloudTrail trail to enhance S3 security. 
However, due to its default settings, this CloudTrail trail saves logs for 
almost all AWS management events into S3, in addition to S3 data object-related events.This behavior causes an issue if an existing trail already exists in the AWS account where OQTOPUS is deployed. 
Under the CloudTrail pricing model, the first copy of management events delivered to S3 is free, but charges apply for the second and subsequent copies.
In fact, a maintainer actually detected an unusual spike in CloudTrail costs on their AWS account due to this duplicate storage of trails.

### Proposed Approach

To address this issue, we would like to take the following approach:
  - Turning off CloudTrail completely is not recommended, as it would trigger a failed (red) status in Security Hub. However, Security Hub evaluates the overall governance of the AWS account rather than the quality of a single application. Therefore, this responsibility lies with the AWS account owner rather than OQTOPUS itself
  - Consequently, OQTOPUS should drop the CloudTrail configuration entirely and eliminate its dependency on CloudTrail.
  
## Side Effects & Mitigation

As a side effect of this change, lambda_version_cleaner, which currently relies on CloudTrail, will no longer trigger automatically. We plan to mitigate this by explicitly executing it during deployment instead: #496 .