### PR TITLE
fix: reconcile User and Provider S3 submit job schemas

### DIFF
--- a/backend/oas/provider/schemas/jobs.yaml
+++ b/backend/oas/provider/schemas/jobs.yaml
@@ -56,37 +56,32 @@ jobs.Job:
       nullable: true
       properties: {}
       additionalProperties: true
-      example: {
-        qubit_allocation: {
-          "0": 12,
+      example:
+        qubit_allocation:
+          "0": 12
           "1": 16
-        },
-        skip_transpilation: false,
+        skip_transpilation: false
         seed_transpilation: 873
-      }
     simulator_info:
       type: object
       properties: {}
       additionalProperties: true
       nullable: true
-      example: {
-        "n_qubits": 5,
-        "n_nodes": 12,
-        "n_per_node": 2,
-        "seed_simulation": 39058567,
-        "simulation_opt": {
-          "optimization_method": "light",
-          "optimization_block_size": 1,
-          "optimization_swap_level": 1
-        }
-      }
+      example:
+        n_qubits: 5
+        n_nodes: 12
+        n_per_node: 2
+        seed_simulation: 39058567
+        simulation_opt:
+          optimization_method: light
+          optimization_block_size: 1
+          optimization_swap_level: 1
     mitigation_info:
       type: object
       properties: {}
       additionalProperties: true
-      example: {
-        "ro_error_mitigation": "pseudo_inverse"
-      }
+      example:
+        ro_error_mitigation: pseudo_inverse
       nullable: true
     status:
       $ref: "#/jobs.JobStatus"
@@ -129,28 +124,23 @@ jobs.Job:
       device_id: Kawasaki
       job_type: sampling
       input: https://oqtopus-cloud.s3.amazonaws.com/jobs/7af020f6-2e38-4d70-8cf0-4349650ea08c/input.zip?AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE&Expires=1714425600&Signature=abc123def456ghi789jkl%2Fsignature%3D
-      transpiler_info: {
-        qubit_allocation: {
-          "0": 12,
+      transpiler_info:
+        qubit_allocation:
+          "0": 12
           "1": 16
-        },
-        skip_transpilation: false,
+        skip_transpilation: false
         seed_transpilation: 873
-      }
-      simulator_info: {
-        "n_qubits": 5,
-        "n_nodes": 12,
-        "n_per_node": 2,
-        "seed_simulation": 39058567,
-        "simulation_opt": {
-          "optimization_method": "light",
-          "optimization_block_size": 1,
-          "optimization_swap_level": 1
-        }
-      }
-      mitigation_info: {
-        "ro_error_mitigation": "pseudo_inverse"
-      }
+      simulator_info:
+        n_qubits: 5
+        n_nodes: 12
+        n_per_node: 2
+        seed_simulation: 39058567
+        simulation_opt:
+          optimization_method: light
+          optimization_block_size: 1
+          optimization_swap_level: 1
+      mitigation_info:
+        ro_error_mitigation: pseudo_inverse
       shots: 1000
       status: submitted
       execution_time: 10.123
@@ -189,11 +179,10 @@ jobs.JobStatusUpdate:
       items:
         type: string
       nullable: true
-      example: [
-        7af020f6-2e38-4d70-8cf0-4349650ea08c/combined_program.zip,
-        7af020f6-2e38-4d70-8cf0-4349650ea08c/transpile_result.zip,
-        7af020f6-2e38-4d70-8cf0-4349650ea08c/result.zip
-      ]
+      example:
+        - 7af020f6-2e38-4d70-8cf0-4349650ea08c/combined_program.zip
+        - 7af020f6-2e38-4d70-8cf0-4349650ea08c/transpile_result.zip
+        - 7af020f6-2e38-4d70-8cf0-4349650ea08c/result.zip
     message:
       type: string
       nullable: true
@@ -287,9 +276,8 @@ jobs.S3SubmitJobInfo:
         Otherwise, those programs are combined according to the multiprogramming machinery.
       items:
         type: string
