### PR TITLE
refactor: make the RDS instance class per-environment and move dev to db.t4g.small

### DIFF
--- a/docs/en/operation/deployment.md
+++ b/docs/en/operation/deployment.md
@@ -95,6 +95,8 @@ org="oqtopus"
 env="dev"
 region = "ap-northeast-1"
 
+db_instance_class = "db.t4g.small"
+
 vpc_flow_log_retention_days = 14
 s3_logs_expiration_days = 365
 s3_logs_transition_days_standard_ia = 30

--- a/docs/ja/operation/deployment.md
+++ b/docs/ja/operation/deployment.md
@@ -98,6 +98,8 @@ org="oqtopus"
 env="dev"
 region = "ap-northeast-1"
 
+db_instance_class = "db.t4g.small"
+
 enable_guardduty               = false
 enable_guardduty_s3_protection = false
 ```

--- a/terraform/example/oqtopus-dev/infrastructure/terraform.tfvars.txt
+++ b/terraform/example/oqtopus-dev/infrastructure/terraform.tfvars.txt
@@ -4,6 +4,8 @@ org="oqtopus"
 env="dev"
 region = "ap-northeast-1"
 
+db_instance_class = "db.t4g.small"
+
 vpc_flow_log_retention_days = 14
 s3_logs_expiration_days = 365
 s3_logs_transition_days_standard_ia = 30

--- a/terraform/infrastructure/oqtopus-dev/main.tf
+++ b/terraform/infrastructure/oqtopus-dev/main.tf
@@ -45,7 +45,7 @@ module "db" {
   db_name                         = "main"
   user_name                       = var.db_user_name
   db_proxy_security_group_ids     = module.security_group.db_proxy_security_group_ids
-  db_instance_class               = "db.t4g.small"
+  db_instance_class               = var.db_instance_class
   db_multi_az                     = false
   db_performance_insights_enabled = false
 }

--- a/terraform/infrastructure/oqtopus-dev/main.tf
+++ b/terraform/infrastructure/oqtopus-dev/main.tf
@@ -45,7 +45,7 @@ module "db" {
   db_name                         = "main"
   user_name                       = var.db_user_name
   db_proxy_security_group_ids     = module.security_group.db_proxy_security_group_ids
-  db_instance_class               = "db.t4g.micro"
+  db_instance_class               = "db.t4g.small"
   db_multi_az                     = false
   db_performance_insights_enabled = false
 }

--- a/terraform/infrastructure/oqtopus-dev/variables.tf
+++ b/terraform/infrastructure/oqtopus-dev/variables.tf
@@ -52,6 +52,12 @@ variable "db_user_name" {
   sensitive = true
 }
 
+variable "db_instance_class" {
+  description = "RDS instance class, e.g. db.t4g.small or db.t4g.medium"
+  type        = string
+  default     = "db.t4g.small"
+}
+
 variable "vpc_flow_log_retention_days" {
   description = "Number of days for which VPC flow logs are retained"
   type        = number

--- a/terraform/infrastructure/oqtopus-prod/main.tf
+++ b/terraform/infrastructure/oqtopus-prod/main.tf
@@ -45,7 +45,7 @@ module "db" {
   db_name                         = "main"
   user_name                       = var.db_user_name
   db_proxy_security_group_ids     = module.security_group.db_proxy_security_group_ids
-  db_instance_class               = "db.t4g.medium"
+  db_instance_class               = var.db_instance_class
   db_multi_az                     = true
   db_performance_insights_enabled = true
 }

--- a/terraform/infrastructure/oqtopus-prod/variables.tf
+++ b/terraform/infrastructure/oqtopus-prod/variables.tf
@@ -23,6 +23,12 @@ variable "db_user_name" {
   type        = string
 }
 
+variable "db_instance_class" {
+  description = "RDS instance class, e.g. db.t4g.small or db.t4g.medium"
+  type        = string
+  default     = "db.t4g.medium"
+}
+
 variable "profile" {
   description = "aws profile"
   type        = string


### PR DESCRIPTION
## Summary

The RDS instance class is hardcoded in each environment's root module, so resizing a database means editing Terraform. This makes it a per-environment variable and sets dev to `db.t4g.small` (2 GiB).

The dev size had to change because the sizing in #492 only looked at CPU utilisation, which stayed in the single digits. Memory was never evaluated, and `db.t4g.micro` (1 GiB) turned out to be too small.

## What went wrong

- Storage in use is ~725 MB. On `db.t3.medium` (4 GiB) the working set fit in the InnoDB buffer pool and read IOPS sat at **0.3**.
- On `db.t4g.micro` it no longer fit: read IOPS jumped to **94**, saturating the 100 IOPS gp2 baseline, and gp2 burst balance hit **0** on 08-30. Swap was in constant use at **470 MB**.
- `max_connections` is derived from instance memory (`{DBInstanceClassMemory/12582880}`), so the ceiling seen by RDS Proxy fell from **149 to 27** and the proxy logged `Too many connections (1040)` continuously.
- Every `provider-api` request blocked on a database connection until the 15 s Lambda timeout. From 08-31 onward this was **6,902 5XX per day, i.e. 100% of requests**.

## Changes

- `db_instance_class` is now a root variable in both `oqtopus-dev` and `oqtopus-prod`, passed through to the `db` module (which already validated it). Each environment sets the value in its own tfvars.
- Each root defaults to the size that environment runs today — `db.t4g.small` for dev, `db.t4g.medium` for prod — so an environment that omits the value keeps its current instance class rather than being resized.
- The example tfvars and the deployment guide carry the key so operators see it.

## Verification

Applied to the dev instance ahead of this change and measured:

| | `db.t4g.micro` | `db.t4g.small` |
| --- | --- | --- |
| SwapUsage | 470 MB | 0 |
| ReadIOPS | 94 | 0.03 |
| gp2 BurstBalance | 0 | 99 |
| provider-api errors | 5/min | 0 |
| provider-api duration | 15,000 ms (timeout) | ~700 ms |

`terraform plan` against a dev environment shows an in-place `instance_class` modify on `aws_db_instance` and nothing else:

```
~ instance_class = "db.t4g.micro" -> "db.t4g.small"
```

## Notes

- **prod is unaffected by this PR.** It stays on `db.t4g.medium`; the value simply moves from the root module into tfvars.
- Whether `small` is the right long-term size still needs a day or so of observation; the buffer pool was still warming up at the time of measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
