### PR TITLE
Feat/enable lambda authorizer cache

### DIFF
--- a/backend/oqtopus_cloud/lambda_auth/lambda_function.py
+++ b/backend/oqtopus_cloud/lambda_auth/lambda_function.py
@@ -86,6 +86,22 @@ def _validate_user_status(
         raise AuthError("Failed to get user status")
 
 
+def _validate_headers_for_api_token(headers: dict) -> None:
+    api_token = headers.get("q-api-token")
+    authorization = headers.get("authorization")
+
+    # validate that both headers are present and match
+    if not authorization or not api_token:
+        raise AuthError(
+            f"Authentication header is missing: authorization={authorization}, q-api-token={api_token}"
+        )
+
+    if authorization != api_token:
+        raise AuthError(
+            f"Authorization and q-api-token do not match: authorization={authorization}, q-api-token={api_token}"
+        )
+
+
 @tracer.capture_method
 def _verify_id_token(id_token: Optional[str]) -> str:
     if id_token is None:
@@ -231,6 +247,35 @@ def _verify_api_token(api_token: Optional[str]) -> str:
         raise AuthError(f"Failed to list users from Cognito {e}")
 
 
+@tracer.capture_method
+def _generate_stage_resource_arn(resource: str) -> str:
+    # Generate the stage resource ARN for the API Gateway
+    # NOTE: Cached policies must cover all API resources and methods.
+    # Reference: https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html
+    arn_parts = resource.split(":")
+
+    if len(arn_parts) != 6:
+        raise AuthError(f"Invalid methodArn: {resource}")
+
+    region = arn_parts[3]
+    account_id = arn_parts[4]
+
+    api_gateway_parts = arn_parts[5].split("/")
+
+    if len(api_gateway_parts) < 2:
+        raise AuthError(f"Invalid methodArn: {resource}")
+
+    api_id = api_gateway_parts[0]
+    stage = api_gateway_parts[1]
+
+    generated_arn = f"arn:aws:execute-api:{region}:{account_id}:{api_id}/{stage}/*/*"
+    logger.info(
+        f"Generated stage resource ARN: {generated_arn} from methodArn: {resource}"
+    )
+
+    return generated_arn
+
+
 def _generate_policy_allow(principal_id="", resource="", user_id=""):
     # Generate allow policy for the API Gateway
     auth_response = {"principalId": principal_id}
@@ -242,7 +287,7 @@ def _generate_policy_allow(principal_id="", resource="", user_id=""):
                 {
                     "Action": "execute-api:Invoke",
                     "Effect": "Allow",
-                    "Resource": resource,
+                    "Resource": _generate_stage_resource_arn(resource),
                 }
             ],
         }
@@ -262,7 +307,11 @@ def _generate_policy_deny(principal_id="", resource="", user_id=""):
         policy_document = {
             "Version": "2012-10-17",
             "Statement": [
-                {"Action": "execute-api:Invoke", "Effect": "Deny", "Resource": resource}
+                {
+                    "Action": "execute-api:Invoke",
+                    "Effect": "Deny",
+                    "Resource": _generate_stage_resource_arn(resource),
+                }
             ],
         }
         auth_response["policyDocument"] = policy_document
@@ -286,6 +335,8 @@ def lambda_handler(event, context):
 
     try:
         if "q-api-token" in headers:
+            # Get API token from headers
+            _validate_headers_for_api_token(headers)
             # Verify API token
             user_id = _verify_api_token(headers["q-api-token"])
         elif "authorization" in headers:

--- a/backend/tests/oqtopus_cloud/lambda_auth/routers/test_lambda_function.py
+++ b/backend/tests/oqtopus_cloud/lambda_auth/routers/test_lambda_function.py
@@ -117,10 +117,28 @@ def test__validate_headers_for_api_token_success():
     _validate_headers_for_api_token(headers)
 
 
-def test__validate_headers_for_api_token_missing_header():
+def test__validate_headers_for_authorization_missing_header():
     headers = {
         "q-api-token": "token-value",
-        "authorization": None,
+    }
+
+    with pytest.raises(AuthError) as excinfo:
+        _validate_headers_for_api_token(headers)
+
+    assert "Authentication header is missing" in str(excinfo.value)
+
+def test__validate_headers_for_q_api_token_missing_header():
+    headers = {
+        "authorization": "token-value",
+    }
+
+    with pytest.raises(AuthError) as excinfo:
+        _validate_headers_for_api_token(headers)
+
+    assert "Authentication header is missing" in str(excinfo.value)
+
+def test__validate_headers_for_both_headers_missing():
+    headers = {
     }
 
     with pytest.raises(AuthError) as excinfo:

--- a/backend/tests/oqtopus_cloud/lambda_auth/routers/test_lambda_function.py
+++ b/backend/tests/oqtopus_cloud/lambda_auth/routers/test_lambda_function.py
@@ -8,6 +8,8 @@ from oqtopus_cloud.lambda_auth.lambda_function import (
     AuthError,
     _generate_policy_allow,
     _generate_policy_deny,
+    _generate_stage_resource_arn,
+    _validate_headers_for_api_token,
     _verify_api_token,
     _verify_id_token,
     lambda_handler,
@@ -104,6 +106,39 @@ def _get_model(n: int, expiration_day=90, status=UserStatus.approved) -> User:
         + timedelta(days=expiration_day),
     }
     return User(**model_dict)