-      example: [
-          "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;"
-        ]
+      example:
+        - "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;"
     operator:
       type: array
       items:
@@ -313,31 +301,27 @@ jobs.S3SamplingResult:
       nullable: false
       properties: {}
       additionalProperties: true
-      example: {
-        "10": 84,
-        "11": 387,
-        "00": 454,
+      example:
+        "10": 84
+        "11": 387
+        "00": 454
         "01": 75
-      }
     divided_counts:
       type: object
       nullable: true
       properties: {}
       additionalProperties: true
-      example: {
-        "0": {
-          "00": 84,
-          "11": 387,
-          "10": 454,
+      example:
+        "0":
+          "00": 84
+          "11": 387
+          "10": 454
           "01": 75
-        },
-        "1": {
-          "00": 84,
-          "11": 387,
-          "10": 454,
+        "1":
+          "00": 84
+          "11": 387
+          "10": 454
           "01": 75
-        }
-      }
   required:
     - counts
 

--- a/backend/oas/user/openapi.yaml
+++ b/backend/oas/user/openapi.yaml
@@ -894,7 +894,7 @@ components:
       properties:
         program:
           type: array
-          description: A list of OPENQASM3 program. For non-multiprogramming jobs, this field is assumed to contain exactly one program. Otherwise, those programs are combined according to the multiprogramming machinery.
+          description: A list of OPENQASM3 program. Required for sampling, estimation and multiprogramming jobs. For non-multiprogramming jobs, this field is assumed to contain exactly one program. Otherwise, those programs are combined according to the multiprogramming machinery.
           items:
             type: string
           example:
@@ -903,8 +903,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/jobs.S3OperatorItem'
-      required:
-        - program
+          description: Estimation operator. Required for estimation jobs.
+        sse_program:
+          type: string
+          description: SSE user program. Required for SSE jobs.
     jobs.S3JobResult:
       type: object
       properties:
@@ -1532,11 +1534,11 @@ components:
         pauli:
           type: string
           description: The Pauli string.
+          nullable: false
           example: X 0 X 1
         coeff:
-          type: number
           description: Coefficient number in the Pauli string representation.
-          example: 1
+          type: number
       required:
         - pauli
     jobs.S3SamplingResult:

--- a/backend/oas/user/schemas/jobs.yaml
+++ b/backend/oas/user/schemas/jobs.yaml
@@ -10,9 +10,9 @@ jobs.GetJobStatusResponse:
       $ref: "#/jobs.JobId"
     status:
       $ref: "#/jobs.JobStatus"
-  required: [
-    job_id,status
-  ]
+  required:
+    - job_id
+    - status
 
 jobs.RegisterJobResponse:
   description: Register new job
@@ -65,36 +65,31 @@ jobs.SubmitJobRequest:
       type: object
       properties: {}
       additionalProperties: true
-      example: {
-        "qubit_allocation": {
-          "0": 12,
+      example:
+        qubit_allocation:
+          "0": 12
           "1": 16
-        },
-        "skip_transpilation": false,
-        "seed_transpilation": 873
-      }
+        skip_transpilation: false
+        seed_transpilation: 873
     simulator_info:
       type: object
       properties: {}
       additionalProperties: true
-      example: {
-        "n_qubits": 5,
-        "n_nodes": 12,
-        "n_per_node": 2,
-        "seed_simulation": 39058567,
-        "simulation_opt": {
-          "optimization_method": "light",
-          "optimization_block_size": 1,
-          "optimization_swap_level": 1
-        }
-      }
+      example:
+        n_qubits: 5
+        n_nodes: 12
+        n_per_node: 2
+        seed_simulation: 39058567
+        simulation_opt:
+          optimization_method: light
+          optimization_block_size: 1
+          optimization_swap_level: 1
     mitigation_info:
       type: object
       properties: {}
       additionalProperties: true
-      example: {
-        "ro_error_mitigation": "pseudo_inverse"
-      }
+      example:
+        ro_error_mitigation: pseudo_inverse
     shots:
       type: integer
       minimum: 1
