### PR TITLE
feat: enrich device API error status codes

### DIFF
--- a/backend/oas/admin/paths/devices.yaml
+++ b/backend/oas/admin/paths/devices.yaml
@@ -61,6 +61,14 @@ devices:
         description: "Unauthorized"
       "403":
         description: "Not authorized"
+      "409":
+        description: Conflict
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/error.yaml#/error.ConflictError"
+            example:
+              message: device_id already exists
       "500":
         description: Internal Server Error
         content:

--- a/backend/oas/admin/schemas/error.yaml
+++ b/backend/oas/admin/schemas/error.yaml
@@ -19,3 +19,10 @@ error.BadRequestError:
       type: string
   required:
     - message
+error.ConflictError:
+  type: object
+  properties:
+    message:
+      type: string
+  required:
+    - message

--- a/backend/oqtopus_cloud/admin/routers/devices.py
+++ b/backend/oqtopus_cloud/admin/routers/devices.py
@@ -18,6 +18,7 @@ from oqtopus_cloud.admin.schemas.devices import (
 )
 from oqtopus_cloud.admin.schemas.errors import (
     BadRequestErrorResponse,
+    ConflictErrorResponse,
     ErrorResponse,
     InternalServerErrorResponse,
     Message,
@@ -170,7 +171,7 @@ def get_device_info_upload_url(
 @router.post(
     "/devices",
     response_model=SuccessResponse,
-    responses={400: {"model": Message}, 500: {"model": Message}},
+    responses={400: {"model": Message}, 409: {"model": Message}, 500: {"model": Message}},
 )
 @tracer.capture_method
 def register_devices(
@@ -188,7 +189,7 @@ def register_devices(
         ).first()
         if existing_device:
             logger.error(f"device_id={device_id} already exists")
-            return BadRequestErrorResponse(
+            return ConflictErrorResponse(
                 message=f"device_id={device_id} already exists"
             )
         new_device = schema_to_model(device_id, device_info)

--- a/backend/oqtopus_cloud/admin/schemas/errors.py
+++ b/backend/oqtopus_cloud/admin/schemas/errors.py
@@ -93,3 +93,26 @@ class BadRequestErrorResponse(ErrorResponse):
             status_code=400,
             content={"message": message},
         )
+
+
+class ConflictErrorResponse(ErrorResponse):
+    """
+    Represents an error response for a conflict (HTTP status code 409).
+
+    Args:
+        message (str): The detailed error message.
+
+    Attributes:
+        status_code (int): The HTTP status code for the error response (409).
+        content (dict): The content of the error response.
+
+    """
+
+    def __init__(
+        self,
+        message: str,
+    ):
+        super().__init__(
+            status_code=409,
+            content={"message": message},
+        )

--- a/backend/oqtopus_cloud/user/routers/devices.py
+++ b/backend/oqtopus_cloud/user/routers/devices.py
@@ -84,27 +84,27 @@ def get_device(
     Returns:
         GetDeviceResponse: _description_
     """
-    # TODO implement error handling
     try:
         user_id = event.state.user_id
         logger.info(f"User {user_id} is trying to access device_id={device_id}.")
-        available_devices = get_user_available_devices(user_id, db)
 
+        # Check order: 404 (existence) before 403 (authorization)
+        device = db.scalars(select(Device).where(Device.id == device_id)).first()
+        logger.info("invoked get_device")
+        if not device:
+            message = f"device_id={device_id} is not found."
+            logger.info(message)
+            return NotFoundErrorResponse(message=message)
+
+        available_devices = get_user_available_devices(user_id, db)
         if available_devices != "*" and device_id not in available_devices:
             logger.error(f"{user_id} is not allowed to access device_id={device_id}.")
             return ForbiddenErrorResponse(
                 message=f"Cannot access device_id={device_id}."
             )
 
-        device = db.scalars(select(Device).where(Device.id == device_id)).first()
-        logger.info("invoked get_device")
-        if device:
-            response = model_to_schema(device, storage)
-            return response
-        else:
-            message = f"device_id={device_id} is not found."
-            logger.info(message)
-            return NotFoundErrorResponse(message=message)
+        response = model_to_schema(device, storage)
+        return response
     except Exception as e:
         tracer.put_annotation("error", str(e))
         logger.exception(f"Internal Server Error: {e}")

--- a/backend/tests/oqtopus_cloud/admin/routers/test_devices.py
+++ b/backend/tests/oqtopus_cloud/admin/routers/test_devices.py
@@ -296,7 +296,7 @@ def test_register_devices_overlap(
     }
 
     response = client.post("/devices", json=body)
-    assert response.status_code == 400
+    assert response.status_code == 409
     assert response.json() == {"message": "device_id=SVSim1 already exists"}
 
 

--- a/backend/tests/oqtopus_cloud/user/routers/test_devices.py
+++ b/backend/tests/oqtopus_cloud/user/routers/test_devices.py
@@ -205,6 +205,29 @@ def test_cannot_get_device_that_not_exist(test_db):
     assert json.loads(response.body) == {"message": f"device_id={device} is not found."}
 
 
+def test_nonexistent_device_returns_404_even_without_permission(test_db):
+    """When device does not exist, return 404 regardless of user permissions.
+    This verifies the check order: existence (404) before authorization (403)."""
+    # Arrange
+    user_no = 1
+    device = "NonExistent"
+    request = _create_request()
+    request.state.user_id = f"email_{user_no}"
+
+    test_db.add(_get_user_model(user_no, ["Kawasaki", "SVSim"]))
+    test_db.commit()
+
+    # Act
+    response = get_device(device, request, test_db)
+
+    # Assert - should be 404, not 403
+    assert isinstance(response, NotFoundErrorResponse)
+    assert response.status_code == 404
+    assert json.loads(response.body) == {
+        "message": f"device_id={device} is not found."
+    }
+
+
 def test_can_only_get_devices_that_user_can_access(test_db):
     # Arrange
     user_no = 1


### PR DESCRIPTION
# 📃 Ticket
N.A.

## ✍ Description
Reorder check logic in device API endpoints so that error status codes follow the design specification: 401 → 400 → 404 → 403 → 409 → 500.

- **User API `GET /devices/{device_id}`:** Reorder existence check (404) before authorization check (403) to prevent ambiguous 403 responses for non-existent devices
- **Admin API `POST /devices`:** Change duplicate device registration response from 400 Bad Request to 409 Conflict, add `ConflictErrorResponse` class
- **OAS definitions:** Add `error.ConflictError` schema and 409 response to `POST /devices`

## 📸 Test Result
- User device tests: 9/9 passed
- Admin device tests: 21/21 passed

## 🔗 Related PRs
N/A