+
+
+def test__validate_headers_for_api_token_success():
+    headers = {
+        "q-api-token": "token-value",
+        "authorization": "token-value",
+    }
+
+    _validate_headers_for_api_token(headers)
+
+
+def test__validate_headers_for_api_token_missing_header():
+    headers = {
+        "q-api-token": "token-value",
+        "authorization": None,
+    }
+
+    with pytest.raises(AuthError) as excinfo:
+        _validate_headers_for_api_token(headers)
+
+    assert "Authentication header is missing" in str(excinfo.value)
+
+
+def test__validate_headers_for_api_token_mismatch():
+    headers = {
+        "q-api-token": "token-value",
+        "authorization": "another-value",
+    }
+
+    with pytest.raises(AuthError) as excinfo:
+        _validate_headers_for_api_token(headers)
+
+    assert "Authorization and q-api-token do not match" in str(excinfo.value)
 
 
 def test__verify_id_token(test_session, monkeypatch):
@@ -358,10 +393,36 @@ def test__verify_api_token_unapproved(test_session, monkeypatch):
         _ = _verify_api_token("api_token_id_1.api_token_secret_1")
 
 
-def test__generate_policy_allow():
-    actual = _generate_policy_allow(
-        "fake_username1", 'event["methodArn"]1', "fake_username1"
+def test__generate_stage_resource_arn():
+    method_arn = "arn:aws:execute-api:ap-northeast-1:123456789012:api-id/dev/GET/foo"
+
+    actual = _generate_stage_resource_arn(method_arn)
+
+    assert (
+        actual
+        == "arn:aws:execute-api:ap-northeast-1:123456789012:api-id/dev/*/*"
     )
+
+
+def test__generate_stage_resource_arn_invalid_arn_format():
+    with pytest.raises(AuthError) as excinfo:
+        _generate_stage_resource_arn("invalid-method-arn")
+
+    assert "Invalid methodArn" in str(excinfo.value)
+
+
+def test__generate_stage_resource_arn_invalid_api_gateway_part():
+    with pytest.raises(AuthError) as excinfo:
+        _generate_stage_resource_arn(
+            "arn:aws:execute-api:ap-northeast-1:123456789012:api-id"
+        )
+
+    assert "Invalid methodArn" in str(excinfo.value)
+
+
+def test__generate_policy_allow():
+    method_arn = "arn:aws:execute-api:ap-northeast-1:123456789012:api-id/dev/GET/devices"
+    actual = _generate_policy_allow("fake_username1", method_arn, "fake_username1")
     expect = {
         "principalId": "fake_username1",
         "policyDocument": {
@@ -370,7 +431,7 @@ def test__generate_policy_allow():
                 {
                     "Action": "execute-api:Invoke",
                     "Effect": "Allow",
-                    "Resource": 'event["methodArn"]1',
+                    "Resource": "arn:aws:execute-api:ap-northeast-1:123456789012:api-id/dev/*/*",
                 }
             ],
         },
@@ -381,9 +442,8 @@ def test__generate_policy_allow():
 
 
 def test__generate_policy_deny():
-    actual = _generate_policy_deny(
-        "fake_username2", 'event["methodArn"]2', "fake_username2"
-    )
+    method_arn = "arn:aws:execute-api:ap-northeast-1:123456789012:api-id/prod/POST/jobs"
+    actual = _generate_policy_deny("fake_username2", method_arn, "fake_username2")
     expect = {
         "principalId": "fake_username2",
         "policyDocument": {
@@ -392,7 +452,7 @@ def test__generate_policy_deny():
                 {
                     "Action": "execute-api:Invoke",
                     "Effect": "Deny",
-                    "Resource": 'event["methodArn"]2',
+                    "Resource": "arn:aws:execute-api:ap-northeast-1:123456789012:api-id/prod/*/*",
                 }
             ],
         },
@@ -406,7 +466,13 @@ def test_lambda_handler_api_token(monkeypatch):
     def fake__verify_api_token(id_token=""):
         return "fake_username"
 
-    input = {"headers": {"q-api-token": "api_token_secret"}, "methodArn": "methodArn"}
+    input = {
+        "headers": {
+            "q-api-token": "api_token_secret",
+            "authorization": "api_token_secret",
+        },
+        "methodArn": "methodArn",
+    }
 
     const = {
         "principalId": "fake_username",

--- a/docs/en/developer_guidelines/faq.md
+++ b/docs/en/developer_guidelines/faq.md
@@ -46,3 +46,11 @@ profile = "myprofile-tf"
 After running `terraform init -backend-config=oqtopus-dev.tfbackend -reconfigure` under `terraform/infrastructure/oqtopus-dev`, you can execute `terraform plan` to run Terraform with MFA authentication.
 
 See details in here: [Terraform AWS Provider Issue #2420](https://github.com/hashicorp/terraform-provider-aws/issues/2420#issuecomment-1899137746)
+
+Q. When using `q-api-token` with Lambda authorizer authentication, is the `authorization` header optional?
+
+A. No. Due to Lambda authorizer cache key behavior, the `authorization` header is required even when using `q-api-token`. Set the same value in both `authorization` and `q-api-token`.
+
+Q. Is there anything to consider when setting the Resource in a Policy Document with Lambda authorizer caching enabled?
+
+A. When caching is enabled, API Gateway reuses the generated Policy Document for subsequent requests. If access to the entire API is allowed, the Resource must cover all resources and HTTP methods within the target stage. Reference: https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html

--- a/docs/ja/developer_guidelines/faq.md
+++ b/docs/ja/developer_guidelines/faq.md
@@ -47,3 +47,11 @@ profile = "myprofile-tf"
 `terraform/infrastructure/oqtopus-dev`配下で`terraform init -backend-config=oqtopus-dev.tfbackend -reconfigure`を実行後、`terraform plan`を実行することでMFA認証付きでのTerraform実行が可能です。
 
 詳細は以下を参照してください。 : [Terraform AWS Provider Issue #2420](https://github.com/hashicorp/terraform-provider-aws/issues/2420#issuecomment-1899137746)
+
+Q. Lambdaオーソライザー認証で`q-api-token`を使う場合、`authorization`ヘッダーは不要ですか？
+
+A. いいえ。Lambdaオーソライザーのキャッシュキー都合で、`q-api-token`利用時でも`authorization`ヘッダーが必須です。`authorization`と`q-api-token`には同じ値を設定してください。
+
+Q. Lambda Authorizerのキャッシュを有効にする場合、Policy DocumentのResource設定で注意することはありますか？
+
+A. キャッシュを有効にすると、API Gatewayは生成されたPolicy Documentを後続のリクエストでも再利用します。API全体へのアクセスを許可する場合は、Resourceに対象ステージ配下のすべてのリソースおよびHTTPメソッドを含めてください。参考: https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html

--- a/terraform/service/modules/api-server/main.tf
+++ b/terraform/service/modules/api-server/main.tf
@@ -341,12 +341,17 @@ resource "aws_api_gateway_deployment" "this" {
   rest_api_id = aws_api_gateway_rest_api.this.id
   triggers = {
     code_hash = md5(file("../modules/api-server/main.tf"))
+    # Redeploy when Lambda authorizer cache TTL changes.
+    authorizer_redeployment = sha1(jsonencode({
+      cache_ttl_seconds = var.lambda_authorizer_cache_ttl_seconds
+    }))
   }
   lifecycle {
     create_before_destroy = true
   }
   depends_on = [
     aws_api_gateway_integration.this,
+    aws_api_gateway_authorizer.lambda,
   ]
 }
 
@@ -502,8 +507,8 @@ resource "aws_api_gateway_authorizer" "lambda" {
   name                             = "${var.product}-${var.org}-${var.env}-${var.identifier}-lambda_auth"
   rest_api_id                      = aws_api_gateway_rest_api.this.id
   type                             = "REQUEST"
-  identity_source                  = ""
-  authorizer_result_ttl_in_seconds = 0
+  identity_source                  = "method.request.header.Authorization"
+  authorizer_result_ttl_in_seconds = var.lambda_authorizer_cache_ttl_seconds
   authorizer_uri                   = "arn:aws:apigateway:${var.region}:lambda:path/2015-03-31/functions/${var.lambda_authorizer_arn}:${var.lambda_authorizer_alias}/invocations"
 }
 

--- a/terraform/service/modules/api-server/variables.tf
+++ b/terraform/service/modules/api-server/variables.tf
@@ -121,6 +121,20 @@ variable "manage_cognito_user_pool" {
   default     = false
 }
 
+variable "lambda_authorizer_cache_ttl_seconds" {
+  description = "TTL in seconds for the Lambda authorizer result cache. Set to 0 to disable caching."
+  type        = number
+  default     = 300
+
+  validation {
+    condition = (
+      var.lambda_authorizer_cache_ttl_seconds >= 0 &&
+      var.lambda_authorizer_cache_ttl_seconds <= 3600
+    )
+    error_message = "lambda_authorizer_cache_ttl_seconds must be between 0 and 3600."
+  }
+}
+
 variable "lambda_authorizer_arn" {
   type        = string
   default     = ""


### PR DESCRIPTION
# 📃 Ticket

- https://github.com/oqtopus-team/oqtopus-cloud/issues/489

## ✍ Description

I enabled caching for the Lambda Authorizer.
The major changes are in two areas: the Lambda Authorizer implementation and Terraform.


### Lambda Authorizer Implementation

- Added the "Authorization" header to requests from oqtopus-client. The authorizer now validates whether this value matches the q-api-token.
- To enable caching, it is necessary to cache authorization results at an appropriate resource scope. Therefore, the resource ARN has been updated to use the following format: "arn:aws:execute-api:{region}:{account_id}:{api_id}/{stage}/*/*"

### Terraform

- Added support for configuring the cache TTL. The default value is 300 seconds.