@@ -148,36 +143,31 @@ jobs.Job:
       type: object
       properties: {}
       additionalProperties: true
-      example: {
-        "qubit_allocation": {
-          "0": 12,
+      example:
+        qubit_allocation:
+          "0": 12
           "1": 16
-        },
-        "skip_transpilation": false,
-        "seed_transpilation": 873
-      }
+        skip_transpilation: false
+        seed_transpilation: 873
     simulator_info:
       type: object
       properties: {}
       additionalProperties: true
-      example: {
-        "n_qubits": 5,
-        "n_nodes": 12,
-        "n_per_node": 2,
-        "seed_simulation": 39058567,
-        "simulation_opt": {
-          "optimization_method": "light",
-          "optimization_block_size": 1,
-          "optimization_swap_level": 1
-        }
-      }
+      example:
+        n_qubits: 5
+        n_nodes: 12
+        n_per_node: 2
+        seed_simulation: 39058567
+        simulation_opt:
+          optimization_method: light
+          optimization_block_size: 1
+          optimization_swap_level: 1
     mitigation_info:
       type: object
       properties: {}
       additionalProperties: true
-      example: {
-        "ro_error_mitigation": "pseudo_inverse"
-      }
+      example:
+        ro_error_mitigation: pseudo_inverse
     execution_time:
       type: number
       example: 10.123
@@ -204,18 +194,25 @@ jobs.Job:
       description: Bell State Sampling Example
       device_id: Kawasaki
       job_type: estimation
-      job_info: {
-        "input": https://oqtopus-cloud.s3.amazonaws.com/jobs/7af020f6-2e38-4d70-8cf0-4349650ea08c/input.zip?AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE&Expires=1714425600&Signature=abc123def456ghi789jkl%2Fsignature%3D
-      }
-      transpiler_info: {
-        "qubit_allocation": { "0": 12, "1": 16 }, "skip_transpilation": false, "seed_transpilation": 873
-      }
-      simulator_info: {
-        "n_qubits": 5, "n_nodes": 12, "n_per_node": 2, "seed_simulation": 39058567, "simulation_opt": { "optimization_method": "light", "optimization_block_size": 1, "optimization_swap_level": 1 }
-      }
-      mitigation_info: {
-        "ro_error_mitigation": "pseudo_inverse"
-      }
+      job_info:
+        input: https://oqtopus-cloud.s3.amazonaws.com/jobs/7af020f6-2e38-4d70-8cf0-4349650ea08c/input.zip?AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE&Expires=1714425600&Signature=abc123def456ghi789jkl%2Fsignature%3D
+      transpiler_info:
+        qubit_allocation:
+          "0": 12
+          "1": 16
+        skip_transpilation: false
+        seed_transpilation: 873
+      simulator_info:
+        n_qubits: 5
+        n_nodes: 12
+        n_per_node: 2
+        seed_simulation: 39058567
+        simulation_opt:
+          optimization_method: light
+          optimization_block_size: 1
+          optimization_swap_level: 1
+      mitigation_info:
+        ro_error_mitigation: pseudo_inverse
       shots: 1000
       status: submitted
       execution_time: 10.123
@@ -318,11 +315,11 @@ jobs.S3OperatorItem:
     pauli:
       type: string
       description: The Pauli string.
+      nullable: false
       example: "X 0 X 1"
     coeff:
-      type: number
       description: "Coefficient number in the Pauli string representation."
-      example: 1.0
+      type: number
   required:
     - pauli
 
@@ -333,19 +330,25 @@ jobs.S3SubmitJobInfo:
       type: array
       description: >-
         A list of OPENQASM3 program.
+        Required for sampling, estimation and multiprogramming jobs.
         For non-multiprogramming jobs, this field is assumed to contain exactly one program.
         Otherwise, those programs are combined according to the multiprogramming machinery.
       items:
         type: string
-      example: [
-        "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;"
-      ]
+      example:
+        - "OPENQASM 3; qubit[2] q; bit[2] c; h q[0]; cnot q[0], q[1]; c = measure q;"
     operator:
       type: array
       items:
         $ref: "#/jobs.S3OperatorItem"
-  required:
-    - program
+      description: >-
+        Estimation operator.
+        Required for estimation jobs.
+    sse_program:
+      type: string
+      description: >-
+        SSE user program.
+        Required for SSE jobs.
 
 jobs.S3SamplingResult:
   type: object
@@ -355,31 +358,27 @@ jobs.S3SamplingResult:
       type: object
       properties: {}
       additionalProperties: true
-      example: {
-        "00": 84,
-        "11": 387,
-        "10": 454,
+      example:
+        "00": 84
+        "11": 387
+        "10": 454
         "01": 75
-      }
     divided_counts:
       type: object
       properties: {}
       additionalProperties: true
       nullable: true
-      example: {
-        "0": {
-          "00": 84,
-          "11": 387,
-          "10": 454,
+      example:
+        "0":
+          "00": 84
+          "11": 387
+          "10": 454
           "01": 75
-        },
-        "1": {
-          "00": 84,
-          "11": 387,
-          "10": 454,
+        "1":
+          "00": 84
+          "11": 387
+          "10": 454
           "01": 75
-        }
-      }
 
 jobs.S3EstimationResult:
   type: object

--- a/backend/oqtopus_cloud/user/schemas/jobs.py
+++ b/backend/oqtopus_cloud/user/schemas/jobs.py
@@ -269,7 +269,7 @@ class S3OperatorItem(BaseModel):
     """
     The Pauli string.
     """
-    coeff: Annotated[float | None, Field(examples=[1])] = None
+    coeff: float | None = None
     """
     Coefficient number in the Pauli string representation.
     """
@@ -340,7 +340,7 @@ class RegisteredJob(Job):
 
 class S3SubmitJobInfo(BaseModel):
     program: Annotated[
-        list[str],
+        list[str] | None,
         Field(
             examples=[
                 [
@@ -348,11 +348,18 @@ class S3SubmitJobInfo(BaseModel):
                 ]
             ]
         ),
-    ]
+    ] = None
     """
-    A list of OPENQASM3 program. For non-multiprogramming jobs, this field is assumed to contain exactly one program. Otherwise, those programs are combined according to the multiprogramming machinery.
+    A list of OPENQASM3 program. Required for sampling, estimation and multiprogramming jobs. For non-multiprogramming jobs, this field is assumed to contain exactly one program. Otherwise, those programs are combined according to the multiprogramming machinery.
     """
     operator: list[S3OperatorItem] | None = None
+    """
+    Estimation operator. Required for estimation jobs.
+    """
+    sse_program: str | None = None
+    """
+    SSE user program. Required for SSE jobs.
+    """
 
 
 class S3JobResult(BaseModel):

--- a/docs/en/architecture/quantum_jobs_in_detail.md
+++ b/docs/en/architecture/quantum_jobs_in_detail.md
@@ -85,8 +85,9 @@ The `ready -> failed` transition is supported so that provider-side preprocessin
 | --- | --- | --- |
 | `program` | `sampling`, `estimation`, `multi_manual` | Array of OpenQASM 3 programs. Non-multiprogramming jobs normally contain one program. |
 | `operator` | `estimation` | Array of Pauli operator items. |
+| `sse_program` | `sse` | SSE user program. |
 
-The Provider API has a separate generated `jobs.S3SubmitJobInfo` schema that includes `sse_program` for SSE jobs. That field is not part of the User API input-upload schema described here.
+The User and Provider API definitions of `jobs.S3SubmitJobInfo` are kept aligned so the upload and download sides use the same contract.
 
 For provider output zip files and the conventional payload names/schema inside them, refer to the storage-model table above.
 

--- a/docs/ja/architecture/quantum_jobs_in_detail.md
+++ b/docs/ja/architecture/quantum_jobs_in_detail.md
@@ -88,8 +88,9 @@ DB にはジョブ ID と `.zip` suffix を除いた正規化済みオブジェ�
 | --- | --- | --- |
 | `program` | `sampling`, `estimation`, `multi_manual` | OpenQASM 3 program の配列です。非 multiprogramming job では通常 1 つの program を含みます。 |
 | `operator` | `estimation` | Pauli operator item の配列です。 |
+| `sse_program` | `sse` | SSE user program です。 |
 
-Provider API には、SSE job 用の `sse_program` を含む別の generated `jobs.S3SubmitJobInfo` schema があります。このフィールドは、ここで説明している User API の input upload schema には含まれません。
+User API と Provider API の `jobs.S3SubmitJobInfo` 定義を揃え、upload 側と download 側で同じ契約を使用します。
 
 Provider の出力 zip とその中の慣例上の payload 名、schema/format の対応は上のストレージモデル表を参照してください。
 

--- a/docs/oas/user/openapi.yaml
+++ b/docs/oas/user/openapi.yaml
@@ -894,7 +894,7 @@ components:
       properties:
         program:
           type: array
-          description: A list of OPENQASM3 program. For non-multiprogramming jobs, this field is assumed to contain exactly one program. Otherwise, those programs are combined according to the multiprogramming machinery.
+          description: A list of OPENQASM3 program. Required for sampling, estimation and multiprogramming jobs. For non-multiprogramming jobs, this field is assumed to contain exactly one program. Otherwise, those programs are combined according to the multiprogramming machinery.
           items:
             type: string
           example:
@@ -903,8 +903,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/jobs.S3OperatorItem'
-      required:
-        - program
+          description: Estimation operator. Required for estimation jobs.
+        sse_program:
+          type: string
+          description: SSE user program. Required for SSE jobs.
     jobs.S3JobResult:
       type: object
       properties:
@@ -1532,11 +1534,11 @@ components:
         pauli:
           type: string
           description: The Pauli string.
+          nullable: false
           example: X 0 X 1
         coeff:
-          type: number
           description: Coefficient number in the Pauli string representation.
-          example: 1
+          type: number
       required:
         - pauli
     jobs.S3SamplingResult:


### PR DESCRIPTION
# 📃 Ticket

Closes #477

## ✍ Description

This PR reconciles the separate `jobs.S3SubmitJobInfo` definitions in the User and Provider APIs.

### Changes

- Added `sse_program` to the User API schema for SSE jobs.
- Made `program` optional:
  - `program` is required for sampling, estimation, and multi-manual jobs.
  - SSE jobs use `sse_program` instead.
  - These requirements depend on `job_type`, which is outside `S3SubmitJobInfo`, so the fields remain optional at the schema level.
- Added the estimation-job description to `operator` in the User API schema.
- Aligned `S3OperatorItem` and `S3SubmitJobInfo` between the User and Provider APIs.
- Kept the existing OAS structure by defining the schemas separately in each API's `schemas/jobs.yaml`.
- Updated the English and Japanese architecture documentation.
- Converted related JSON-style multiline YAML examples to standard YAML syntax so they can be processed by the current Redocly CLI.
  - This formatting change does not alter the example values.

## 📸 Test Result

### OpenAPI generation and lint

```console
cd backend/oas
make generate-user generate-provider
```

Both User and Provider OpenAPI specifications were bundled and validated successfully. Only pre-existing warnings remain.

### Related API tests

```console
cd backend
pytest \
  tests/oqtopus_cloud/user/routers/test_jobs.py \
  tests/oqtopus_cloud/provider/routers/test_jobs.py
```

```text
51 passed
```

### Generated model validation

Confirmed that both generated Pydantic models accept:

- A standard job payload containing only `program`
- An SSE job payload containing only `sse_program`

Also confirmed that the User and Provider definitions of `S3OperatorItem` and `S3SubmitJobInfo` are structurally identical.

### Documentation

```console
mkdocs build
```

Build succeeded.

## 🔗 Related PRs

- #466